### PR TITLE
WIP: Adding Missouri and updating puppet code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ this is helpful while debugging and developing. This can be disabled by passing
 
 ## Setting up VS Code
 
-Steps to set up VS code:
+Steps to set up VS Code:
 
-1. Install `python` and `pylance` Visual Studio Code extensions
+1. Install `python`, `pylance`, and `Python Test Explorer for Visual Studio` Visual Studio Code extensions
 2. Reload Visual Studio Code
 3. Open can-scrapers directory in Visual Studio Code
 4. Select the `can-tools` conda environment as the workspace interpreter.

--- a/can_tools/scrapers/official/MO/__init__.py
+++ b/can_tools/scrapers/official/MO/__init__.py
@@ -1,0 +1,1 @@
+from can_tools.scrapers.official.MO.mo_state import MissouriState

--- a/can_tools/scrapers/official/MO/mo_state.py
+++ b/can_tools/scrapers/official/MO/mo_state.py
@@ -1,0 +1,227 @@
+from abc import ABC
+
+import pandas as pd
+
+import pyppeteer
+import us
+from typing import List
+
+from can_tools.scrapers.base import CMU
+from can_tools.scrapers.official.base import StateDashboard
+from can_tools.scrapers.puppet import TableauNeedsClick
+
+
+class MissouriBase(
+    StateDashboard,
+    TableauNeedsClick,
+    ABC,
+):
+    source = "https://results.mo.gov/t/COVID19/views/COVID-19DataforDownload/{tab}?:isGuestRedirectFromVizportal=y&:embed=y"
+    has_location = False
+    location_type = "county"
+    state_fips = int(us.states.lookup("Missouri").fips)
+
+    out_cols = [
+        "dt",
+        "vintage",
+        "location_name",
+        "category",
+        "measurement",
+        "unit",
+        "age",
+        "race",
+        "sex",
+        "value",
+    ]
+
+    #def clean_desoto(self, df: pd.DataFrame):
+    #    df.loc[df["location_name"] == "Desoto", "location_name"] = "DeSoto"
+
+async def _special_tableau_handler(page, tmpdirname):
+    # Get a reference to the page that was just opened
+    pages = await page.browser.pages()
+    popup = pages[-1]
+
+    import requests
+    import os
+    await popup.waitForSelector('.csvLink_summary')
+    url = await popup.querySelectorEval('.csvLink_summary', 'node => node.href')
+    data = requests.get(url)
+    open(os.path.join(tmpdirname, 'Metrics_by_Test_Date_by_County_data.csv'), 'wb').write(data.content)
+
+
+class MissouriState(MissouriBase):
+    """
+    Fetch details about overall Missouri state testing by county
+    """
+    headless = True
+    url = MissouriBase.source.format(tab="MetricsbyTestDatebyCounty")
+
+# TODO0: ZW: The Data tab below is better... I think. Remove this once confirmed which data to use
+#    # Download Crosstab from Tableau
+#    tableau_click_selector_list: List[str] = [
+#        "@data-tb-test-id = 'DownloadCrosstab-Button'",
+#        "@data-tb-test-id = 'crosstab-options-dialog-radio-csv-Label'",
+#        "@data-tb-test-id = 'export-crosstab-export-Button'"
+#    ]
+
+    # Download Data from Tableau
+    tableau_click_selector_list: List[str] = [
+        "@data-tb-test-id = 'DownloadData-Button'",
+        _special_tableau_handler
+    ]
+
+    async def _pre_click(self, page: pyppeteer.page.Page):
+        # TODO0: ZW: This page is slow to load. Adding wait. 
+        #  Should probably find a better selector to use to determine that the page has loaded
+        import asyncio
+        await asyncio.sleep(5)
+        await page.waitForSelector("#main-content")
+
+    def _clean_cols(self, df: pd.DataFrame, bads: list, str_cols: list) -> pd.DataFrame:
+        for col in list(df):
+            for bad in bads:
+                df[col] = df[col].astype(str).str.replace(bad, "")
+            if col not in str_cols:
+                df[col] = pd.to_numeric(df[col])
+
+        return df
+
+    def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
+        bads = [r",", r"%", "nan"]
+        str_cols = ["County", "FileNumber", "ProviderName"]
+        df = self._clean_cols(df, bads, str_cols)
+        df["location_name"] = df["County"].str.title()
+
+        # Rename appropriate columns
+        crename = {
+            "Bed Census": CMU(
+                category="hospital_beds_in_use", measurement="current", unit="beds"
+            ),
+            "Available": CMU(
+                category="hospital_beds_available", measurement="current", unit="beds"
+            ),
+            "Total Staffed Bed Capacity": CMU(
+                category="hospital_beds_capacity", measurement="current", unit="beds"
+            ),
+        }
+
+        # Drop grand total and melt
+        out = (
+            df.query("location_name != 'Grand Total'")
+            .melt(id_vars=["location_name"], value_vars=crename.keys())
+            .dropna()
+        )
+        out["value"] = pd.to_numeric(out["value"])
+        out = out.groupby(["location_name", "variable"]).sum().reset_index()
+
+        # Extract category information and add other context
+        out = self.extract_CMU(out, crename)
+        out["dt"] = self._retrieve_dt("US/Eastern")
+        out["vintage"] = self._retrieve_vintage()
+        #self.clean_desoto(out)
+        return out.loc[:, self.out_cols]
+
+
+#class MissouriICUUsage(MissouriHospitalUsage):
+#    """
+#    Fetch ICU usage details from Tableau dashboard
+#    """
+
+#    url = "https://bi.ahca.myflorida.com/t/ABICC/views/Public/ICUBedsHospital?:isGuestRedirectFromVizportal=y&:embed=y"
+
+#    def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
+#        bads = [r",", r"%", "nan"]
+#        str_cols = ["County", "FileNumber", "ProviderName"]
+#        df = self._clean_cols(df, bads, str_cols)
+#        df["location_name"] = df["County"].str.title()
+
+#        # Create new columns
+#        df["ICU Census"] = df["Adult ICU Census"] + df["Pediatric ICU Census"]
+#        df["ICU Capacity"] = (
+#            df["Total AdultICU Capacity"] + df["Total PediatricICU Capacity"]
+#        )
+#        df["Available ICU"] = df["Available Adult ICU"] + df["Available Pediatric ICU"]
+
+#        # Rename appropriate columns
+#        crename = {
+#            "Adult ICU Census": CMU(
+#                category="adult_icu_beds_in_use", measurement="current", unit="beds"
+#            ),
+#            "Available Adult ICU": CMU(
+#                category="adult_icu_beds_available", measurement="current", unit="beds"
+#            ),
+#            "Total AdultICU Capacity": CMU(
+#                category="adult_icu_beds_capacity", measurement="current", unit="beds"
+#            ),
+#            "Pediatric ICU Census": CMU(
+#                category="pediatric_icu_beds_in_use", measurement="current", unit="beds"
+#            ),
+#            "Available Pediatric ICU": CMU(
+#                category="pediatric_icu_beds_available",
+#                measurement="current",
+#                unit="beds",
+#            ),
+#            "Total PediatricICU Capacity": CMU(
+#                category="pediatric_icu_beds_capacity",
+#                measurement="current",
+#                unit="beds",
+#            ),
+#            "ICU Census": CMU(
+#                category="icu_beds_in_use", measurement="current", unit="beds"
+#            ),
+#            "ICU Capacity": CMU(
+#                category="icu_beds_capacity", measurement="current", unit="beds"
+#            ),
+#            "Available ICU": CMU(
+#                category="icu_beds_available", measurement="current", unit="beds"
+#            ),
+#        }
+
+#        # Drop grand total and melt
+#        out = (
+#            df.query("location_name != 'Grand Total'")
+#            .melt(id_vars=["location_name"], value_vars=crename.keys())
+#            .dropna()
+#        )
+#        out["value"] = pd.to_numeric(out["value"])
+#        out = out.groupby(["location_name", "variable"]).sum().reset_index()
+#        out.loc[out["location_name"] == "Desoto", "location_name"] = "DeSoto"
+
+#        # Extract category information and add other context
+#        out = self.extract_CMU(out, crename)
+#        out["dt"] = self._retrieve_dt("US/Eastern")
+#        out["vintage"] = self._retrieve_vintage()
+#        self.clean_desoto(out)
+#        return out.loc[:, self.out_cols]
+
+
+#class MissouriHospitalCovid(MissouriHospitalBase):
+#    """
+#    Fetch count of all hospital beds in use by covid patients
+#    """
+
+#    url = "https://bi.ahca.myflorida.com/t/ABICC/views/Public/COVIDHospitalizationsCounty?:isGuestRedirectFromVizportal=y&:embed=y"
+
+#    def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
+#        # Clean up column names
+#        df.columns = ["location_name", "value"]
+#        df["location_name"] = df["location_name"].str.title()
+#        df = df.query("location_name != 'Grand Total'")
+
+#        # Covnert to numeric
+#        df["value"] = pd.to_numeric(df["value"].astype(str).str.replace(",", ""))
+
+#        # Set category/measurment/unit/age/sex/race
+#        df["category"] = "hospital_beds_in_use_covid"
+#        df["measurement"] = "current"
+#        df["unit"] = "beds"
+#        df["age"] = "all"
+#        df["sex"] = "all"
+#        df["race"] = "all"
+#        df["dt"] = self._retrieve_dt("US/Eastern")
+#        df["vintage"] = self._retrieve_vintage()
+
+#        self.clean_desoto(df)
+
+#        return df

--- a/can_tools/scrapers/official/MO/mo_state.py
+++ b/can_tools/scrapers/official/MO/mo_state.py
@@ -34,8 +34,9 @@ class MissouriBase(
         "value",
     ]
 
-    #def clean_desoto(self, df: pd.DataFrame):
+    # def clean_desoto(self, df: pd.DataFrame):
     #    df.loc[df["location_name"] == "Desoto", "location_name"] = "DeSoto"
+
 
 async def _special_tableau_handler(page, tmpdirname):
     # Get a reference to the page that was just opened
@@ -44,37 +45,42 @@ async def _special_tableau_handler(page, tmpdirname):
 
     import requests
     import os
-    await popup.waitForSelector('.csvLink_summary')
-    url = await popup.querySelectorEval('.csvLink_summary', 'node => node.href')
+
+    await popup.waitForSelector(".csvLink_summary")
+    url = await popup.querySelectorEval(".csvLink_summary", "node => node.href")
     data = requests.get(url)
-    open(os.path.join(tmpdirname, 'Metrics_by_Test_Date_by_County_data.csv'), 'wb').write(data.content)
+    open(
+        os.path.join(tmpdirname, "Metrics_by_Test_Date_by_County_data.csv"), "wb"
+    ).write(data.content)
 
 
 class MissouriState(MissouriBase):
     """
     Fetch details about overall Missouri state testing by county
     """
+
     headless = True
     url = MissouriBase.source.format(tab="MetricsbyTestDatebyCounty")
 
-# TODO0: ZW: The Data tab below is better... I think. Remove this once confirmed which data to use
-#    # Download Crosstab from Tableau
-#    tableau_click_selector_list: List[str] = [
-#        "@data-tb-test-id = 'DownloadCrosstab-Button'",
-#        "@data-tb-test-id = 'crosstab-options-dialog-radio-csv-Label'",
-#        "@data-tb-test-id = 'export-crosstab-export-Button'"
-#    ]
+    # TODO0: ZW: The Data tab below is better... I think. Remove this once confirmed which data to use
+    #    # Download Crosstab from Tableau
+    #    tableau_click_selector_list: List[str] = [
+    #        "@data-tb-test-id = 'DownloadCrosstab-Button'",
+    #        "@data-tb-test-id = 'crosstab-options-dialog-radio-csv-Label'",
+    #        "@data-tb-test-id = 'export-crosstab-export-Button'"
+    #    ]
 
     # Download Data from Tableau
     tableau_click_selector_list: List[str] = [
         "@data-tb-test-id = 'DownloadData-Button'",
-        _special_tableau_handler
+        _special_tableau_handler,
     ]
 
     async def _pre_click(self, page: pyppeteer.page.Page):
-        # TODO0: ZW: This page is slow to load. Adding wait. 
+        # TODO0: ZW: This page is slow to load. Adding wait.
         #  Should probably find a better selector to use to determine that the page has loaded
         import asyncio
+
         await asyncio.sleep(5)
         await page.waitForSelector("#main-content")
 
@@ -119,11 +125,11 @@ class MissouriState(MissouriBase):
         out = self.extract_CMU(out, crename)
         out["dt"] = self._retrieve_dt("US/Eastern")
         out["vintage"] = self._retrieve_vintage()
-        #self.clean_desoto(out)
+        # self.clean_desoto(out)
         return out.loc[:, self.out_cols]
 
 
-#class MissouriICUUsage(MissouriHospitalUsage):
+# class MissouriICUUsage(MissouriHospitalUsage):
 #    """
 #    Fetch ICU usage details from Tableau dashboard
 #    """
@@ -196,7 +202,7 @@ class MissouriState(MissouriBase):
 #        return out.loc[:, self.out_cols]
 
 
-#class MissouriHospitalCovid(MissouriHospitalBase):
+# class MissouriHospitalCovid(MissouriHospitalBase):
 #    """
 #    Fetch count of all hospital beds in use by covid patients
 #    """

--- a/can_tools/scrapers/puppet.py
+++ b/can_tools/scrapers/puppet.py
@@ -46,17 +46,17 @@ class with_page:
 
     async def __aenter__(self):
         args = [
-                "--disable-dev-shm-usage",
-                "--disable-setuid-sandbox",
-                "--disable-gpu",
-                "--no-zygote",
-            ]
+            "--disable-dev-shm-usage",
+            "--disable-setuid-sandbox",
+            "--disable-gpu",
+            "--no-zygote",
+        ]
 
-        if os.name != 'nt':
+        if os.name != "nt":
             # Windows does not work with these arguments
             args.append("--single-process")
             args.append("--no-sandbox")
-                
+
         self.browser = await pyppeteer.launch(
             headless=self.headless,
             args=args,
@@ -67,9 +67,9 @@ class with_page:
         await page.setUserAgent(CHROME_AGENT)
         await page.setViewport(DEFAULT_VIEWPORT)
 
-        # Required if site is using F5 Big-IP ASM. 
+        # Required if site is using F5 Big-IP ASM.
         # You can tell by looking at the cookies and if you see one called
-        # TSxxxxxxxxxx and/or BIGipServerSDC_xxxxxxx, 
+        # TSxxxxxxxxxx and/or BIGipServerSDC_xxxxxxx,
         # https://stackoverflow.com/questions/52330611/anyone-know-what-a-ts-cookie-is-and-what-kind-of-data-its-for
         await page.setBypassCSP(True)
 
@@ -107,7 +107,7 @@ class TableauNeedsClick(DatasetBase, ABC):
     headless: bool = True
     download_button_id: str = "#download-ToolbarButton"
     tableau_click_selector_list: List[str] = [
-    	# Default is just clicking the Crosstab button
+        # Default is just clicking the Crosstab button
         "@data-tb-test-id = 'DownloadCrosstab-Button'"
     ]
 
@@ -204,13 +204,11 @@ class TableauNeedsClick(DatasetBase, ABC):
                 await button.click()
 
                 for click_selector in self.tableau_click_selector_list:
-                    if hasattr(click_selector, '__call__'):
+                    if hasattr(click_selector, "__call__"):
                         # Use for special handling in an instance specific function
                         await click_selector(page, tmpdirname)
                     else:
-                        selector = await page.waitForXPath(
-                            f"//*[{click_selector}]"
-                        )
+                        selector = await page.waitForXPath(f"//*[{click_selector}]")
                         await selector.click()
                         await asyncio.sleep(2)
 
@@ -222,8 +220,6 @@ class TableauNeedsClick(DatasetBase, ABC):
                 else:
                     # TODO0: ZW: Throw / report error?
                     pass
-
-
 
                 # call the post_download method to process download
                 df = await self._post_download(tmpdirname)


### PR DESCRIPTION
First real PR so feedback welcome.

The code in mo_state is just a copy from Florida, so ignore it other than the tableau_click_selector_list setting up the list of arguments to be sent to puppet.py to get data from Tableau.

The Missouri dashboard was in ARCGIS https://mophep.maps.arcgis.com/apps/MapSeries/index.html?appid=8e01a5d8d8bd4b4f85add006f9e14a9d
   but has been moved to Tableau https://showmestrong.mo.gov/data-download/

The Excel data that they have is not as detailed as what is available in TableauNeedsClick
https://results.mo.gov/t/COVID19/views/COVID-19DataforDownload/MetricsbyTestDatebyCounty?%3AisGuestRedirectFromVizportal=y&%3Aembed=y

The page is protected by F5 to stop bots from accessing the site. Take a look in the cookies and the notes in can_tools/scrapers/puppet.py for more details.

Also, this Tableau sheet requires more clicks to get the data via the Download button. Updated the code to allow the state code to specify the click stream to follow to get to the data via tableau_click_selector_list.

One more fun challenge. When downloading data from Tableau's Data download option, it opens another tab that shows the first 1000 rows of data. There is a link on that new tab that allows you to download ALL the data. Clicking that opens another tab that will download the data. I was unable to find away to set the Page.setDownloadBehavior for this new page, hence, _special_tableau_handler code. This / Any special function can be added to the tableau_click_selector_list and that code will be run as part of the click process. In this case, it will get the download link from the new tab and download that code manually via the Requests module.

Lastly, Windows doesn't like the puppeteer / chromium options --single-process, --no-sandbox. I wrapped them in a os.name != 'nt' check to only include them in non-Windows environments.