### PR TITLE
A few schema changes:

### DIFF
--- a/can_tools/bootstrap_data/locations.csv
+++ b/can_tools/bootstrap_data/locations.csv
@@ -1,3290 +1,3290 @@
-"location","state_fips","state","name","area","latitude","longitude","fullname","location_type"
-54,54,"54","West Virginia",24041.943,38.647285,-80.618324,"West Virginia","state"
-12,12,"12","Florida",53649.703,28.45743,-82.40915,"Florida","state"
-17,17,"17","Illinois",55515.605,40.102875,-89.15261,"Illinois","state"
-27,27,"27","Minnesota",79628.586,46.315956,-94.19960999999999,"Minnesota","state"
-24,24,"24","Maryland",9711.466,38.946659999999994,-76.67449,"Maryland","state"
-44,44,"44","Rhode Island",1033.9346,41.59742,-71.527275,"Rhode Island","state"
-16,16,"16","Idaho",82647.94,44.348423,-114.55885,"Idaho","state"
-33,33,"33","New Hampshire",8953.704,43.67269,-71.58431,"New Hampshire","state"
-37,37,"37","North Carolina",48621.926,35.53971,-79.13087,"North Carolina","state"
-50,50,"50","Vermont",9218.193000000001,44.068577000000005,-72.66918000000001,"Vermont","state"
-9,9,"09","Connecticut",4842.85,41.579865000000005,-72.74665999999999,"Connecticut","state"
-10,10,"10","Delaware",1948.5771,38.998566,-75.44164,"Delaware","state"
-35,35,"35","New Mexico",121316.37,34.434684999999995,-106.131615,"New Mexico","state"
-6,6,"06","California",155859.33,37.155178,-119.54342,"California","state"
-34,34,"34","New Jersey",7355.052,40.107273,-74.6652,"New Jersey","state"
-55,55,"55","Wisconsin",54169.28,44.63091,-89.70939,"Wisconsin","state"
-41,41,"41","Oregon",95991.266,43.971714,-120.622955,"Oregon","state"
-31,31,"31","Nebraska",76819.11,41.543304,-99.81187,"Nebraska","state"
-42,42,"42","Pennsylvania",44743.22,40.904602000000004,-77.82753000000001,"Pennsylvania","state"
-53,53,"53","Washington",66457.375,47.407322,-120.5758,"Washington","state"
-22,22,"22","Louisiana",43205.957,30.863438000000002,-91.79871,"Louisiana","state"
-13,13,"13","Georgia",57718.293,32.629578,-83.42351,"Georgia","state"
-1,1,"01","Alabama",50648.363,32.73963,-86.84346,"Alabama","state"
-49,49,"49","Utah",82379.68,39.334990000000005,-111.65633400000002,"Utah","state"
-39,39,"39","Ohio",40860.15,40.41493,-82.712,"Ohio","state"
-48,48,"48","Texas",261271.94,31.434703999999996,-99.28182,"Texas","state"
-8,8,"08","Colorado",103641.016,38.993846999999995,-105.508316,"Colorado","state"
-45,45,"45","South Carolina",30064.736,33.874176,-80.85426,"South Carolina","state"
-40,40,"40","Oklahoma",68598.27,35.59005,-97.48682,"Oklahoma","state"
-47,47,"47","Tennessee",41239.367,35.8608,-86.34999,"Tennessee","state"
-56,56,"56","Wyoming",97092.0,42.98966,-107.544395,"Wyoming","state"
-15,15,"15","Hawaii",6422.644,19.597765,-155.50243999999998,"Hawaii","state"
-38,38,"38","North Dakota",68997.12,47.442173,-100.46082,"North Dakota","state"
-21,21,"21","Kentucky",39492.73,37.533684,-85.29298,"Kentucky","state"
-78,78,"78","United States Virgin Islands",134.37657,18.326748000000002,-64.97125,"United States Virgin Islands","state"
-69,69,"69","Commonwealth of the Northern Mariana Islands",182.35938000000002,14.936784,145.60103,"Commonwealth of the Northern Mariana Islands","state"
-66,66,"66","Guam",209.87523,13.441745000000001,144.7719,"Guam","state"
-23,23,"23","Maine",30845.847999999998,45.409283,-68.66662,"Maine","state"
-36,36,"36","New York",47125.37,42.9134,-75.596275,"New York","state"
-32,32,"32","Nevada",109864.11,39.331093,-116.61515,"Nevada","state"
-2,2,"02","Alaska",571036.4,63.34735500000001,-152.83973999999998,"Alaska","state"
-60,60,"60","American Samoa",76.3578,-14.267159,-170.66827,"American Samoa","state"
-26,26,"26","Michigan",56607.855,44.844177,-85.66049,"Michigan","state"
-5,5,"05","Arkansas",52039.3,34.895527,-92.444626,"Arkansas","state"
-28,28,"28","Mississippi",46927.133,32.68647,-89.656136,"Mississippi","state"
-29,29,"29","Missouri",68747.8,38.35075,-92.45678000000001,"Missouri","state"
-30,30,"30","Montana",145552.66,47.051178,-109.63481999999999,"Montana","state"
-20,20,"20","Kansas",81761.26,38.498546999999995,-98.38343,"Kansas","state"
-18,18,"18","Indiana",35827.656,39.901314,-86.291916,"Indiana","state"
-72,72,"72","Puerto Rico",3424.3416,18.217648,-66.4108,"Puerto Rico","state"
-46,46,"46","South Dakota",75812.266,44.446796,-100.238174,"South Dakota","state"
-25,25,"25","Massachusetts",7801.223000000001,42.15652,-71.48959,"Massachusetts","state"
-51,51,"51","Virginia",39483.496,37.52225,-78.66819,"Virginia","state"
-11,11,"11","District of Columbia",61.137646,38.904247,-77.01652,"District of Columbia","state"
-19,19,"19","Iowa",55855.617,42.070023,-93.49335,"Iowa","state"
-4,4,"04","Arizona",113657.01,34.203934000000004,-111.60635,"Arizona","state"
-31039,31,"31","Cuming",570.5441,41.915867,-96.78851,"Cuming County","county"
-53069,53,"53","Wahkiakum",262.93018,46.29464,-123.42446000000001,"Wahkiakum County","county"
-35011,35,"35","De Baca",2323.186,34.359272,-104.3687,"De Baca County","county"
-31109,31,"31","Lancaster",837.5885599999999,40.783546,-96.68866,"Lancaster County","county"
-31129,31,"31","Nuckolls",575.1748,40.17649,-98.046844,"Nuckolls County","county"
-72085,72,"72","Las Piedras Municipio",33.880984999999995,18.18715,-65.871185,"Las Piedras Municipio","county"
-46099,46,"46","Minnehaha",806.86194,43.667473,-96.79571999999999,"Minnehaha County","county"
-48327,48,"48","Menard",902.0572,30.885267,-99.858864,"Menard County","county"
-6091,6,"06","Sierra",953.20074,39.576923,-120.521996,"Sierra County","county"
-21053,21,"21","Clinton",197.25694,36.727257,-85.1361,"Clinton County","county"
-39063,39,"39","Hancock",531.3431400000001,41.00047,-83.66603,"Hancock County","county"
-48189,48,"48","Hale",1004.71423,34.068436,-101.82289,"Hale County","county"
-1027,1,"01","Clay",603.98157,33.2704,-85.863525,"Clay County","county"
-48011,48,"48","Armstrong",909.14,34.96418,-101.356636,"Armstrong County","county"
-39003,39,"39","Allen",402.51743,40.771626,-84.1061,"Allen County","county"
-13189,13,"13","McDuffie",257.4805,33.479620000000004,-82.47874,"McDuffie County","county"
-55111,55,"55","Sauk",831.5711,43.428000000000004,-89.94332,"Sauk County","county"
-5137,5,"05","Stone",606.49243,35.857002,-92.14048000000001,"Stone County","county"
-41063,41,"41","Wallowa",3146.0040000000004,45.593754,-117.18558,"Wallowa County","county"
-42007,42,"42","Beaver",434.72775,40.68414,-80.35072,"Beaver County","county"
-28061,28,"28","Jasper",676.2634,32.01699,-89.11943000000001,"Jasper County","county"
-29083,29,"29","Henry",696.9683,38.38649,-93.792625,"Henry County","county"
-8109,8,"08","Saguache",3168.6736,38.03165,-106.23466499999999,"Saguache County","county"
-37037,37,"37","Chatham",681.7438400000001,35.704994,-79.25146,"Chatham County","county"
-49033,49,"49","Rich",1028.8818,41.627598,-111.24023000000001,"Rich County","county"
-40001,40,"40","Adair",573.87463,35.898045,-94.65102399999999,"Adair County","county"
-39085,39,"39","Lake",229.27805,41.924118,-81.39264,"Lake County","county"
-51775,51,"51","Salem city",14.518981,37.28533,-80.05524399999999,"Salem city","county"
-51121,51,"51","Montgomery",386.85724,37.175533,-80.387794,"Montgomery County","county"
-47065,47,"47","Hamilton",542.3849,35.163470000000004,-85.20184,"Hamilton County","county"
-35035,35,"35","Otero",6612.786999999999,32.6156,-105.751305,"Otero County","county"
-35003,35,"35","Catron",6924.422,33.90162,-108.39193,"Catron County","county"
-1091,1,"01","Marengo",976.92584,32.247593,-87.79109,"Marengo County","county"
-56023,56,"56","Lincoln",4075.4753,42.229991999999996,-110.68296000000001,"Lincoln County","county"
-29011,29,"29","Barton",592.0503,37.500797,-94.344086,"Barton County","county"
-48057,48,"48","Calhoun",506.85625999999996,28.44172,-96.579575,"Calhoun County","county"
-51735,51,"51","Poquoson city",15.381905,37.12836,-76.303535,"Poquoson city","county"
-54075,54,"54","Pocahontas",940.2705699999999,38.332607,-80.010124,"Pocahontas County","county"
-48077,48,"48","Clay",1088.795,33.785903999999995,-98.21292,"Clay County","county"
-51095,51,"51","James City",142.37006,37.324837,-76.777885,"James City County","county"
-31101,31,"31","Keith",1061.6364,41.194244,-101.64445,"Keith County","county"
-31137,31,"31","Phelps",539.8079,40.516365,-99.40655500000001,"Phelps County","county"
-22019,22,"22","Calcasieu Parish",1064.1895,30.229559000000002,-93.35802,"Calcasieu Parish","county"
-22111,22,"22","Union Parish",876.96875,32.82935,-92.37565,"Union Parish","county"
-40135,40,"40","Sequoyah",673.49677,35.502434,-94.750755,"Sequoyah County","county"
-1049,1,"01","DeKalb",777.1252,34.46093,-85.80399,"DeKalb County","county"
-36101,36,"36","Steuben",1390.602,42.266723999999996,-77.38553,"Steuben County","county"
-42053,42,"42","Forest",427.28442,41.513306,-79.2497,"Forest County","county"
-22105,22,"22","Tangipahoa Parish",791.3367,30.62153,-90.40663,"Tangipahoa Parish","county"
-51179,51,"51","Stafford",269.21396,38.41326,-77.45133,"Stafford County","county"
-26109,26,"26","Menominee",1044.0763,45.536204999999995,-87.50180999999999,"Menominee County","county"
-18073,18,"18","Jasper",559.6987,41.01769,-87.11881,"Jasper County","county"
-13025,13,"13","Brantley",443.24075,31.197334,-81.98298,"Brantley County","county"
-13171,13,"13","Lamar",183.50687,33.07444,-84.14669,"Lamar County","county"
-18151,18,"18","Steuben",308.78772000000004,41.643467,-85.0024,"Steuben County","county"
-48361,48,"48","Orange",333.7971,30.122321999999997,-93.8941,"Orange County","county"
-39047,39,"39","Fayette",406.37473,39.555244,-83.46189,"Fayette County","county"
-25015,25,"25","Hampshire",527.25366,42.339459999999995,-72.6637,"Hampshire County","county"
-21003,21,"21","Allen",344.3526,36.75077,-86.19246,"Allen County","county"
-37001,37,"37","Alamance",423.45963,36.043953,-79.40057,"Alamance County","county"
-20073,20,"20","Greenwood",1143.3429,37.87935,-96.24173,"Greenwood County","county"
-25025,25,"25","Suffolk",58.250533999999995,42.33855,-71.01825,"Suffolk County","county"
-16051,16,"16","Jefferson",1093.7168,43.796966999999995,-112.31858999999999,"Jefferson County","county"
-48177,48,"48","Gonzales",1066.7227,29.461911999999998,-97.49192,"Gonzales County","county"
-47115,47,"47","Marion",498.27127,35.133423,-85.6184,"Marion County","county"
-26007,26,"26","Alpena",571.88605,44.894954999999996,-83.426575,"Alpena County","county"
-21231,21,"21","Wayne",458.19943,36.80077,-84.82659,"Wayne County","county"
-47185,47,"47","White",376.69104,35.927048,-85.45579000000001,"White County","county"
-48147,48,"48","Fannin",890.8649,33.591159999999995,-96.10499,"Fannin County","county"
-20043,20,"20","Doniphan",393.49228,39.7885,-95.147224,"Doniphan County","county"
-48265,48,"48","Kerr",1103.3644,30.059953999999998,-99.35334,"Kerr County","county"
-12053,12,"12","Hernando",472.97665,28.573041999999997,-82.466225,"Hernando County","county"
-12129,12,"12","Wakulla",606.4388,30.139433,-84.37485,"Wakulla County","county"
-12131,12,"12","Walton",1037.7776,30.63121,-86.17661,"Walton County","county"
-28017,28,"28","Chickasaw",501.79868,33.933277000000004,-88.947556,"Chickasaw County","county"
-2130,2,"02","Ketchikan Gateway Borough",4857.0903,55.449936,-131.10669,"Ketchikan Gateway Borough","county"
-26035,26,"26","Clare",564.3848,43.99114,-84.838326,"Clare County","county"
-20157,20,"20","Republic",717.4016,39.828907,-97.65089,"Republic County","county"
-12127,12,"12","Volusia",1101.2797,29.05777,-81.16179,"Volusia County","county"
-40017,40,"40","Canadian",896.6103,35.543354,-97.97989,"Canadian County","county"
-72115,72,"72","Quebradillas Municipio",22.683378,18.466356,-66.927605,"Quebradillas Municipio","county"
-78030,78,"78","St. Thomas Island",31.317203999999997,18.326748000000002,-64.97125,"St. Thomas Island","county"
-13115,13,"13","Floyd",509.83994,34.263690000000004,-85.213684,"Floyd County","county"
-32001,32,"32","Churchill",4950.6875,39.53771,-118.26417,"Churchill County","county"
-31181,31,"31","Webster",574.9326,40.180645,-98.49859000000001,"Webster County","county"
-17067,17,"17","Hancock",793.7753,40.401317999999996,-91.1688,"Hancock County","county"
-46067,46,"46","Hutchinson",813.0409,43.33671,-97.74938,"Hutchinson County","county"
-41013,41,"41","Crook",2979.0305,44.163055,-120.37158000000001,"Crook County","county"
-50011,50,"50","Franklin",634.1441,44.858963,-72.9094,"Franklin County","county"
-26103,26,"26","Marquette",1809.1069,46.656597,-87.58403,"Marquette County","county"
-9007,9,"09","Middlesex",369.31686,41.433002,-72.52278000000001,"Middlesex County","county"
-37057,37,"37","Davidson",553.19794,35.79513,-80.20711,"Davidson County","county"
-17025,17,"17","Clay",468.2867,38.74682,-88.48232,"Clay County","county"
-29103,29,"29","Knox",504.02588,40.136856,-92.146835,"Knox County","county"
-29117,29,"29","Livingston",532.32074,39.778587,-93.5482,"Livingston County","county"
-42117,42,"42","Tioga",1133.8116,41.76686,-77.257286,"Tioga County","county"
-31043,31,"31","Dakota",264.28165,42.391644,-96.561356,"Dakota County","county"
-26089,26,"26","Leelanau",347.21106000000003,45.146183,-86.051575,"Leelanau County","county"
-51181,51,"51","Surry",278.95892000000003,37.119762,-76.88016999999999,"Surry County","county"
-48391,48,"48","Refugio",770.5107,28.322115000000004,-97.162476,"Refugio County","county"
-39017,39,"39","Butler",466.54456,39.439747,-84.565735,"Butler County","county"
-13273,13,"13","Terrell",335.7503,31.777191,-84.43944499999999,"Terrell County","county"
-13063,13,"13","Clayton",141.68373,33.542685999999996,-84.355576,"Clayton County","county"
-56013,56,"56","Fremont",9183.902,43.054832,-108.60893,"Fremont County","county"
-18115,18,"18","Ohio",86.15268,38.940529999999995,-84.9643,"Ohio County","county"
-13073,13,"13","Columbia",290.0858,33.54763,-82.2523,"Columbia County","county"
-8115,8,"08","Sedgwick",548.0594,40.871567,-102.355354,"Sedgwick County","county"
-30065,30,"30","Musselshell",1869.0211,46.50528,-108.43976599999999,"Musselshell County","county"
-42043,42,"42","Dauphin",524.9068599999999,40.412563,-76.79263,"Dauphin County","county"
-46101,46,"46","Moody",519.4010599999999,44.01243,-96.676056,"Moody County","county"
-54079,54,"54","Putnam",345.69006,38.510513,-81.90611,"Putnam County","county"
-34037,34,"34","Sussex",518.77094,41.137463000000004,-74.69192,"Sussex County","county"
-20039,20,"20","Decatur",893.5477,39.783543,-100.45971,"Decatur County","county"
-18123,18,"18","Perry",381.7531,38.081436,-86.62654,"Perry County","county"
-28145,28,"28","Union",415.6214,34.489532000000004,-89.00234,"Union County","county"
-31015,31,"31","Boyd",539.953,42.894447,-98.773026,"Boyd County","county"
-27095,27,"27","Mille Lacs",572.3831,45.929043,-93.63299599999999,"Mille Lacs County","county"
-38099,38,"38","Walsh",1281.6504,48.376979999999996,-97.72223000000001,"Walsh County","county"
-39115,39,"39","Morgan",416.44012000000004,39.624947,-81.861694,"Morgan County","county"
-39133,39,"39","Portage",487.42037999999997,41.168972,-81.19696,"Portage County","county"
-56041,56,"56","Uinta",2081.7915,41.284725,-110.558945,"Uinta County","county"
-32013,32,"32","Humboldt",9641.119,41.407913,-118.12759399999999,"Humboldt County","county"
-48247,48,"48","Jim Hogg",1136.2117,27.05323,-98.747574,"Jim Hogg County","county"
-8017,8,"08","Cheyenne",1778.3365,38.835644,-102.60179000000001,"Cheyenne County","county"
-41005,41,"41","Clackamas",1870.7423,45.160492,-122.19513,"Clackamas County","county"
-5113,5,"05","Polk",857.5093,34.490913,-94.23088,"Polk County","county"
-13193,13,"13","Macon",400.6757,32.362686,-84.05123,"Macon County","county"
-18007,18,"18","Benton",406.4313,40.60094,-87.31479,"Benton County","county"
-47129,47,"47","Morgan",522.19763,36.1387,-84.63926,"Morgan County","county"
-46043,46,"46","Douglas",431.81543,43.391506,-98.35844,"Douglas County","county"
-24047,24,"24","Worcester",468.41772000000003,38.222134000000004,-75.30993000000001,"Worcester County","county"
-17185,17,"17","Wabash",223.33062999999999,38.44582,-87.83916500000001,"Wabash County","county"
-18069,18,"18","Huntington",382.66213999999997,40.826392999999996,-85.4786,"Huntington County","county"
-21209,21,"21","Scott",281.77707000000004,38.285709999999995,-84.57834,"Scott County","county"
-19053,19,"19","Decatur",531.8998,40.736378,-93.78458,"Decatur County","county"
-18169,18,"18","Wabash",412.55188,40.843746,-85.79519,"Wabash County","county"
-18003,18,"18","Allen",657.3426,41.091908000000004,-85.07179000000001,"Allen County","county"
-18099,18,"18","Marshall",443.6349,41.325005,-86.269035,"Marshall County","county"
-31171,31,"31","Thomas",712.9247,41.85573,-100.524704,"Thomas County","county"
-38085,38,"38","Sioux",1094.0887,46.110620000000004,-101.06129,"Sioux County","county"
-48127,48,"48","Dimmit",1328.9298,28.423588,-99.76586999999999,"Dimmit County","county"
-27045,27,"27","Fillmore",861.3254400000001,43.679188,-92.09393,"Fillmore County","county"
-45023,45,"45","Chester",580.681,34.689341999999996,-81.16125,"Chester County","county"
-27073,27,"27","Lac qui Parle",765.04675,44.999855,-96.176834,"Lac qui Parle County","county"
-49005,49,"49","Cache",1164.7704,41.734116,-111.7454,"Cache County","county"
-55093,55,"55","Pierce",574.0378,44.725338,-92.42628,"Pierce County","county"
-13049,13,"13","Charlton",780.1134,30.779903000000004,-82.13964,"Charlton County","county"
-13233,13,"13","Polk",310.3435,33.996014,-85.18834,"Polk County","county"
-17113,17,"17","McLean",1183.2893,40.49456,-88.844536,"McLean County","county"
-23001,23,"23","Androscoggin",467.96808,44.167683000000004,-70.207436,"Androscoggin County","county"
-16055,16,"16","Kootenai",1237.8215,47.675964,-116.69592,"Kootenai County","county"
-32003,32,"32","Clark",7891.9175,36.214256,-115.01381,"Clark County","county"
-20147,20,"20","Phillips",885.90125,39.784504,-99.34215,"Phillips County","county"
-31089,31,"31","Holt",2412.4788,42.459286,-98.78477,"Holt County","county"
-29101,29,"29","Johnson",829.28827,38.741528,-93.81187,"Johnson County","county"
-55063,55,"55","La Crosse",451.7845,43.908221999999995,-91.111755,"La Crosse County","county"
-22021,22,"22","Caldwell Parish",529.5077,32.10122,-92.11423,"Caldwell Parish","county"
-21061,21,"21","Edmonson",302.89522999999997,37.227512,-86.21802,"Edmonson County","county"
-17005,17,"17","Bond",380.35187,38.885925,-89.43659,"Bond County","county"
-17009,17,"17","Brown",305.73715,39.962070000000004,-90.75031,"Brown County","county"
-27085,27,"27","McLeod",491.50284000000005,44.821655,-94.27232,"McLeod County","county"
-55033,55,"55","Dunn",850.18933,44.94775,-91.897644,"Dunn County","county"
-8027,8,"08","Custer",738.6509,38.101997,-105.37351000000001,"Custer County","county"
-29123,29,"29","Madison",494.40445,37.47448,-90.343414,"Madison County","county"
-48353,48,"48","Nolan",912.02814,32.31234,-100.41810600000001,"Nolan County","county"
-42127,42,"42","Wayne",725.6251,41.646603000000006,-75.292496,"Wayne County","county"
-36091,36,"36","Saratoga",810.0232,43.106136,-73.855385,"Saratoga County","county"
-48041,48,"48","Brazos",586.15814,30.656713,-96.30239,"Brazos County","county"
-40095,40,"40","Marshall",371.61404,34.027008,-96.77053000000001,"Marshall County","county"
-24001,24,"24","Allegany",422.20242,39.612312,-78.7031,"Allegany County","county"
-54103,54,"54","Wetzel",358.07912999999996,39.59818,-80.6354,"Wetzel County","county"
-55053,55,"55","Jackson",987.9485,44.32459,-90.79951,"Jackson County","county"
-41007,41,"41","Clatsop",828.16797,46.02451,-123.70504,"Clatsop County","county"
-53041,53,"53","Lewis",2402.8647,46.58007,-122.37743999999999,"Lewis County","county"
-36003,36,"36","Allegany",1029.3948,42.247852,-78.02615,"Allegany County","county"
-19031,19,"19","Cedar",579.4813,41.77236,-91.132614,"Cedar County","county"
-18117,18,"18","Orange",398.39162999999996,38.547382,-86.48926,"Orange County","county"
-13089,13,"13","DeKalb",267.74036,33.77066,-84.22634000000001,"DeKalb County","county"
-13227,13,"13","Pickens",232.06727999999998,34.456745,-84.49035,"Pickens County","county"
-30015,30,"30","Chouteau",3972.6726,47.886833,-110.4362,"Chouteau County","county"
-31017,31,"31","Brown",1221.3971,42.359562,-99.92392,"Brown County","county"
-47013,47,"47","Campbell",480.2059,36.401592,-84.15925,"Campbell County","county"
-37069,37,"37","Franklin",491.8171,36.08824,-78.28309,"Franklin County","county"
-24510,24,"24","Baltimore city",80.94945,39.300034000000004,-76.61046999999999,"Baltimore city","county"
-20111,20,"20","Lyon",847.5147,38.455402,-96.161644,"Lyon County","county"
-19027,19,"19","Carroll",569.45636,42.039494,-94.867645,"Carroll County","county"
-22107,22,"22","Tensas Parish",602.80493,32.001488,-91.342575,"Tensas Parish","county"
-47123,47,"47","Monroe",635.7995,35.44782,-84.2497,"Monroe County","county"
-20075,20,"20","Hamilton",996.5475,37.995243,-101.793686,"Hamilton County","county"
-19151,19,"19","Pocahontas",577.2605599999999,42.73403,-94.678276,"Pocahontas County","county"
-16045,16,"16","Gem",559.78845,44.061474,-116.39878,"Gem County","county"
-5063,5,"05","Independence",764.0507,35.7375,-91.55994399999999,"Independence County","county"
-5085,5,"05","Lonoke",771.39996,34.755115999999994,-91.89413499999999,"Lonoke County","county"
-18111,18,"18","Newton",401.76833999999997,40.9624,-87.40217,"Newton County","county"
-13119,13,"13","Franklin",261.57043,34.375267,-83.22753,"Franklin County","county"
-12051,12,"12","Hendry",1156.2683,26.539966999999997,-81.15211500000001,"Hendry County","county"
-13265,13,"13","Taliaferro",194.61409,33.55932,-82.875275,"Taliaferro County","county"
-48245,48,"48","Jefferson",876.4018,29.854,-94.14933,"Jefferson County","county"
-30059,30,"30","Meagher",2391.9495,46.5857,-110.92173999999999,"Meagher County","county"
-8067,8,"08","La Plata",1689.739,37.28737,-107.83971399999999,"La Plata County","county"
-48027,48,"48","Bell",1051.4247,31.042747,-97.48127,"Bell County","county"
-28069,28,"28","Kemper",766.20844,32.750137,-88.62563,"Kemper County","county"
-5019,5,"05","Clark",866.10693,34.053318,-93.17621,"Clark County","county"
-41035,41,"41","Klamath",5942.9478,42.68376,-121.64617,"Klamath County","county"
-36075,36,"36","Oswego",951.6782,43.461445,-76.20926,"Oswego County","county"
-72105,72,"72","Naranjito Municipio",27.402287,18.289920000000002,-66.25344,"Naranjito Municipio","county"
-1019,1,"01","Cherokee",553.5439,34.069515,-85.65424,"Cherokee County","county"
-48019,48,"48","Bandera",791.0216,29.756390000000003,-99.24828000000001,"Bandera County","county"
-30087,30,"30","Rosebud",5008.305,46.173233,-106.66675,"Rosebud County","county"
-35059,35,"35","Union",3825.1926,36.488087,-103.47572,"Union County","county"
-26153,26,"26","Schoolcraft",1171.9161,46.021122,-86.19703,"Schoolcraft County","county"
-36111,36,"36","Ulster",1124.2743,41.947212,-74.26546,"Ulster County","county"
-34007,34,"34","Camden",221.35754,39.802406,-74.96125,"Camden County","county"
-17083,17,"17","Jersey",369.67264,39.080196,-90.36138000000001,"Jersey County","county"
-51085,51,"51","Hanover",467.90157999999997,37.760216,-77.49132,"Hanover County","county"
-20199,20,"20","Wallace",913.6833,38.926624,-101.7711,"Wallace County","county"
-26003,26,"26","Alger",915.06445,47.08008,-86.56411,"Alger County","county"
-5049,5,"05","Fulton",618.2091,36.383617,-91.819664,"Fulton County","county"
-48215,48,"48","Hidalgo",1570.8699,26.396383,-98.18099000000001,"Hidalgo County","county"
-37155,37,"37","Robeson",947.309,34.63921,-79.10088,"Robeson County","county"
-26123,26,"26","Newaygo",838.91516,43.562709999999996,-85.791374,"Newaygo County","county"
-41049,41,"41","Morrow",2030.5983,45.425495,-119.60231,"Morrow County","county"
-27153,27,"27","Todd",945.11786,46.06657,-94.90057,"Todd County","county"
-5083,5,"05","Logan",708.2959599999999,35.218655,-93.72091,"Logan County","county"
-37109,37,"37","Lincoln",295.8535,35.488490000000006,-81.22689,"Lincoln County","county"
-5091,5,"05","Miller",625.753,33.305504,-93.901505,"Miller County","county"
-12095,12,"12","Orange",901.8962,28.514390000000002,-81.32328000000001,"Orange County","county"
-8111,8,"08","San Juan",387.52875,37.781048,-107.67026000000001,"San Juan County","county"
-16041,16,"16","Franklin",663.0415,42.17361,-111.82297,"Franklin County","county"
-13045,13,"13","Carroll",499.0447,33.582237,-85.08053000000001,"Carroll County","county"
-20161,20,"20","Riley",609.72107,39.29121,-96.727486,"Riley County","county"
-48413,48,"48","Schleicher",1310.6862,30.896233000000002,-100.527214,"Schleicher County","county"
-51167,51,"51","Russell",473.53964,36.93342,-82.09593000000001,"Russell County","county"
-37027,37,"37","Caldwell",471.90722999999997,35.966396,-81.51254,"Caldwell County","county"
-16065,16,"16","Madison",469.2831,43.788612,-111.65699,"Madison County","county"
-18173,18,"18","Warrick",384.82748,38.09773,-87.27205,"Warrick County","county"
-21001,21,"21","Adair",405.3018,37.10556,-85.28138,"Adair County","county"
-21077,21,"21","Gallatin",98.3439,38.7601,-84.86215,"Gallatin County","county"
-21097,21,"21","Harrison",306.42258,38.444576,-84.33413,"Harrison County","county"
-23023,23,"23","Sagadahoc",253.97975,43.916843,-69.84423000000001,"Sagadahoc County","county"
-30097,30,"30","Sweet Grass",1855.5679,45.81129,-109.94479,"Sweet Grass County","county"
-48181,48,"48","Grayson",932.8647,33.624522999999996,-96.67569,"Grayson County","county"
-42059,42,"42","Greene",575.9519700000001,39.847706,-80.225655,"Greene County","county"
-2188,2,"02","Northwest Arctic Borough",35665.17,67.005066,-160.02109,"Northwest Arctic Borough","county"
-20051,20,"20","Ellis",899.943,38.914597,-99.317314,"Ellis County","county"
-1065,1,"01","Hale",644.00854,32.752796000000004,-87.62306,"Hale County","county"
-1105,1,"01","Perry",719.6805400000001,32.639004,-87.29382,"Perry County","county"
-1033,1,"01","Colbert",592.7651,34.703114,-87.80145999999999,"Colbert County","county"
-20151,20,"20","Pratt",735.0635,37.647594,-98.74011999999999,"Pratt County","county"
-21017,21,"21","Bourbon",289.7561,38.20256,-84.20985999999999,"Bourbon County","county"
-47149,47,"47","Rutherford",619.28754,35.84337,-86.41721,"Rutherford County","county"
-13075,13,"13","Cook",228.42836,31.152515,-83.42944,"Cook County","county"
-20101,20,"20","Lane",717.43317,38.481285,-100.46619,"Lane County","county"
-40059,40,"40","Harper",1038.619,36.80035,-99.6628,"Harper County","county"
-17147,17,"17","Piatt",439.2031,40.009033,-88.592354,"Piatt County","county"
-48107,48,"48","Crosby",900.2291,33.609142,-101.29871,"Crosby County","county"
-72053,72,"72","Fajardo Municipio",29.904108,18.386377,-65.58845500000001,"Fajardo Municipio","county"
-1063,1,"01","Greene",647.0451,32.844498,-87.9642,"Greene County","county"
-16033,16,"16","Clark",1763.205,44.29022,-112.35461399999998,"Clark County","county"
-19109,19,"19","Kossuth",972.7641,43.21248,-94.21398,"Kossuth County","county"
-72151,72,"72","Yabucoa Municipio",55.216488,18.059858,-65.85987,"Yabucoa Municipio","county"
-38013,38,"38","Burke",1103.5867,48.786453,-102.52009,"Burke County","county"
-37063,37,"37","Durham",286.49536,36.03383,-78.87813,"Durham County","county"
-19085,19,"19","Harrison",696.8666,41.688583,-95.82715,"Harrison County","county"
-31103,31,"31","Keya Paha",773.1023,42.875479999999996,-99.71835,"Keya Paha County","county"
-19187,19,"19","Webster",715.73303,42.43358,-94.17583499999999,"Webster County","county"
-17151,17,"17","Pope",368.86624,37.417168,-88.54236999999999,"Pope County","county"
-47159,47,"47","Smith",314.3058,36.256645,-85.94192,"Smith County","county"
-51089,51,"51","Henry",382.36404,36.78148,-79.75923,"Henry County","county"
-51510,51,"51","Alexandria city",14.934701,38.819252,-77.08367,"Alexandria city","county"
-19101,19,"19","Jefferson",435.53795999999994,41.005886,-91.96664,"Jefferson County","county"
-30049,30,"30","Lewis and Clark",3458.4983,47.13201,-112.37337,"Lewis and Clark County","county"
-49013,49,"49","Duchesne",3235.454,40.289394,-110.42958,"Duchesne County","county"
-40003,40,"40","Alfalfa",866.5943599999999,36.729702,-98.32345,"Alfalfa County","county"
-48119,48,"48","Delta",256.84085,33.385933,-95.67335,"Delta County","county"
-47169,47,"47","Trousdale",114.34556599999999,36.393029999999996,-86.15669,"Trousdale County","county"
-21193,21,"21","Perry",339.71155,37.241283,-83.21777,"Perry County","county"
-46039,46,"46","Deuel",622.7598,44.75629,-96.69024,"Deuel County","county"
-41029,41,"41","Jackson",2783.3499,42.41162,-122.67561,"Jackson County","county"
-72067,72,"72","Hormigueros Municipio",11.345957,18.134695,-67.116196,"Hormigueros Municipio","county"
-48507,48,"48","Zavala",1297.4512,28.864653000000004,-99.75983000000001,"Zavala County","county"
-31007,31,"31","Banner",746.2360000000001,41.53975,-103.726265,"Banner County","county"
-19121,19,"19","Madison",561.0252,41.33062,-94.01518,"Madison County","county"
-12011,12,"12","Broward",1202.8607,26.193535,-80.476685,"Broward County","county"
-13279,13,"13","Toombs",364.02127,32.117813,-82.33063,"Toombs County","county"
-26151,26,"26","Sanilac",962.6036,43.449154,-82.642815,"Sanilac County","county"
-48397,48,"48","Rockwall",127.118454,32.898678000000004,-96.4044,"Rockwall County","county"
-26163,26,"26","Wayne",611.8002,42.284664,-83.261955,"Wayne County","county"
-27105,27,"27","Nobles",715.11694,43.677685,-95.76313,"Nobles County","county"
-27001,27,"27","Aitkin",1821.8594,46.602447999999995,-93.41976,"Aitkin County","county"
-38071,38,"38","Ramsey",1185.4205,48.266163,-98.73903,"Ramsey County","county"
-37145,37,"37","Person",392.34726,36.38635,-78.96562,"Person County","county"
-20195,20,"20","Trego",889.5043300000001,38.921303,-99.865425,"Trego County","county"
-28151,28,"28","Washington",725.6668,33.273174,-90.94444,"Washington County","county"
-48133,48,"48","Eastland",926.53955,32.324646,-98.83655999999999,"Eastland County","county"
-28055,28,"28","Issaquena",413.05953999999997,32.75554,-91.00353,"Issaquena County","county"
-48123,48,"48","DeWitt",909.00726,29.082346,-97.36166,"DeWitt County","county"
-48005,48,"48","Angelina",797.81635,31.251896000000002,-94.61114,"Angelina County","county"
-45081,45,"45","Saluda",452.9661,34.00528,-81.727905,"Saluda County","county"
-29125,29,"29","Maries",526.9961,38.162617,-91.9236,"Maries County","county"
-5001,5,"05","Arkansas",988.8463,34.28957,-91.37655,"Arkansas County","county"
-29109,29,"29","Lawrence",611.7585,37.106590000000004,-93.83055,"Lawrence County","county"
-51540,51,"51","Charlottesville city",10.245017,38.037659999999995,-78.48538,"Charlottesville city","county"
-17011,17,"17","Bureau",869.1206,41.401306,-89.52837,"Bureau County","county"
-39145,39,"39","Scioto",610.2508,38.814888,-82.99866999999999,"Scioto County","county"
-37115,37,"37","Madison",449.63037,35.86421,-82.71263,"Madison County","county"
-16053,16,"16","Jerome",597.49176,42.691395,-114.26208500000001,"Jerome County","county"
-39163,39,"39","Vinton",412.37,39.25204,-82.48595999999999,"Vinton County","county"
-48309,48,"48","McLennan",1037.1843,31.549595,-97.20151,"McLennan County","county"
-16037,16,"16","Custer",4922.344,44.27335,-114.25226599999999,"Custer County","county"
-19089,19,"19","Howard",473.2626,43.36531,-92.32191,"Howard County","county"
-12099,12,"12","Palm Beach",1964.3495,26.649126000000003,-80.44836,"Palm Beach County","county"
-13181,13,"13","Lincoln",210.38835,33.792152,-82.448296,"Lincoln County","county"
-1013,1,"01","Butler",776.8649,31.751666999999998,-86.68196999999999,"Butler County","county"
-47165,47,"47","Sumner",529.4754,36.473442,-86.4598,"Sumner County","county"
-51097,51,"51","King and Queen",315.17368,37.717773,-76.90558,"King and Queen County","county"
-5015,5,"05","Carroll",630.0721,36.33737,-93.54097,"Carroll County","county"
-51820,51,"51","Waynesboro city",14.970304999999998,38.067158,-78.90142,"Waynesboro city","county"
-2220,2,"02","Sitka City and Borough",2870.1128,57.193203000000004,-135.3674,"Sitka City and Borough","county"
-41051,41,"41","Multnomah",431.121,45.547709999999995,-122.41736599999999,"Multnomah County","county"
-47061,47,"47","Grundy",360.45633,35.393387,-85.71038,"Grundy County","county"
-27057,27,"27","Hubbard",926.03796,47.09555,-94.91329,"Hubbard County","county"
-38081,38,"38","Sargent",858.5125,46.108204,-97.63005,"Sargent County","county"
-36089,36,"36","St. Lawrence",2679.5928,44.488113,-75.07431,"St. Lawrence County","county"
-29179,29,"29","Reynolds",808.5047,37.366463,-90.97228,"Reynolds County","county"
-6067,6,"06","Sacramento",965.28204,38.450016,-121.34043999999999,"Sacramento County","county"
-39125,39,"39","Paulding",416.44897000000003,41.11895,-84.58211999999999,"Paulding County","county"
-18179,18,"18","Wells",368.09963999999997,40.73527,-85.212975,"Wells County","county"
-51063,51,"51","Floyd",380.9358,36.931435,-80.350266,"Floyd County","county"
-6083,6,"06","Santa Barbara",2735.2651,34.537056,-120.03997,"Santa Barbara County","county"
-54005,54,"54","Boone",501.55118,38.022816,-81.71354000000001,"Boone County","county"
-28009,28,"28","Benton",406.63016,34.810520000000004,-89.20029,"Benton County","county"
-21055,21,"21","Crittenden",359.97546,37.35815,-88.10501,"Crittenden County","county"
-19147,19,"19","Palo Alto",563.883,43.075336,-94.66905,"Palo Alto County","county"
-19159,19,"19","Ringgold",535.5158,40.735332,-94.24425500000001,"Ringgold County","county"
-37151,37,"37","Randolph",782.3584,35.709915,-79.80621,"Randolph County","county"
-24015,24,"24","Cecil",346.31067,39.562355,-75.94158,"Cecil County","county"
-18171,18,"18","Warren",364.70285,40.352657,-87.37585,"Warren County","county"
-31077,31,"31","Greeley",569.83057,41.56757,-98.53056,"Greeley County","county"
-31095,31,"31","Jefferson",570.1904,40.175734999999996,-97.143105,"Jefferson County","county"
-31151,31,"31","Saline",574.081,40.516804,-97.13175,"Saline County","county"
-21119,21,"21","Knott",351.53002999999995,37.35437,-82.952545,"Knott County","county"
-19045,19,"19","Clinton",694.9375,41.898075,-90.53424,"Clinton County","county"
-27063,27,"27","Jackson",702.99603,43.671112,-95.149734,"Jackson County","county"
-27039,27,"27","Dodge",439.29297,44.020706,-92.869354,"Dodge County","county"
-27047,27,"27","Freeborn",707.26917,43.674202,-93.35029,"Freeborn County","county"
-6009,6,"06","Calaveras",1020.0335699999999,38.1839,-120.56143999999999,"Calaveras County","county"
-25001,25,"25","Barnstable",394.23107999999996,41.799015000000004,-70.21188000000001,"Barnstable County","county"
-51119,51,"51","Middlesex",130.33482,37.606976,-76.52808,"Middlesex County","county"
-42065,42,"42","Jefferson",652.4575,41.138027,-79.01241999999999,"Jefferson County","county"
-18089,18,"18","Lake",498.80605999999995,41.472248,-87.37434,"Lake County","county"
-47003,47,"47","Bedford",473.65527000000003,35.513659999999994,-86.45829,"Bedford County","county"
-47027,47,"47","Clay",236.5446,36.54575,-85.545715,"Clay County","county"
-17029,17,"17","Coles",508.30037999999996,39.51368,-88.22078,"Coles County","county"
-47097,47,"47","Lauderdale",471.98315,35.76295,-89.62773,"Lauderdale County","county"
-41001,41,"41","Baker",3068.0708,44.703426,-117.69193,"Baker County","county"
-36097,36,"36","Schuyler",328.35452000000004,42.419777,-76.93861,"Schuyler County","county"
-26159,26,"26","Van Buren",607.8481,42.28215,-86.306076,"Van Buren County","county"
-17131,17,"17","Mercer",561.25885,41.205605,-90.74176999999999,"Mercer County","county"
-21127,21,"21","Lawrence",415.6098,38.07445,-82.73829,"Lawrence County","county"
-21175,21,"21","Morgan",381.1399,37.922940000000004,-83.25894,"Morgan County","county"
-21177,21,"21","Muhlenberg",467.37384000000003,37.213817999999996,-87.13409399999999,"Muhlenberg County","county"
-17049,17,"17","Effingham",478.7859,39.047943,-88.59285,"Effingham County","county"
-47105,47,"47","Loudon",229.27965,35.735085,-84.31409000000001,"Loudon County","county"
-46025,46,"46","Clark",957.6361699999999,44.85521,-97.724915,"Clark County","county"
-15003,15,"15","Honolulu",600.5916,21.580023,-158.12341,"Honolulu County","county"
-12041,12,"12","Gilchrist",349.7068,29.723454999999998,-82.7958,"Gilchrist County","county"
-18157,18,"18","Tippecanoe",498.92407000000003,40.389133,-86.893555,"Tippecanoe County","county"
-42109,42,"42","Snyder",328.79437,40.755404999999996,-77.07293,"Snyder County","county"
-48277,48,"48","Lamar",907.22687,33.667263,-95.57035,"Lamar County","county"
-12086,12,"12","Miami-Dade",1899.9056,25.61058,-80.4971,"Miami-Dade County","county"
-31057,31,"31","Dundy",919.7097,40.180164000000005,-101.68113000000001,"Dundy County","county"
-48289,48,"48","Leon",1073.1927,31.300493,-95.99562,"Leon County","county"
-8097,8,"08","Pitkin",970.7344,39.217537,-106.91616,"Pitkin County","county"
-38035,38,"38","Grand Forks",1436.2742,47.926003,-97.45085,"Grand Forks County","county"
-18091,18,"18","LaPorte",598.2905,41.549009999999996,-86.744736,"LaPorte County","county"
-18057,18,"18","Hamilton",394.36078,40.053509999999996,-86.02171,"Hamilton County","county"
-51595,51,"51","Emporia city",6.904155,36.696182,-77.53596999999999,"Emporia city","county"
-40081,40,"40","Lincoln",952.4038,35.703117,-96.88139,"Lincoln County","county"
-20071,20,"20","Greeley",778.4308,38.480404,-101.80597,"Greeley County","county"
-13145,13,"13","Harris",463.84055,32.73155,-84.91243,"Harris County","county"
-13251,13,"13","Screven",645.7934,32.74475,-81.617584,"Screven County","county"
-72127,72,"72","San Juan Municipio",47.88984,18.422249,-66.069084,"San Juan Municipio","county"
-48433,48,"48","Stonewall",916.34375,33.17958,-100.25381,"Stonewall County","county"
-39069,39,"39","Henry",416.02435,41.331585,-84.0689,"Henry County","county"
-33009,33,"33","Grafton",1708.6584,43.926437,-71.84241999999999,"Grafton County","county"
-29145,29,"29","Newton",624.77563,36.90837,-94.33504,"Newton County","county"
-18129,18,"18","Posey",409.38245,38.027615000000004,-87.86865,"Posey County","county"
-48311,48,"48","McMullen",1139.8378,28.384921999999996,-98.57885,"McMullen County","county"
-17035,17,"17","Cumberland",345.95544,39.27312,-88.240616,"Cumberland County","county"
-13297,13,"13","Walton",326.82614,33.783885999999995,-83.73183,"Walton County","county"
-27121,27,"27","Pope",669.5531599999999,45.589622,-95.44671,"Pope County","county"
-51157,51,"51","Rappahannock",266.3813,38.68452,-78.16882,"Rappahannock County","county"
-51009,51,"51","Amherst",473.97763,37.629303,-79.15467,"Amherst County","county"
-6111,6,"06","Ventura",1842.5375,34.358740000000004,-119.13314,"Ventura County","county"
-17033,17,"17","Crawford",443.65854,39.002784999999996,-87.76061999999999,"Crawford County","county"
-8093,8,"08","Park",2193.9775,39.118916,-105.71765,"Park County","county"
-6037,6,"06","Los Angeles",4058.7905,34.1964,-118.26186000000001,"Los Angeles County","county"
-4027,4,"04","Yuma",5514.026999999999,32.77394,-113.910904,"Yuma County","county"
-13129,13,"13","Gordon",356.4548,34.509665999999996,-84.87386,"Gordon County","county"
-19025,19,"19","Calhoun",569.8655,42.38617,-94.643684,"Calhoun County","county"
-12055,12,"12","Highlands",1017.67847,27.341079999999998,-81.342354,"Highlands County","county"
-51580,51,"51","Covington city",5.468876,37.78106,-79.985435,"Covington city","county"
-50017,50,"50","Orange",687.0518,44.00339,-72.36969,"Orange County","county"
-20113,20,"20","McPherson",898.31555,38.395813000000004,-97.64749,"McPherson County","county"
-4021,4,"04","Pinal",5366.2295,32.91852,-111.36634,"Pinal County","county"
-39051,39,"39","Fulton",405.4609,41.597263,-84.12427,"Fulton County","county"
-8003,8,"08","Alamosa",722.6016,37.568443,-105.78804,"Alamosa County","county"
-12017,12,"12","Citrus",581.93066,28.84364,-82.52481,"Citrus County","county"
-72049,72,"72","Culebra Municipio",11.627883,18.3266,-65.30771999999999,"Culebra Municipio","county"
-72051,72,"72","Dorado Municipio",23.116757999999997,18.474375,-66.26196999999999,"Dorado Municipio","county"
-47041,47,"47","DeKalb",304.42526000000004,35.98222,-85.83359499999999,"DeKalb County","county"
-42031,42,"42","Clarion",600.8558,41.198159999999994,-79.42036999999999,"Clarion County","county"
-46097,46,"46","Miner",570.18964,44.02154,-97.60812,"Miner County","county"
-46073,46,"46","Jerauld",526.1505,44.06341,-98.62317,"Jerauld County","county"
-18031,18,"18","Decatur",372.58044,39.30598,-85.49983,"Decatur County","county"
-18037,18,"18","Dubois",427.27975,38.373344,-86.87338000000001,"Dubois County","county"
-51057,51,"51","Essex",257.09692,37.939479999999996,-76.94187,"Essex County","county"
-45089,45,"45","Williamsburg",934.1972699999999,33.626459999999994,-79.71648,"Williamsburg County","county"
-36031,36,"36","Essex",1794.1791,44.1096,-73.77843,"Essex County","county"
-19195,19,"19","Worth",400.13705,43.373490000000004,-93.248535,"Worth County","county"
-40063,40,"40","Hughes",804.51245,35.052933,-96.25118,"Hughes County","county"
-51027,51,"51","Buchanan",502.8715,37.26812,-82.038155,"Buchanan County","county"
-51005,51,"51","Alleghany",446.58435,37.787907000000004,-80.00867,"Alleghany County","county"
-28087,28,"28","Lowndes",505.46063,33.471424,-88.43972,"Lowndes County","county"
-18143,18,"18","Scott",190.40756000000002,38.679432,-85.7519,"Scott County","county"
-8099,8,"08","Prowers",1638.453,37.958183,-102.39216,"Prowers County","county"
-48435,48,"48","Sutton",1453.9846,30.522184000000003,-100.51335999999999,"Sutton County","county"
-72121,72,"72","Sabana Grande Municipio",36.314240000000005,18.084484,-66.94761,"Sabana Grande Municipio","county"
-40101,40,"40","Muskogee",810.65137,35.61755,-95.38391,"Muskogee County","county"
-29043,29,"29","Christian",562.6669,36.969738,-93.187614,"Christian County","county"
-72039,72,"72","Ciales Municipio",66.5316,18.295912,-66.51559,"Ciales Municipio","county"
-28073,28,"28","Lamar",496.6915,31.197585999999998,-89.50636999999999,"Lamar County","county"
-18137,18,"18","Ripley",446.4385,39.100227000000004,-85.26049,"Ripley County","county"
-38057,38,"38","Mercer",1042.8163,47.307148,-101.83333,"Mercer County","county"
-13147,13,"13","Hart",232.43005,34.348732,-82.96329,"Hart County","county"
-22049,22,"22","Jackson Parish",569.2048,32.30429,-92.5617,"Jackson Parish","county"
-51133,51,"51","Northumberland",191.4468,37.856970000000004,-76.379684,"Northumberland County","county"
-48157,48,"48","Fort Bend",861.7923599999999,29.526602,-95.77101,"Fort Bend County","county"
-55047,55,"55","Green Lake",349.55588,43.780246999999996,-88.97038,"Green Lake County","county"
-30073,30,"30","Pondera",1624.622,48.228603,-112.22076399999999,"Pondera County","county"
-55127,55,"55","Walworth",555.43805,42.66811,-88.54173,"Walworth County","county"
-32021,32,"32","Mineral",3752.9692,38.516647,-118.41628,"Mineral County","county"
-17057,17,"17","Fulton",865.7226,40.46524,-90.20227,"Fulton County","county"
-36103,36,"36","Suffolk",911.8377,40.943554,-72.692215,"Suffolk County","county"
-18161,18,"18","Union",161.19566,39.62311,-84.925156,"Union County","county"
-29119,29,"29","McDonald",539.4985,36.63022,-94.343956,"McDonald County","county"
-31157,31,"31","Scotts Bluff",739.4414,41.85033,-103.701546,"Scotts Bluff County","county"
-35047,35,"35","San Miguel",4721.6753,35.476859999999995,-104.80351999999999,"San Miguel County","county"
-1081,1,"01","Lee",607.5581,32.604065000000006,-85.35305,"Lee County","county"
-48367,48,"48","Parker",903.7507300000001,32.777096,-97.80591,"Parker County","county"
-38021,38,"38","Dickey",1131.5319,46.107758000000004,-98.49651999999999,"Dickey County","county"
-38003,38,"38","Barnes",1491.609,46.94255,-98.0702,"Barnes County","county"
-27143,27,"27","Sibley",588.8544,44.575733,-94.230125,"Sibley County","county"
-13293,13,"13","Upson",323.4777,32.881836,-84.29228,"Upson County","county"
-6097,6,"06","Sonoma",1575.6454,38.52518,-122.92611000000001,"Sonoma County","county"
-26033,26,"26","Chippewa",1558.5604,46.32182,-84.52063000000001,"Chippewa County","county"
-16019,16,"16","Bonneville",1866.0458,43.395171999999995,-111.62188,"Bonneville County","county"
-13013,13,"13","Barrow",161.04183999999998,33.99201,-83.7123,"Barrow County","county"
-13183,13,"13","Long",400.40677,31.749563000000002,-81.74287,"Long County","county"
-48271,48,"48","Kinney",1360.1011,29.347085999999997,-100.4177,"Kinney County","county"
-40115,40,"40","Ottawa",470.83272999999997,36.835762,-94.80268000000001,"Ottawa County","county"
-42033,42,"42","Clearfield",1144.7216,41.000248,-78.47375,"Clearfield County","county"
-26037,26,"26","Clinton",566.43787,42.950455,-84.5917,"Clinton County","county"
-72133,72,"72","Santa Isabel Municipio",34.036106,17.952920000000002,-66.38759,"Santa Isabel Municipio","county"
-17135,17,"17","Montgomery",703.7826,39.22807,-89.47814,"Montgomery County","county"
-28003,28,"28","Alcorn",400.05807000000004,34.88657,-88.58111,"Alcorn County","county"
-28071,28,"28","Lafayette",631.7157599999999,34.353077,-89.48538,"Lafayette County","county"
-22043,22,"22","Grant Parish",643.0479,31.597788,-92.561714,"Grant Parish","county"
-29005,29,"29","Atchison",547.304,40.431847,-95.43755,"Atchison County","county"
-17115,17,"17","Macon",580.59546,39.860237,-88.96153000000001,"Macon County","county"
-26149,26,"26","St. Joseph",500.61252,41.911488,-85.52287,"St. Joseph County","county"
-17055,17,"17","Franklin",408.93532999999996,37.99185,-88.92631999999999,"Franklin County","county"
-30033,30,"30","Garfield",4676.7188,47.267185,-106.995995,"Garfield County","county"
-31001,31,"31","Adams",563.2931,40.520634,-98.500046,"Adams County","county"
-27109,27,"27","Olmsted",653.6394,43.9995,-92.410095,"Olmsted County","county"
-34039,34,"34","Union",102.769806,40.65987,-74.30869,"Union County","county"
-72139,72,"72","Trujillo Alto Municipio",20.76765,18.335386,-66.003784,"Trujillo Alto Municipio","county"
-1097,1,"01","Mobile",1229.4523,30.684571999999996,-88.19657,"Mobile County","county"
-46087,46,"46","McCook",574.22485,43.680415999999994,-97.35805,"McCook County","county"
-1057,1,"01","Fayette",627.705,33.716156,-87.76429,"Fayette County","county"
-1017,1,"01","Chambers",596.5812,32.915504,-85.394035,"Chambers County","county"
-37131,37,"37","Northampton",536.6957,36.421772,-77.39835,"Northampton County","county"
-8081,8,"08","Moffat",4743.405,40.610863,-108.217155,"Moffat County","county"
-21087,21,"21","Green",286.05875,37.275383000000005,-85.57848,"Green County","county"
-18047,18,"18","Franklin",384.4389,39.409763,-85.06696,"Franklin County","county"
-37013,37,"37","Beaufort",832.1208,35.48231,-76.84201999999999,"Beaufort County","county"
-72073,72,"72","Jayuya Municipio",44.534748,18.211153,-66.58686999999999,"Jayuya Municipio","county"
-38015,38,"38","Burleigh",1632.75,46.97883,-100.469536,"Burleigh County","county"
-37159,37,"37","Rowan",511.49744000000004,35.641354,-80.52172,"Rowan County","county"
-26071,26,"26","Iron",1166.037,46.170254,-88.54053,"Iron County","county"
-27067,27,"27","Kandiyohi",797.4093,45.152714,-95.00498,"Kandiyohi County","county"
-21237,21,"21","Wolfe",222.17812999999998,37.743893,-83.49511,"Wolfe County","county"
-48149,48,"48","Fayette",949.966,29.877886,-96.921234,"Fayette County","county"
-46081,46,"46","Lawrence",800.0801,44.348766,-103.80495,"Lawrence County","county"
-23029,23,"23","Washington",2562.8137,44.967009999999995,-67.60935,"Washington County","county"
-48045,48,"48","Briscoe",900.0313,34.525172999999995,-101.205894,"Briscoe County","county"
-26131,26,"26","Ontonagon",1311.0221,47.216602,-89.500465,"Ontonagon County","county"
-28015,28,"28","Carroll",628.3113400000001,33.440796,-89.91888399999999,"Carroll County","county"
-41003,41,"41","Benton",675.20465,44.49388,-123.42466999999999,"Benton County","county"
-27133,27,"27","Rock",482.47452000000004,43.669585999999995,-96.26324,"Rock County","county"
-42063,42,"42","Indiana",827.3409,40.651432,-79.08755,"Indiana County","county"
-22061,22,"22","Lincoln Parish",471.75802999999996,32.601820000000004,-92.6623,"Lincoln Parish","county"
-42099,42,"42","Perry",551.46704,40.39778,-77.26633000000001,"Perry County","county"
-46137,46,"46","Ziebach",1961.307,44.989765000000006,-101.66083,"Ziebach County","county"
-48203,48,"48","Harrison",900.0884,32.547993,-94.37443499999999,"Harrison County","county"
-26013,26,"26","Baraga",898.4572,46.695858,-88.36180999999999,"Baraga County","county"
-40131,40,"40","Rogers",675.6568599999999,36.377792,-95.60139000000001,"Rogers County","county"
-29019,29,"29","Boone",685.5742,38.98986,-92.3102,"Boone County","county"
-72097,72,"72","Mayagüez Municipio",77.67653,18.164125,-67.89333,"Mayagüez Municipio","county"
-40015,40,"40","Caddo",1277.797,35.16792,-98.38104,"Caddo County","county"
-8059,8,"08","Jefferson",764.36285,39.57951,-105.24546000000001,"Jefferson County","county"
-54011,54,"54","Cabell",281.02914,38.419579999999996,-82.24339,"Cabell County","county"
-48383,48,"48","Reagan",1175.3539,31.375190000000003,-101.5144,"Reagan County","county"
-5141,5,"05","Van Buren",709.7743,35.582954,-92.515976,"Van Buren County","county"
-8117,8,"08","Summit",608.3596,39.62102,-106.13756000000001,"Summit County","county"
-20035,20,"20","Cowley",1125.7764,37.23451,-96.83725,"Cowley County","county"
-5071,5,"05","Johnson",659.8636,35.57336,-93.466324,"Johnson County","county"
-36041,36,"36","Hamilton",1717.4368,43.65788,-74.50246,"Hamilton County","county"
-51045,51,"51","Craig",328.10938,37.473602,-80.23105,"Craig County","county"
-48083,48,"48","Coleman",1262.9574,31.914206,-99.34662,"Coleman County","county"
-2290,2,"02","Yukon-Koyukuk Census Area",145580.47,65.375725,-151.57785,"Yukon-Koyukuk Census Area","county"
-4017,4,"04","Navajo",9950.392,35.390785,-110.32101999999999,"Navajo County","county"
-28085,28,"28","Lincoln",586.2272,31.535215,-90.45357,"Lincoln County","county"
-48357,48,"48","Ochiltree",917.7157599999999,36.278744,-100.815865,"Ochiltree County","county"
-48103,48,"48","Crane",785.0958,31.422796,-102.48778,"Crane County","county"
-56003,56,"56","Big Horn",3137.0640000000003,44.525116,-107.99485,"Big Horn County","county"
-47081,47,"47","Hickman",612.5042,35.802326,-87.46712,"Hickman County","county"
-28143,28,"28","Tunica",454.69372999999996,34.652203,-90.37177,"Tunica County","county"
-29081,29,"29","Harrison",722.5414,40.345620000000004,-93.992584,"Harrison County","county"
-72029,72,"72","Canóvanas Municipio",32.869137,18.329872,-65.88514,"Canóvanas Municipio","county"
-18005,18,"18","Bartholomew",406.96924,39.205845000000004,-85.897995,"Bartholomew County","county"
-13223,13,"13","Paulding",312.33966000000004,33.92103,-84.86717,"Paulding County","county"
-39015,39,"39","Brown",490.0338,38.931377000000005,-83.866776,"Brown County","county"
-47141,47,"47","Putnam",401.11996,36.14094,-85.49618000000001,"Putnam County","county"
-38101,38,"38","Ward",2012.9983,48.216685999999996,-101.54053499999999,"Ward County","county"
-25027,25,"25","Worcester",1510.6973,42.311695,-71.940285,"Worcester County","county"
-39091,39,"39","Logan",458.52524000000005,40.387553999999994,-83.76634,"Logan County","county"
-6031,6,"06","Kings",1390.3563,36.07248,-119.81553000000001,"Kings County","county"
-6073,6,"06","San Diego",4210.345,33.023604999999996,-116.77611499999999,"San Diego County","county"
-72123,72,"72","Salinas Municipio",69.39692,17.971485,-66.26225,"Salinas Municipio","county"
-13079,13,"13","Crawford",324.9245,32.709427000000005,-83.97919,"Crawford County","county"
-72103,72,"72","Naguabo Municipio",51.66212,18.21107,-65.73575,"Naguabo Municipio","county"
-29037,29,"29","Cass",696.6382,38.646473,-94.354546,"Cass County","county"
-36027,36,"36","Dutchess",795.67584,41.75477,-73.74004000000001,"Dutchess County","county"
-48477,48,"48","Washington",604.2144,30.215075,-96.41027,"Washington County","county"
-8101,8,"08","Pueblo",2386.179,38.17066,-104.48989,"Pueblo County","county"
-29067,29,"29","Douglas",813.65076,36.946518,-92.51589,"Douglas County","county"
-38009,38,"38","Bottineau",1668.4335,48.79441,-100.83126,"Bottineau County","county"
-37051,37,"37","Cumberland",652.5849599999999,35.050194,-78.82871999999999,"Cumberland County","county"
-56017,56,"56","Hot Springs",2004.4972,43.720209999999994,-108.435074,"Hot Springs County","county"
-26001,26,"26","Alcona",674.6783,44.682533,-82.834076,"Alcona County","county"
-6061,6,"06","Placer",1407.1224,39.06203,-120.72272,"Placer County","county"
-5129,5,"05","Searcy",666.0318599999999,35.896384999999995,-92.695885,"Searcy County","county"
-48305,48,"48","Lynn",891.89734,33.178413,-101.8185,"Lynn County","county"
-36077,36,"36","Otsego",1001.7712,42.629776,-75.02884,"Otsego County","county"
-37153,37,"37","Richmond",473.70538,35.004635,-79.75569,"Richmond County","county"
-37093,37,"37","Hoke",390.13727,35.01723,-79.24197,"Hoke County","county"
-31131,31,"31","Otoe",615.68463,40.637993,-96.13103000000001,"Otoe County","county"
-42023,42,"42","Cameron",396.2444,41.43829,-78.198326,"Cameron County","county"
-45035,45,"45","Dorchester",568.6133,33.082188,-80.40469,"Dorchester County","county"
-27161,27,"27","Waseca",423.37737999999996,44.01846,-93.58984,"Waseca County","county"
-46015,46,"46","Brule",817.2686,43.729874,-99.09291,"Brule County","county"
-47177,47,"47","Warren",432.6882,35.67825,-85.77734,"Warren County","county"
-17023,17,"17","Clark",501.3919,39.332333,-87.79169,"Clark County","county"
-21201,21,"21","Robertson",99.9247,38.513474,-84.06423000000001,"Robertson County","county"
-47095,47,"47","Lake",165.79066,36.333904,-89.485535,"Lake County","county"
-45015,45,"45","Berkeley",1103.7072,33.2077,-79.95366,"Berkeley County","county"
-5051,5,"05","Garland",677.6422,34.578854,-93.146935,"Garland County","county"
-20139,20,"20","Osage",705.53046,38.650215,-95.70825,"Osage County","county"
-39155,39,"39","Trumbull",618.1079,41.306374,-80.7704,"Trumbull County","county"
-48333,48,"48","Mills",748.2401,31.494888,-98.59461999999999,"Mills County","county"
-48359,48,"48","Oldham",1500.5742,35.401920000000004,-102.59761999999999,"Oldham County","county"
-42019,42,"42","Butler",789.58527,40.913845,-79.918976,"Butler County","county"
-16049,16,"16","Idaho",8477.787,45.849644,-115.46734,"Idaho County","county"
-20115,20,"20","Marion",944.3309300000001,38.359646000000005,-97.10276999999999,"Marion County","county"
-51029,51,"51","Buckingham",579.6422,37.57393,-78.52917,"Buckingham County","county"
-37025,37,"37","Cabarrus",361.26883,35.388344000000004,-80.55273000000001,"Cabarrus County","county"
-29225,29,"29","Webster",592.5833,37.280803999999996,-92.876076,"Webster County","county"
-49011,49,"49","Davis",299.07482999999996,41.03756,-112.20194,"Davis County","county"
-27033,27,"27","Cottonwood",639.9947,44.01064,-95.18315,"Cottonwood County","county"
-12093,12,"12","Okeechobee",769.1833,27.385592,-80.88739,"Okeechobee County","county"
-13291,13,"13","Union",322.09634,34.833332,-83.98926,"Union County","county"
-19013,19,"19","Black Hawk",565.7868,42.47113,-92.3076,"Black Hawk County","county"
-48403,48,"48","Sabine",491.72687,31.3433,-93.85191,"Sabine County","county"
-39131,39,"39","Pike",440.29672,39.071342,-83.05291,"Pike County","county"
-1125,1,"01","Tuscaloosa",1320.9043,33.29022,-87.52278000000001,"Tuscaloosa County","county"
-1131,1,"01","Wilcox",888.4803,31.990082,-87.30493,"Wilcox County","county"
-28097,28,"28","Montgomery",406.99442,33.500713,-89.639626,"Montgomery County","county"
-31099,31,"31","Kearney",516.2607,40.50912,-98.9476,"Kearney County","county"
-31087,31,"31","Hitchcock",709.9667,40.176895,-101.04422,"Hitchcock County","county"
-10003,10,"10","New Castle",426.33227999999997,39.575916,-75.64413499999999,"New Castle County","county"
-16081,16,"16","Teton",449.10614000000004,43.760994000000004,-111.21177,"Teton County","county"
-17161,17,"17","Rock Island",427.46747,41.468422,-90.57213,"Rock Island County","county"
-51073,51,"51","Gloucester",217.81717999999998,37.40354,-76.52350600000001,"Gloucester County","county"
-5133,5,"05","Sevier",565.3238,33.994877,-94.24328,"Sevier County","county"
-18017,18,"18","Cass",412.16913,40.7538,-86.35517,"Cass County","county"
-16077,16,"16","Power",1403.8737,42.694126000000004,-112.844406,"Power County","county"
-18015,18,"18","Carroll",372.2373,40.58498,-86.56514,"Carroll County","county"
-42101,42,"42","Philadelphia",134.28388999999999,40.009377,-75.13335,"Philadelphia County","county"
-56043,56,"56","Washakie",2238.75,43.87883,-107.66905,"Washakie County","county"
-37029,37,"37","Camden",240.33696,36.342341999999995,-76.16249,"Camden County","county"
-36109,36,"36","Tompkins",474.65732,42.453007,-76.47348000000001,"Tompkins County","county"
-5069,5,"05","Jefferson",870.08185,34.27724,-91.92967,"Jefferson County","county"
-5079,5,"05","Lincoln",561.55975,33.957676,-91.72762,"Lincoln County","county"
-55123,55,"55","Vernon",791.58875,43.599365,-90.82198000000001,"Vernon County","county"
-29093,29,"29","Iron",550.28314,37.594364,-90.98468000000001,"Iron County","county"
-48223,48,"48","Hopkins",767.4540400000001,33.148967999999996,-95.56544,"Hopkins County","county"
-36001,36,"36","Albany",522.8467400000001,42.58824,-73.97400999999999,"Albany County","county"
-48225,48,"48","Houston",1231.0432,31.323036,-95.4216,"Houston County","county"
-39111,39,"39","Monroe",455.73874000000006,39.726254,-81.09098,"Monroe County","county"
-20165,20,"20","Rush",717.7874,38.523598,-99.30918,"Rush County","county"
-18107,18,"18","Montgomery",504.66437,40.040295,-86.892715,"Montgomery County","county"
-20187,20,"20","Stanton",680.37506,37.565933,-101.78938000000001,"Stanton County","county"
-21129,21,"21","Lee",208.86603,37.608115999999995,-83.719246,"Lee County","county"
-27071,27,"27","Koochiching",3104.8372,48.245373,-93.7829,"Koochiching County","county"
-48029,48,"48","Bexar",1240.3489,29.448671,-98.52015,"Bexar County","county"
-8013,8,"08","Boulder",726.40234,40.09497,-105.39769,"Boulder County","county"
-47089,47,"47","Jefferson",275.08206,36.048336,-83.44114,"Jefferson County","county"
-40097,40,"40","Mayes",655.3995,36.303802000000005,-95.23564,"Mayes County","county"
-27165,27,"27","Watonwan",434.96905999999996,43.978107,-94.6138,"Watonwan County","county"
-16013,16,"16","Blaine",2637.8271,43.39419,-113.95537,"Blaine County","county"
-22053,22,"22","Jefferson Davis Parish",651.3863,30.26953,-92.81622,"Jefferson Davis Parish","county"
-46119,46,"46","Sully",1006.7569,44.722324,-100.1314,"Sully County","county"
-8031,8,"08","Denver",153.29733000000002,39.76185,-104.8811,"Denver County","county"
-40029,40,"40","Coal",516.78723,34.582863,-96.28804000000001,"Coal County","county"
-30011,30,"30","Carter",3340.5908,45.516822999999995,-104.51533,"Carter County","county"
-48461,48,"48","Upton",1241.3647,31.353817,-102.04155,"Upton County","county"
-18051,18,"18","Gibson",487.4385,38.317398,-87.58051999999999,"Gibson County","county"
-31105,31,"31","Kimball",951.8781,41.199272,-103.703156,"Kimball County","county"
-17093,17,"17","Kendall",320.24896,41.58814,-88.430626,"Kendall County","county"
-11001,11,"11","District of Columbia",61.137646,38.904247,-77.01652,"District of Columbia","county"
-8085,8,"08","Montrose",2241.0222,38.407505,-108.26628000000001,"Montrose County","county"
-27171,27,"27","Wright",661.1412,45.175090000000004,-93.9664,"Wright County","county"
-55059,55,"55","Kenosha",271.85422,42.579704,-87.425,"Kenosha County","county"
-8037,8,"08","Eagle",1684.5275,39.62699,-106.69516999999999,"Eagle County","county"
-6075,6,"06","San Francisco",46.904415,37.727238,-123.03223,"San Francisco County","county"
-8113,8,"08","San Miguel",1286.7701,38.00932,-108.42726,"San Miguel County","county"
-2020,2,"02","Anchorage Municipality",1706.8579,61.17425,-149.28433,"Anchorage Municipality","county"
-12109,12,"12","St. Johns",600.5854,29.890488,-81.40004,"St. Johns County","county"
-28019,28,"28","Choctaw",418.2102,33.345963,-89.251335,"Choctaw County","county"
-29079,29,"29","Grundy",435.3069,40.11254,-93.56505600000001,"Grundy County","county"
-26085,26,"26","Lake",567.6106,43.995186,-85.8114,"Lake County","county"
-26139,26,"26","Ottawa",563.5306,42.94246,-86.654945,"Ottawa County","county"
-17031,17,"17","Cook",944.96234,41.894295,-87.645454,"Cook County","county"
-17059,17,"17","Gallatin",323.00116,37.768677000000004,-88.22797,"Gallatin County","county"
-45047,45,"45","Greenwood",454.73868,34.155796,-82.12788,"Greenwood County","county"
-20059,20,"20","Franklin",571.79126,38.558018,-95.27896,"Franklin County","county"
-27027,27,"27","Clay",1045.2338,46.898376,-96.4949,"Clay County","county"
-47075,47,"47","Haywood",533.1254,35.586678000000006,-89.28269,"Haywood County","county"
-49003,49,"49","Box Elder",5745.7880000000005,41.276061999999996,-113.12623,"Box Elder County","county"
-28139,28,"28","Tippah",457.83797999999996,34.76362,-88.918816,"Tippah County","county"
-54051,54,"54","Marshall",305.4417,39.854427,-80.67179,"Marshall County","county"
-54035,54,"54","Jackson",464.3751,38.834232,-81.67772,"Jackson County","county"
-16039,16,"16","Elmore",3075.1833,43.3947,-115.47121000000001,"Elmore County","county"
-24005,24,"24","Baltimore",598.3803,39.443165,-76.61657,"Baltimore County","county"
-38005,38,"38","Benson",1388.6023,48.071743,-99.35115,"Benson County","county"
-29163,29,"29","Pike",670.4616,39.33996,-91.17161,"Pike County","county"
-39087,39,"39","Lawrence",453.3861,38.603867,-82.51719,"Lawrence County","county"
-29201,29,"29","Scott",420.00574000000006,37.047794,-89.5681,"Scott County","county"
-39001,39,"39","Adams",583.887,38.83447,-83.47808,"Adams County","county"
-48143,48,"48","Erath",1083.2146,32.23666,-98.220505,"Erath County","county"
-13137,13,"13","Habersham",276.83704,34.63439,-83.52587,"Habersham County","county"
-13319,13,"13","Wilkinson",449.22964,32.804268,-83.175514,"Wilkinson County","county"
-54061,54,"54","Monongalia",360.1032,39.633644,-80.059074,"Monongalia County","county"
-39033,39,"39","Crawford",401.79916000000003,40.848526,-82.92478,"Crawford County","county"
-12027,12,"12","DeSoto",636.7148,27.190579999999997,-81.80625,"DeSoto County","county"
-9011,9,"09","New London",665.1651,41.472652000000004,-72.10863499999999,"New London County","county"
-39059,39,"39","Guernsey",522.2716,40.056664000000005,-81.49786999999999,"Guernsey County","county"
-26015,26,"26","Barry",553.1134,42.582809999999995,-85.31455,"Barry County","county"
-29209,29,"29","Stone",463.8969,36.751003000000004,-93.4737,"Stone County","county"
-51760,51,"51","Richmond city",59.925087,37.5314,-77.47600600000001,"Richmond city","county"
-37169,37,"37","Stokes",449.0295,36.393505,-80.26621,"Stokes County","county"
-19039,19,"19","Clarke",431.18118,41.02919,-93.78409599999999,"Clarke County","county"
-19065,19,"19","Fayette",730.8548599999999,42.86412,-91.84038000000001,"Fayette County","county"
-6041,6,"06","Marin",520.4642,38.051815000000005,-122.74597,"Marin County","county"
-48381,48,"48","Randall",911.9643599999999,34.96253,-101.895546,"Randall County","county"
-48401,48,"48","Rusk",924.0683,32.109425,-94.75638599999999,"Rusk County","county"
-19181,19,"19","Warren",569.8572,41.332446999999995,-93.56875,"Warren County","county"
-39161,39,"39","Van Wert",409.1672,40.855522,-84.58578,"Van Wert County","county"
-12043,12,"12","Glades",806.5956,26.954811,-81.19082,"Glades County","county"
-13199,13,"13","Meriwether",501.24042000000003,33.029266,-84.66705999999999,"Meriwether County","county"
-8023,8,"08","Costilla",1227.6351,37.277546,-105.42894,"Costilla County","county"
-48099,48,"48","Coryell",1052.2344,31.391178000000004,-97.79802,"Coryell County","county"
-19001,19,"19","Adair",569.29,41.32853,-94.478165,"Adair County","county"
-13053,13,"13","Chattahoochee",248.7456,32.347446000000005,-84.78801999999999,"Chattahoochee County","county"
-6043,6,"06","Mariposa",1448.8868,37.570029999999996,-119.912865,"Mariposa County","county"
-29089,29,"29","Howard",463.81604000000004,39.143364,-92.69592,"Howard County","county"
-41047,41,"41","Marion",1180.5992,44.900898,-122.57626,"Marion County","county"
-55079,55,"55","Milwaukee",241.49011000000002,43.01766,-87.48155,"Milwaukee County","county"
-27139,27,"27","Scott",356.2658,44.651806,-93.53373,"Scott County","county"
-39129,39,"39","Pickaway",501.2453,39.64895,-83.052826,"Pickaway County","county"
-51145,51,"51","Powhatan",260.21378,37.549403999999996,-77.91286,"Powhatan County","county"
-8014,8,"08","Broomfield",33.004658,39.953594,-105.05078999999999,"Broomfield County","county"
-47099,47,"47","Lawrence",617.1509,35.220478,-87.39654499999999,"Lawrence County","county"
-26009,26,"26","Antrim",475.69507000000004,45.005455,-85.17564,"Antrim County","county"
-45069,45,"45","Marlboro",479.89005,34.60167,-79.679436,"Marlboro County","county"
-16009,16,"16","Benewah",776.95776,47.218452,-116.633545,"Benewah County","county"
-17103,17,"17","Lee",724.8114,41.747448,-89.29936,"Lee County","county"
-31127,31,"31","Nemaha",407.39047,40.38739,-95.85271999999999,"Nemaha County","county"
-37031,37,"37","Carteret",507.6199,34.858340000000005,-76.53586,"Carteret County","county"
-20149,20,"20","Pottawatomie",840.7688,39.382187,-96.33711,"Pottawatomie County","county"
-26075,26,"26","Jackson",701.90497,42.248474,-84.42087,"Jackson County","county"
-48091,48,"48","Comal",559.54364,29.805490000000002,-98.260544,"Comal County","county"
-25019,25,"25","Nantucket",46.16652,41.305878,-70.14191,"Nantucket County","county"
-45009,45,"45","Bamberg",393.3801,33.203022,-81.05315999999999,"Bamberg County","county"
-48007,48,"48","Aransas",252.07799,28.122621999999996,-96.9675,"Aransas County","county"
-13019,13,"13","Berrien",453.3911,31.288652000000003,-83.22787,"Berrien County","county"
-18165,18,"18","Vermillion",256.873,39.854046000000004,-87.462074,"Vermillion County","county"
-26143,26,"26","Roscommon",519.91437,44.339515999999996,-84.611275,"Roscommon County","county"
-37005,37,"37","Alleghany",234.42593,36.489357,-81.1323,"Alleghany County","county"
-6035,6,"06","Lassen",4541.34,40.721084999999995,-120.62995,"Lassen County","county"
-51610,51,"51","Falls Church city",2.0465120999999997,38.884724,-77.175606,"Falls Church city","county"
-12081,12,"12","Manatee",743.65607,27.481682,-82.36877,"Manatee County","county"
-39119,39,"39","Muskingum",664.5685,39.966045,-81.943504,"Muskingum County","county"
-8015,8,"08","Chaffee",1013.4429,38.738224,-106.31668,"Chaffee County","county"
-8025,8,"08","Crowley",787.4543,38.30618,-103.772736,"Crowley County","county"
-8043,8,"08","Fremont",1533.1343,38.45517,-105.42496000000001,"Fremont County","county"
-28109,28,"28","Pearl River",811.3314,30.774794,-89.58691,"Pearl River County","county"
-28111,28,"28","Perry",647.2295,31.169308,-88.988754,"Perry County","county"
-31041,31,"31","Custer",2575.6814,41.393894,-99.72686999999999,"Custer County","county"
-12013,12,"12","Calhoun",567.3557,30.388802000000002,-85.197914,"Calhoun County","county"
-21117,21,"21","Kenton",160.29568,38.930504,-84.53344,"Kenton County","county"
-19037,19,"19","Chickasaw",504.34094000000005,43.059742,-92.31721,"Chickasaw County","county"
-17037,17,"17","DeKalb",631.35803,41.89461,-88.76899,"DeKalb County","county"
-19081,19,"19","Hancock",571.024,43.07541,-93.7437,"Hancock County","county"
-38089,38,"38","Stark",1334.9585,46.817029999999995,-102.662025,"Stark County","county"
-26095,26,"26","Luce",899.1056,46.9406,-85.58237,"Luce County","county"
-40019,40,"40","Carter",822.22955,34.25185,-97.287926,"Carter County","county"
-37139,37,"37","Pasquotank",226.8877,36.265198,-76.26069,"Pasquotank County","county"
-35055,35,"35","Taos",2202.4478,36.57653,-105.63798500000001,"Taos County","county"
-28011,28,"28","Bolivar",876.6908,33.79914,-90.88412,"Bolivar County","county"
-32023,32,"32","Nye",18182.531000000003,37.965862,-116.45901,"Nye County","county"
-47073,47,"47","Hawkins",487.07097999999996,36.452087,-82.93149,"Hawkins County","county"
-38011,38,"38","Bowman",1161.8481,46.110146,-103.50594,"Bowman County","county"
-42057,42,"42","Fulton",437.56622000000004,39.91075,-78.12262,"Fulton County","county"
-22055,22,"22","Lafayette Parish",268.77045,30.206507000000002,-92.06416999999999,"Lafayette Parish","county"
-48237,48,"48","Jack",910.971,33.232162,-98.17116999999999,"Jack County","county"
-17175,17,"17","Stark",288.1023,41.09691,-89.79741,"Stark County","county"
-40055,40,"40","Greer",639.3036,34.933853000000006,-99.55297,"Greer County","county"
-48211,48,"48","Hemphill",906.3168300000001,35.815956,-100.27920999999999,"Hemphill County","county"
-16069,16,"16","Nez Perce",848.3493,46.33379,-116.76091000000001,"Nez Perce County","county"
-46129,46,"46","Walworth",708.6661,45.427605,-100.027855,"Walworth County","county"
-6055,6,"06","Napa",748.2863,38.5071,-122.325905,"Napa County","county"
-40033,40,"40","Cotton",632.6549,34.290676,-98.373436,"Cotton County","county"
-29221,29,"29","Washington",759.89185,37.942609999999995,-90.89702,"Washington County","county"
-36011,36,"36","Cayuga",691.6061,43.008545,-76.574585,"Cayuga County","county"
-48417,48,"48","Shackelford",914.3169,32.74382,-99.34701,"Shackelford County","county"
-48407,48,"48","San Jacinto",569.2622,30.574389,-95.16314,"San Jacinto County","county"
-19061,19,"19","Dubuque",608.32,42.46348,-90.87876999999999,"Dubuque County","county"
-51075,51,"51","Goochland",280.6402,37.718815,-77.917625,"Goochland County","county"
-20181,20,"20","Sherman",1056.1,39.351353,-101.71986,"Sherman County","county"
-39139,39,"39","Richland",495.2137,40.774159999999995,-82.54278000000001,"Richland County","county"
-17001,17,"17","Adams",855.16986,39.986053000000005,-91.19496,"Adams County","county"
-39021,39,"39","Champaign",429.0089,40.132774,-83.7676,"Champaign County","county"
-33019,33,"33","Sullivan",537.56195,43.361187,-72.222084,"Sullivan County","county"
-17075,17,"17","Iroquois",1117.433,40.748867,-87.8336,"Iroquois County","county"
-19157,19,"19","Poweshiek",584.9435,41.684525,-92.52288,"Poweshiek County","county"
-39169,39,"39","Wayne",554.8243,40.829662,-81.88719,"Wayne County","county"
-13113,13,"13","Fayette",194.38464,33.412715999999996,-84.49394000000001,"Fayette County","county"
-13141,13,"13","Hancock",471.08307,33.269220000000004,-83.000465,"Hancock County","county"
-48259,48,"48","Kendall",662.4764,29.943525,-98.70926999999999,"Kendall County","county"
-36039,36,"36","Greene",647.1835,42.27982,-74.14203,"Greene County","county"
-51137,51,"51","Orange",341.12335,38.250195,-78.00962,"Orange County","county"
-40089,40,"40","McCurtain",1850.9272,34.117073,-94.76608,"McCurtain County","county"
-13277,13,"13","Tift",260.89797999999996,31.457003000000004,-83.52593,"Tift County","county"
-31025,31,"31","Cass",557.3717,40.909878000000006,-96.14061,"Cass County","county"
-46077,46,"46","Kingsbury",832.2652,44.362970000000004,-97.49931,"Kingsbury County","county"
-56009,56,"56","Converse",4255.108,42.984623,-105.52475,"Converse County","county"
-36043,36,"36","Herkimer",1411.5886,43.40749,-75.01168,"Herkimer County","county"
-38047,38,"38","Logan",992.6325699999999,46.469276,-99.50458499999999,"Logan County","county"
-26053,26,"26","Gogebic",1102.173,46.461514,-89.80686,"Gogebic County","county"
-27005,27,"27","Becker",1315.1289,46.93763,-95.74176,"Becker County","county"
-1095,1,"01","Marshall",565.86426,34.309563,-86.32167,"Marshall County","county"
-47173,47,"47","Union",223.58577999999997,36.28414,-83.83609,"Union County","county"
-54057,54,"54","Mineral",327.87854,39.40478,-78.95669000000001,"Mineral County","county"
-55003,55,"55","Ashland",1045.0118,46.544426,-90.67969000000001,"Ashland County","county"
-17053,17,"17","Ford",485.6134,40.596540000000005,-88.22459,"Ford County","county"
-38029,38,"38","Emmons",1510.0541,46.284256,-100.23784,"Emmons County","county"
-6089,6,"06","Shasta",3775.5928,40.760513,-122.04356000000001,"Shasta County","county"
-22113,22,"22","Vermilion Parish",1173.2518,29.789721999999998,-92.291565,"Vermilion Parish","county"
-5121,5,"05","Randolph",652.2458,36.341297,-91.02844,"Randolph County","county"
-55085,55,"55","Oneida",1113.9801,45.716175,-89.53453,"Oneida County","county"
-22035,22,"22","East Carroll Parish",420.72222999999997,32.73017,-91.23414,"East Carroll Parish","county"
-22037,22,"22","East Feliciana Parish",453.418,30.839785,-91.04343399999999,"East Feliciana Parish","county"
-22087,22,"22","St. Bernard Parish",377.5247,29.91811,-89.2635,"St. Bernard Parish","county"
-48481,48,"48","Wharton",1086.1876,29.27848,-96.229675,"Wharton County","county"
-2198,2,"02","Prince of Wales-Hyder Census Area",5263.9473,55.682774,-133.16238,"Prince of Wales-Hyder Census Area","county"
-2195,2,"02","Petersburg Borough",2900.7524,57.11245699999999,-133.00859,"Petersburg Borough","county"
-48153,48,"48","Floyd",992.1763,34.07373,-101.303276,"Floyd County","county"
-2275,2,"02","Wrangell City and Borough",2556.0820000000003,56.317417000000006,-132.34398000000002,"Wrangell City and Borough","county"
-21151,21,"21","Madison",437.36782999999997,37.72551,-84.27835999999999,"Madison County","county"
-47009,47,"47","Blount",558.8387,35.688187,-83.92296999999999,"Blount County","county"
-30031,30,"30","Gallatin",2605.1038,45.518055,-111.163925,"Gallatin County","county"
-45031,45,"45","Darlington",560.6199,34.332184000000005,-79.96211,"Darlington County","county"
-1053,1,"01","Escambia",945.2547,31.122286,-87.16841,"Escambia County","county"
-13143,13,"13","Haralson",282.17484,33.795165999999995,-85.22006,"Haralson County","county"
-20001,20,"20","Allen",500.3144,37.884228,-95.30094,"Allen County","county"
-17041,17,"17","Douglas",416.66095,39.76608,-88.22286,"Douglas County","county"
-51079,51,"51","Greene",155.93849,38.297979999999995,-78.47015999999999,"Greene County","county"
-66010,66,"66","Guam",209.87523,13.441745000000001,144.7719,"Guam","county"
-55137,55,"55","Waushara",626.183,44.112823,-89.239784,"Waushara County","county"
-5065,5,"05","Izard",580.6151,36.094879999999996,-91.91363,"Izard County","county"
-6053,6,"06","Monterey",3281.8320000000003,36.240109999999994,-121.315575,"Monterey County","county"
-35017,35,"35","Grant",3961.3403,32.732085999999995,-108.38151,"Grant County","county"
-29131,29,"29","Miller",592.622,38.21668,-92.42988000000001,"Miller County","county"
-37193,37,"37","Wilkes",754.56573,36.208884999999995,-81.16609,"Wilkes County","county"
-2110,2,"02","Juneau City and Borough",2704.0676,58.37291,-134.17845,"Juneau City and Borough","county"
-29165,29,"29","Platte",419.80023,39.378696000000005,-94.761475,"Platte County","county"
-29021,29,"29","Buchanan",408.25818,39.66037,-94.808174,"Buchanan County","county"
-1083,1,"01","Limestone",559.9745,34.810238,-86.9814,"Limestone County","county"
-18065,18,"18","Henry",391.89307,39.929592,-85.39735999999999,"Henry County","county"
-31143,31,"31","Polk",438.3605,41.187923,-97.57066,"Polk County","county"
-39123,39,"39","Ottawa",254.72237,41.545494,-83.01261,"Ottawa County","county"
-27107,27,"27","Norman",872.81854,47.329453,-96.463776,"Norman County","county"
-19165,19,"19","Shelby",590.7991,41.679016,-95.308914,"Shelby County","county"
-24013,24,"24","Carroll",447.6439,39.56333,-77.01533,"Carroll County","county"
-19011,19,"19","Benton",716.1266,42.09255,-92.05763,"Benton County","county"
-21159,21,"21","Martin",229.62616,37.796776,-82.50662,"Martin County","county"
-27025,27,"27","Chisago",414.91373,45.505444,-92.90385,"Chisago County","county"
-21189,21,"21","Owsley",197.41644,37.423621999999995,-83.69163499999999,"Owsley County","county"
-42015,42,"42","Bradford",1147.4524,41.791503999999996,-76.50211999999999,"Bradford County","county"
-54029,54,"54","Hancock",82.61211,40.51696,-80.57016999999999,"Hancock County","county"
-29051,29,"29","Cole",391.5611,38.503235,-92.28003000000001,"Cole County","county"
-26021,26,"26","Berrien",567.79944,41.79138,-86.74254599999999,"Berrien County","county"
-42061,42,"42","Huntingdon",874.6814,40.422309999999996,-77.9686,"Huntingdon County","county"
-31045,31,"31","Dawes",1396.531,42.711216,-103.13486999999999,"Dawes County","county"
-51141,51,"51","Patrick",482.97083,36.667137,-80.286415,"Patrick County","county"
-26119,26,"26","Montmorency",546.6933,45.024136,-84.130104,"Montmorency County","county"
-26135,26,"26","Oscoda",565.6929299999999,44.687256,-84.12691,"Oscoda County","county"
-35007,35,"35","Colfax",3758.1028,36.612965,-104.640114,"Colfax County","county"
-17163,17,"17","St. Clair",657.72546,38.470196,-89.92854,"St. Clair County","county"
-17189,17,"17","Washington",562.6061,38.35314,-89.41719,"Washington County","county"
-42009,42,"42","Bedford",1012.337,39.998634,-78.49474000000001,"Bedford County","county"
-5127,5,"05","Scott",892.3963,34.858868,-94.063644,"Scott County","county"
-20099,20,"20","Labette",645.41516,37.191466999999996,-95.29746999999999,"Labette County","county"
-42073,42,"42","Lawrence",357.23828,40.992737,-80.33444,"Lawrence County","county"
-39067,39,"39","Harrison",402.34472999999997,40.292316,-81.09156999999999,"Harrison County","county"
-37003,37,"37","Alexander",259.9939,35.92095,-81.17747,"Alexander County","county"
-34009,34,"34","Cape May",251.4919,39.085842,-74.84635,"Cape May County","county"
-33005,33,"33","Cheshire",706.7328,42.92546,-72.248184,"Cheshire County","county"
-27089,27,"27","Marshall",1775.1205,48.36273,-96.35776,"Marshall County","county"
-51101,51,"51","King William",273.93692000000004,37.708259999999996,-77.09106,"King William County","county"
-8055,8,"08","Huerfano",1591.0870000000002,37.687816999999995,-104.95993,"Huerfano County","county"
-48255,48,"48","Karnes",747.5224,28.908996999999996,-97.8522,"Karnes County","county"
-47023,47,"47","Chester",285.74597,35.420254,-88.61135,"Chester County","county"
-17171,17,"17","Scott",250.79811,39.637,-90.47776999999999,"Scott County","county"
-49027,49,"49","Millard",6785.7305,38.956745,-113.133095,"Millard County","county"
-49029,49,"49","Morgan",609.1893299999999,41.091026,-111.57788000000001,"Morgan County","county"
-48257,48,"48","Kaufman",780.71625,32.598946000000005,-96.288376,"Kaufman County","county"
-4011,4,"04","Greenlee",1842.2039,33.238873,-109.242325,"Greenlee County","county"
-4013,4,"04","Maricopa",9200.981,33.345177,-112.49893,"Maricopa County","county"
-26129,26,"26","Ogemaw",563.5224,44.33328,-84.128075,"Ogemaw County","county"
-47087,47,"47","Jackson",308.63797,36.354248,-85.674126,"Jackson County","county"
-17159,17,"17","Richland",360.04636,38.71219,-88.08545,"Richland County","county"
-1009,1,"01","Blount",644.85266,33.977356,-86.56644,"Blount County","county"
-30051,30,"30","Liberty",1430.0317,48.559653999999995,-111.03693,"Liberty County","county"
-48131,48,"48","Duval",1793.5382,27.681124,-98.49739,"Duval County","county"
-29173,29,"29","Ralls",469.80273,39.553455,-91.52479,"Ralls County","county"
-48251,48,"48","Johnson",725.0466299999999,32.37982,-97.36496,"Johnson County","county"
-13061,13,"13","Clay",195.41058,31.619831,-84.992584,"Clay County","county"
-41023,41,"41","Grant",4527.9453,44.496326,-119.01406000000001,"Grant County","county"
-41011,41,"41","Coos",1596.1249,43.18591,-124.09413,"Coos County","county"
-48159,48,"48","Franklin",284.40106000000003,33.175846,-95.21906,"Franklin County","county"
-36113,36,"36","Warren",867.24677,43.555107,-73.83814,"Warren County","county"
-51113,51,"51","Madison",320.64856000000003,38.41206,-78.27696,"Madison County","county"
-40005,40,"40","Atoka",975.4794,34.392466999999996,-96.03656,"Atoka County","county"
-17129,17,"17","Menard",314.40186,40.022568,-89.794136,"Menard County","county"
-13015,13,"13","Bartow",458.92462,34.240916999999996,-84.83819,"Bartow County","county"
-12069,12,"12","Lake",950.7899,28.764112,-81.71228,"Lake County","county"
-40111,40,"40","Okmulgee",697.4684,35.6435,-95.96595,"Okmulgee County","county"
-38083,38,"38","Sheridan",972.2589,47.58136,-100.330986,"Sheridan County","county"
-18049,18,"18","Fulton",368.4055,41.050385,-86.26501,"Fulton County","county"
-20091,20,"20","Johnson",473.635,38.883907,-94.82233000000001,"Johnson County","county"
-24009,24,"24","Calvert",213.19824,38.52272,-76.52976,"Calvert County","county"
-55129,55,"55","Washburn",797.1412,45.89249,-91.796425,"Washburn County","county"
-53031,53,"53","Jefferson",1803.7855,47.805706,-123.527054,"Jefferson County","county"
-72003,72,"72","Aguada Municipio",30.859737,18.37568,-67.18370999999999,"Aguada Municipio","county"
-27169,27,"27","Winona",626.1393400000001,43.98227,-91.77671,"Winona County","county"
-28149,28,"28","Warren",588.55035,32.356094,-90.85239,"Warren County","county"
-29003,29,"29","Andrew",432.64597000000003,39.988859999999995,-94.80355,"Andrew County","county"
-29139,29,"29","Montgomery",535.0652,38.935184,-91.46542,"Montgomery County","county"
-20021,20,"20","Cherokee",587.5868,37.16939,-94.84569499999999,"Cherokee County","county"
-37083,37,"37","Halifax",723.7627,36.25144,-77.64484399999999,"Halifax County","county"
-35043,35,"35","Sandoval",3710.2366,35.685093,-106.88311999999999,"Sandoval County","county"
-21051,21,"21","Clay",469.3125,37.164272,-83.71548,"Clay County","county"
-42035,42,"42","Clinton",888.0143400000001,41.262623,-77.69636,"Clinton County","county"
-41043,41,"41","Linn",2287.3225,44.4889,-122.53721000000002,"Linn County","county"
-55065,55,"55","Lafayette",633.60956,42.65558,-90.13029499999999,"Lafayette County","county"
-40147,40,"40","Washington",415.53787,36.70438,-95.90615,"Washington County","county"
-54077,54,"54","Preston",648.8357,39.46903,-79.66886,"Preston County","county"
-69100,69,"69","Rota Municipality",32.857174,14.1524935,145.2129,"Rota Municipality","county"
-55135,55,"55","Waupaca",747.71906,44.478004,-88.96700000000001,"Waupaca County","county"
-48137,48,"48","Edwards",2117.9426,29.985878000000003,-100.30736999999999,"Edwards County","county"
-41037,41,"41","Lake",8138.8765,42.788403,-120.38978999999999,"Lake County","county"
-29153,29,"29","Ozark",744.9968,36.64959,-92.45855,"Ozark County","county"
-48473,48,"48","Waller",513.2746599999999,30.01359,-95.98215,"Waller County","county"
-1099,1,"01","Monroe",1025.7036,31.580332000000002,-87.38325999999999,"Monroe County","county"
-50009,50,"50","Essex",663.62177,44.724022,-71.73273499999999,"Essex County","county"
-51111,51,"51","Lunenburg",431.71463,36.945553000000004,-78.240524,"Lunenburg County","county"
-38097,38,"38","Traill",861.90027,47.446213,-97.16476,"Traill County","county"
-13139,13,"13","Hall",393.01232999999996,34.31757,-83.8185,"Hall County","county"
-13283,13,"13","Treutlen",199.4399,32.409584,-82.570885,"Treutlen County","county"
-13037,13,"13","Calhoun",280.39365,31.521278000000002,-84.62629,"Calhoun County","county"
-55125,55,"55","Vilas",857.73645,46.049847,-89.50125,"Vilas County","county"
-27007,27,"27","Beltrami",2504.7896,47.879509999999996,-95.00505,"Beltrami County","county"
-72043,72,"72","Coamo Municipio",78.015495,18.1038,-66.35759,"Coamo Municipio","county"
-72055,72,"72","Guánica Municipio",37.051464,17.948051,-66.92299,"Guánica Municipio","county"
-24019,24,"24","Dorchester",540.78296,38.429195,-76.04743,"Dorchester County","county"
-42037,42,"42","Columbia",483.0099,41.045517,-76.40426,"Columbia County","county"
-39023,39,"39","Clark",396.89083999999997,39.91703,-83.783676,"Clark County","county"
-48323,48,"48","Maverick",1279.5157,28.729788,-100.31668,"Maverick County","county"
-4019,4,"04","Pima",9189.002,32.128044,-111.78366000000001,"Pima County","county"
-35006,35,"35","Cibola",4540.1387,34.928272,-107.99268000000001,"Cibola County","county"
-34005,34,"34","Burlington",799.3196,39.875786,-74.66301,"Burlington County","county"
-50021,50,"50","Rutland",929.8503,43.580856,-73.0382,"Rutland County","county"
-13099,13,"13","Early",512.61694,31.32419,-84.90671999999999,"Early County","county"
-25007,25,"25","Dukes",103.20883,41.38097,-70.7015,"Dukes County","county"
-38049,38,"38","McHenry",1874.006,48.23384,-100.63327,"McHenry County","county"
-31179,31,"31","Wayne",442.931,42.210747,-97.12624,"Wayne County","county"
-38045,38,"38","LaMoure",1146.0441,46.464195000000004,-98.526054,"LaMoure County","county"
-16023,16,"16","Butte",2236.5627,43.6851,-113.17763000000001,"Butte County","county"
-33007,33,"33","Coos",1794.6344,44.652546,-71.28943000000001,"Coos County","county"
-38043,38,"38","Kidder",1351.1078,46.938274,-99.7312,"Kidder County","county"
-48273,48,"48","Kleberg",881.3361,27.438734000000004,-97.66062,"Kleberg County","county"
-18127,18,"18","Porter",418.09845,41.509914,-87.07131,"Porter County","county"
-28101,28,"28","Newton",577.8743,32.40197,-89.11841,"Newton County","county"
-37163,37,"37","Sampson",945.7344,34.989296,-78.37118000000001,"Sampson County","county"
-47127,47,"47","Moore",129.22693999999998,35.288887,-86.35868,"Moore County","county"
-12103,12,"12","Pinellas",273.7863,27.903109000000004,-82.73952,"Pinellas County","county"
-72019,72,"72","Barranquitas Municipio",34.25385,18.200018,-66.30928,"Barranquitas Municipio","county"
-17065,17,"17","Hamilton",434.66217,38.085228,-88.53901,"Hamilton County","county"
-5105,5,"05","Perry",551.57745,34.94636,-92.92688000000001,"Perry County","county"
-20023,20,"20","Cheyenne",1019.9243,39.789916999999996,-101.727325,"Cheyenne County","county"
-8029,8,"08","Delta",1142.1642,38.861595,-107.86488999999999,"Delta County","county"
-19185,19,"19","Wayne",525.50824,40.739983,-93.33261,"Wayne County","county"
-48165,48,"48","Gaines",1502.4153,32.743942,-102.63156,"Gaines County","county"
-1093,1,"01","Marion",742.36743,34.138218,-87.88155,"Marion County","county"
-37189,37,"37","Watauga",312.45108,36.235367,-81.709885,"Watauga County","county"
-51770,51,"51","Roanoke city",42.522667,37.278458,-79.958176,"Roanoke city","county"
-48317,48,"48","Martin",914.9869,32.30983,-101.96184000000001,"Martin County","county"
-48037,48,"48","Bowie",885.03204,33.446064,-94.42239000000001,"Bowie County","county"
-49057,49,"49","Weber",576.2913,41.270325,-111.876884,"Weber County","county"
-29127,29,"29","Marion",436.93707,39.807536999999996,-91.63537600000001,"Marion County","county"
-36045,36,"36","Jefferson",1268.7452,43.996387,-76.05297,"Jefferson County","county"
-19097,19,"19","Jackson",636.06506,42.164227000000004,-90.574585,"Jackson County","county"
-38063,38,"38","Nelson",981.84845,47.918667,-98.20443,"Nelson County","county"
-36019,36,"36","Clinton",1037.7926,44.752712,-73.70564,"Clinton County","county"
-8045,8,"08","Garfield",2947.5251,39.59935,-107.90978,"Garfield County","county"
-29177,29,"29","Ray",568.8286,39.3084,-93.99574,"Ray County","county"
-39073,39,"39","Hocking",421.34265,39.49034,-82.48344399999999,"Hocking County","county"
-1085,1,"01","Lowndes",715.9355,32.147890000000004,-86.65059000000001,"Lowndes County","county"
-13043,13,"13","Candler",243.06762999999998,32.40395,-82.07126600000001,"Candler County","county"
-19113,19,"19","Linn",717.1026,42.07795,-91.59767,"Linn County","county"
-6105,6,"06","Trinity",3179.3757,40.647804,-123.11448,"Trinity County","county"
-13215,13,"13","Muscogee",216.48656,32.510197,-84.87495,"Muscogee County","county"
-28135,28,"28","Tallahatchie",645.24506,33.95453,-90.17224,"Tallahatchie County","county"
-20005,20,"20","Atchison",431.18906,39.532543,-95.3134,"Atchison County","county"
-72081,72,"72","Lares Municipio",61.452296999999994,18.277102,-66.869644,"Lares Municipio","county"
-48003,48,"48","Andrews",1500.7723,32.312259999999995,-102.64020500000001,"Andrews County","county"
-39109,39,"39","Miami",406.52637000000004,40.053326,-84.22842,"Miami County","county"
-48375,48,"48","Potter",908.42065,35.398674,-101.89381,"Potter County","county"
-40133,40,"40","Seminole",632.85364,35.158367,-96.60285999999999,"Seminole County","county"
-45003,45,"45","Aiken",1070.7167,33.550014000000004,-81.63298,"Aiken County","county"
-60020,60,"60","Manu'a District",22.248345999999998,-14.219693,-169.50732,"Manu'a District","county"
-6045,6,"06","Mendocino",3506.4778,39.432390000000005,-123.44288,"Mendocino County","county"
-51550,51,"51","Chesapeake city",338.5219,36.679375,-76.30179,"Chesapeake city","county"
-69120,69,"69","Tinian Municipality",41.792194,14.936784,145.60103,"Tinian Municipality","county"
-72153,72,"72","Yauco Municipio",67.71378,18.085669,-66.8579,"Yauco Municipio","county"
-56037,56,"56","Sweetwater",10427.335,41.660328,-108.87568,"Sweetwater County","county"
-48169,48,"48","Garza",893.4441,33.183792,-101.30113,"Garza County","county"
-54031,54,"54","Hardy",582.33594,39.011359999999996,-78.84173,"Hardy County","county"
-72001,72,"72","Adjuntas Municipio",66.69205,18.181612,-66.75816,"Adjuntas Municipio","county"
-55089,55,"55","Ozaukee",233.02615,43.360752000000005,-87.499306,"Ozaukee County","county"
-47163,47,"47","Sullivan",413.43036,36.509679999999996,-82.30134,"Sullivan County","county"
-45059,45,"45","Laurens",713.7889,34.483677,-82.0055,"Laurens County","county"
-56011,56,"56","Crook",2854.577,44.589264,-104.5673,"Crook County","county"
-55117,55,"55","Sheboygan",511.54526,43.741234000000006,-87.731514,"Sheboygan County","county"
-25013,25,"25","Hampden",617.0214,42.136196000000005,-72.63565,"Hampden County","county"
-48055,48,"48","Caldwell",545.2586,29.8324,-97.62814,"Caldwell County","county"
-20029,20,"20","Cloud",715.3661,39.487328000000005,-97.64139,"Cloud County","county"
-6027,6,"06","Inyo",10197.567,36.561977,-117.40393,"Inyo County","county"
-1037,1,"01","Coosa",650.9328,32.931446,-86.243484,"Coosa County","county"
-19059,19,"19","Dickinson",380.53292999999996,43.38961,-95.19606,"Dickinson County","county"
-21095,21,"21","Harlan",465.84662000000003,36.859221999999995,-83.2215,"Harlan County","county"
-20061,20,"20","Geary",384.67615,39.002140000000004,-96.7681,"Geary County","county"
-42011,42,"42","Berks",856.43555,40.413956,-75.92685999999999,"Berks County","county"
-47019,47,"47","Carter",341.26993,36.284744,-82.126595,"Carter County","county"
-27083,27,"27","Lyon",714.435,44.409195000000004,-95.84727,"Lyon County","county"
-51037,51,"51","Charlotte",475.31183,37.00904,-78.65857,"Charlotte County","county"
-47179,47,"47","Washington",326.5014,36.295666,-82.49504,"Washington County","county"
-45071,45,"45","Newberry",630.0651,34.28988,-81.59968,"Newberry County","county"
-51093,51,"51","Isle of Wight",315.69067,36.901416999999995,-76.707565,"Isle of Wight County","county"
-41069,41,"41","Wheeler",1716.0798,44.736416,-120.02686000000001,"Wheeler County","county"
-29023,29,"29","Butler",694.6939,36.71518,-90.40313,"Butler County","county"
-22047,22,"22","Iberville Parish",618.65076,30.270628000000002,-91.365845,"Iberville Parish","county"
-28125,28,"28","Sharkey",431.73467999999997,32.892395,-90.827614,"Sharkey County","county"
-51061,51,"51","Fauquier",648.0281,38.744095,-77.8215,"Fauquier County","county"
-51750,51,"51","Radford city",9.676716,37.12012,-80.55915,"Radford city","county"
-32005,32,"32","Douglas",709.74567,38.90513,-119.60902,"Douglas County","county"
-12037,12,"12","Franklin",545.1594,29.810175,-84.79916999999999,"Franklin County","county"
-18055,18,"18","Greene",542.4858,39.047146000000005,-87.00477,"Greene County","county"
-18139,18,"18","Rush",408.13754,39.62238,-85.46644599999999,"Rush County","county"
-55131,55,"55","Washington",430.65842000000004,43.391155,-88.23292,"Washington County","county"
-29105,29,"29","Laclede",764.6562,37.6597,-92.59484,"Laclede County","county"
-42085,42,"42","Mercer",672.5385,41.300014000000004,-80.252785,"Mercer County","county"
-5031,5,"05","Craighead",707.32733,35.827729999999995,-90.631424,"Craighead County","county"
-29195,29,"29","Saline",755.5184,39.13584,-93.20416,"Saline County","county"
-17193,17,"17","White",494.9995,38.087326000000004,-88.17862,"White County","county"
-17039,17,"17","De Witt",397.57455,40.1815,-88.901855,"De Witt County","county"
-32033,32,"32","White Pine",8886.966999999999,39.418236,-114.900604,"White Pine County","county"
-27049,27,"27","Goodhue",756.7326,44.406178000000004,-92.71600000000001,"Goodhue County","county"
-37173,37,"37","Swain",527.7464,35.568847999999996,-83.465614,"Swain County","county"
-12101,12,"12","Pasco",746.6056,28.307709999999997,-82.464836,"Pasco County","county"
-12119,12,"12","Sumter",557.15155,28.7141,-82.07435,"Sumter County","county"
-36059,36,"36","Nassau",284.6426,40.72961,-73.58941999999999,"Nassau County","county"
-38091,38,"38","Steele",712.16705,47.45106,-97.71892,"Steele County","county"
-18163,18,"18","Vanderburgh",233.6834,38.020070000000004,-87.58617,"Vanderburgh County","county"
-29071,29,"29","Franklin",922.6824,38.413002,-91.07283000000001,"Franklin County","county"
-37011,37,"37","Avery",247.34627999999998,36.07209,-81.92029000000001,"Avery County","county"
-54107,54,"54","Wood",366.52047999999996,39.2116,-81.516235,"Wood County","county"
-55007,55,"55","Bayfield",1477.9241,46.6342,-91.177284,"Bayfield County","county"
-47161,47,"47","Stewart",459.7917,36.458465999999994,-87.81189,"Stewart County","county"
-55097,55,"55","Portage",800.9028,44.476246,-89.49807,"Portage County","county"
-45063,45,"45","Lexington",699.0159,33.899475,-81.26626999999999,"Lexington County","county"
-24003,24,"24","Anne Arundel",414.82437000000004,38.991620000000005,-76.5609,"Anne Arundel County","county"
-55039,55,"55","Fond du Lac",719.5904,43.754723,-88.493286,"Fond du Lac County","county"
-54101,54,"54","Webster",553.48914,38.48346,-80.44905,"Webster County","county"
-55061,55,"55","Kewaunee",342.46567000000005,44.501034000000004,-87.16331,"Kewaunee County","county"
-48369,48,"48","Parmer",880.8495,34.53216,-102.78485,"Parmer County","county"
-40151,40,"40","Woods",1286.507,36.726986,-98.86365,"Woods County","county"
-21063,21,"21","Elliott",234.32661000000002,38.116882000000004,-83.096115,"Elliott County","county"
-25003,25,"25","Berkshire",926.9086,42.371494,-73.217926,"Berkshire County","county"
-29041,29,"29","Chariton",751.2035,39.517967,-92.961624,"Chariton County","county"
-8103,8,"08","Rio Blanco",3221.08,39.972621999999994,-108.20071399999999,"Rio Blanco County","county"
-8087,8,"08","Morgan",1280.5288,40.26316,-103.81221,"Morgan County","county"
-41045,41,"41","Malheur",9888.046999999999,43.188625,-117.603195,"Malheur County","county"
-34023,34,"34","Middlesex",309.22598,40.43962,-74.40743,"Middlesex County","county"
-20167,20,"20","Russell",886.29016,38.91604,-98.77095,"Russell County","county"
-17155,17,"17","Putnam",160.10243,41.198963,-89.29835,"Putnam County","county"
-46055,46,"46","Haakon",1810.6027,44.282883,-101.59544,"Haakon County","county"
-47111,47,"47","Macon",307.15407999999996,36.537758000000004,-86.00095999999999,"Macon County","county"
-5023,5,"05","Cleburne",553.7194,35.566315,-92.05995,"Cleburne County","county"
-1109,1,"01","Pike",672.09064,31.79865,-85.94160500000001,"Pike County","county"
-16003,16,"16","Adams",1362.8514,44.877003,-116.461624,"Adams County","county"
-25005,25,"25","Bristol",553.1274,41.74859,-71.0889,"Bristol County","county"
-42107,42,"42","Schuylkill",778.6578400000001,40.703682,-76.21779000000001,"Schuylkill County","county"
-38103,38,"38","Wells",1270.576,47.580853000000005,-99.68221,"Wells County","county"
-37045,37,"37","Cleveland",464.2308,35.33463,-81.55711,"Cleveland County","county"
-5059,5,"05","Hot Spring",615.3112,34.315178,-92.94414499999999,"Hot Spring County","county"
-24021,24,"24","Frederick",660.5489,39.470215,-77.39763,"Frederick County","county"
-17169,17,"17","Schuyler",437.3153,40.156906,-90.61346400000001,"Schuyler County","county"
-6051,6,"06","Mono",3049.09,37.915836,-118.87517,"Mono County","county"
-6109,6,"06","Tuolumne",2220.9465,38.021435,-119.96473999999999,"Tuolumne County","county"
-35013,35,"35","Doña Ana",3808.3186,32.349920000000004,-106.83497,"Doña Ana County","county"
-13081,13,"13","Crisp",272.68883999999997,31.915148,-83.75353,"Crisp County","county"
-5027,5,"05","Columbia",766.0095,33.223038,-93.23284,"Columbia County","county"
-38039,38,"38","Griggs",708.67896,47.456333,-98.232285,"Griggs County","county"
-6095,6,"06","Solano",821.84204,38.267227,-121.93959,"Solano County","county"
-19043,19,"19","Clayton",778.5227,42.840984000000006,-91.32358,"Clayton County","county"
-48449,48,"48","Titus",406.0766,33.2146,-94.96678,"Titus County","county"
-54027,54,"54","Hampshire",640.42377,39.312138,-78.61199,"Hampshire County","county"
-37125,37,"37","Moore",697.70026,35.308273,-79.49271999999999,"Moore County","county"
-20009,20,"20","Barton",895.2876,38.48124,-98.76784,"Barton County","county"
-38087,38,"38","Slope",1215.3057,46.445834999999995,-103.46246,"Slope County","county"
-22083,22,"22","Richland Parish",555.747,32.41316,-91.74835,"Richland Parish","county"
-31071,31,"31","Garfield",569.34955,41.906867999999996,-98.95123000000001,"Garfield County","county"
-22099,22,"22","St. Martin Parish",737.2469,30.121433000000003,-91.61148,"St. Martin Parish","county"
-1119,1,"01","Sumter",903.8569,32.59748,-88.20006,"Sumter County","county"
-1133,1,"01","Winston",613.0021,34.154568,-87.36535,"Winston County","county"
-12117,12,"12","Seminole",309.3364,28.690092,-81.13199,"Seminole County","county"
-28035,28,"28","Forrest",466.0577,31.188579999999998,-89.259445,"Forrest County","county"
-26065,26,"26","Ingham",556.0819,42.603535,-84.37380999999999,"Ingham County","county"
-20177,20,"20","Shawnee",544.0414400000001,39.041805,-95.75565999999999,"Shawnee County","county"
-46061,46,"46","Hanson",434.60147,43.680609999999994,-97.796844,"Hanson County","county"
-27061,27,"27","Itasca",2667.4126,47.490818,-93.6111,"Itasca County","county"
-8073,8,"08","Lincoln",2577.7668,38.99374,-103.50755,"Lincoln County","county"
-36053,36,"36","Madison",654.8703,42.910027,-75.663574,"Madison County","county"
-36115,36,"36","Washington",831.1956,43.312378,-73.43943,"Washington County","county"
-18081,18,"18","Johnson",320.4548,39.496094,-86.09425999999999,"Johnson County","county"
-48445,48,"48","Terry",888.86957,33.17123,-102.33929,"Terry County","county"
-35021,35,"35","Harding",2125.5505,35.858517,-103.84792,"Harding County","county"
-1121,1,"01","Talladega",736.8211,33.369312,-86.175934,"Talladega County","county"
-55067,55,"55","Langlade",870.7279,45.262383,-89.06772600000001,"Langlade County","county"
-48155,48,"48","Foard",704.4205,33.963306,-99.816826,"Foard County","county"
-19021,19,"19","Buena Vista",574.91864,42.741524,-95.14143,"Buena Vista County","county"
-19129,19,"19","Mills",437.4466,41.033703,-95.6191,"Mills County","county"
-48385,48,"48","Real",699.18256,29.830097,-99.812546,"Real County","county"
-39041,39,"39","Delaware",443.17465,40.278942,-83.00746,"Delaware County","county"
-37067,37,"37","Forsyth",407.82333,36.132465,-80.25695999999999,"Forsyth County","county"
-32510,32,"32","Carson City",144.66615,39.153059999999996,-119.74736999999999,"Carson City","county"
-19049,19,"19","Dallas",588.3398,41.685320000000004,-94.0407,"Dallas County","county"
-48065,48,"48","Carson",920.2661,35.405495,-101.355354,"Carson County","county"
-13261,13,"13","Sumter",482.89365,32.042266999999995,-84.20429,"Sumter County","county"
-29223,29,"29","Wayne",759.2113,37.111073,-90.45393,"Wayne County","county"
-45007,45,"45","Anderson",713.8774,34.521236,-82.6386,"Anderson County","county"
-56007,56,"56","Carbon",7898.0713,41.703590000000005,-106.93315,"Carbon County","county"
-30093,30,"30","Silver Bow",718.00775,45.896233,-112.66006999999999,"Silver Bow County","county"
-17177,17,"17","Stephenson",564.2658,42.349728000000006,-89.66599000000001,"Stephenson County","county"
-26087,26,"26","Lapeer",647.0039,43.088634000000006,-83.22433000000001,"Lapeer County","county"
-22027,22,"22","Claiborne Parish",754.9038,32.82716,-92.98973000000001,"Claiborne Parish","county"
-28161,28,"28","Yalobusha",467.16655999999995,34.030666,-89.703804,"Yalobusha County","county"
-72093,72,"72","Maricao Municipio",36.623726,18.173956,-66.93555,"Maricao Municipio","county"
-26079,26,"26","Kalkaska",559.7626,44.678883,-85.08899,"Kalkaska County","county"
-72005,72,"72","Aguadilla Municipio",36.53283,18.48019,-67.14376,"Aguadilla Municipio","county"
-22039,22,"22","Evangeline Parish",662.4032599999999,30.720694,-92.40408000000001,"Evangeline Parish","county"
-47069,47,"47","Hardeman",667.7658700000001,35.218784,-88.98869,"Hardeman County","county"
-4003,4,"04","Cochise",6209.96,31.840128000000004,-109.77516000000001,"Cochise County","county"
-35023,35,"35","Hidalgo",3438.6504,31.898052000000003,-108.75193,"Hidalgo County","county"
-38023,38,"38","Divide",1260.9208,48.814754,-103.50932,"Divide County","county"
-6071,6,"06","San Bernardino",20068.564,34.85722,-116.1812,"San Bernardino County","county"
-8083,8,"08","Montezuma",2029.4181,37.338024,-108.59579,"Montezuma County","county"
-28023,28,"28","Clarke",691.60095,32.045372,-88.68796999999999,"Clarke County","county"
-19125,19,"19","Marion",554.5082,41.331455,-93.09385,"Marion County","county"
-31055,31,"31","Douglas",326.42184,41.297092,-96.15406999999999,"Douglas County","county"
-51600,51,"51","Fairfax city",6.240677,38.853184000000006,-77.29903,"Fairfax city","county"
-40057,40,"40","Harmon",537.2763,34.74597,-99.84419,"Harmon County","county"
-29039,29,"29","Cedar",474.48584000000005,37.733654,-93.85001,"Cedar County","county"
-13059,13,"13","Clarke",119.22658500000001,33.952187,-83.36715,"Clarke County","county"
-16085,16,"16","Valley",3665.241,44.855959999999996,-115.61806499999999,"Valley County","county"
-48275,48,"48","Knox",850.6501,33.61189,-99.730354,"Knox County","county"
-5103,5,"05","Ouachita",732.8077400000001,33.591167,-92.87841,"Ouachita County","county"
-39037,39,"39","Darke",598.12067,40.131541999999996,-84.62125,"Darke County","county"
-40071,40,"40","Kay",919.6264,36.814884,-97.14386,"Kay County","county"
-46041,46,"46","Dewey",2302.5667,45.14805,-100.83795,"Dewey County","county"
-41057,41,"41","Tillamook",1102.4066,45.455890000000004,-123.7593,"Tillamook County","county"
-13077,13,"13","Coweta",440.9485,33.352897999999996,-84.76214,"Coweta County","county"
-28127,28,"28","Simpson",589.18524,31.902503999999997,-89.91771,"Simpson County","county"
-28131,28,"28","Stone",445.49987999999996,30.790184000000004,-89.1123,"Stone County","county"
-6013,6,"06","Contra Costa",717.1048599999999,37.91948,-121.951546,"Contra Costa County","county"
-47017,47,"47","Carroll",597.6779,35.965748,-88.45238,"Carroll County","county"
-51087,51,"51","Henrico",233.68398,37.631268,-77.651924,"Henrico County","county"
-18119,18,"18","Owen",385.30893,39.31734,-86.838844,"Owen County","county"
-36119,36,"36","Westchester",430.60332999999997,41.152687,-73.74575,"Westchester County","county"
-29017,29,"29","Bollinger",617.9252299999999,37.318428000000004,-90.02464,"Bollinger County","county"
-54047,54,"54","McDowell",533.47565,37.38273,-81.65818,"McDowell County","county"
-54033,54,"54","Harrison",416.02182,39.279182,-80.3865,"Harrison County","county"
-37077,37,"37","Granville",532.0090299999999,36.299884999999996,-78.65763000000001,"Granville County","county"
-9009,9,"09","New Haven",604.5342,41.34972,-72.9002,"New Haven County","county"
-31139,31,"31","Pierce",573.2682,42.271409999999996,-97.61099,"Pierce County","county"
-13023,13,"13","Bleckley",215.87956,32.435402,-83.33171999999999,"Bleckley County","county"
-13033,13,"13","Burke",827.063,33.060179999999995,-82.00016,"Burke County","county"
-17181,17,"17","Union",413.42523,37.485653000000006,-89.24464,"Union County","county"
-17091,17,"17","Kankakee",676.51825,41.139509999999994,-87.861115,"Kankakee County","county"
-38051,38,"38","McIntosh",974.59625,46.10868,-99.41649,"McIntosh County","county"
-31141,31,"31","Platte",674.12274,41.576865999999995,-97.51346600000001,"Platte County","county"
-37185,37,"37","Warren",429.40555,36.398106,-78.0999,"Warren County","county"
-72009,72,"72","Aibonito Municipio",31.311813,18.130648,-66.26398,"Aibonito Municipio","county"
-13197,13,"13","Marion",366.02936,32.35931,-84.52873000000001,"Marion County","county"
-46027,46,"46","Clay",412.04465,42.91615,-96.98047,"Clay County","county"
-10005,10,"10","Sussex",936.16486,38.67323,-75.33702,"Sussex County","county"
-13159,13,"13","Jasper",368.4187,33.316982,-83.68915,"Jasper County","county"
-29175,29,"29","Randolph",482.72824,39.439246999999995,-92.49296,"Randolph County","county"
-20015,20,"20","Butler",1429.7142,37.773647,-96.83884,"Butler County","county"
-48209,48,"48","Hays",678.0478,30.061224,-98.02927,"Hays County","county"
-48325,48,"48","Medina",1325.4038,29.353659999999998,-99.11108399999999,"Medina County","county"
-26105,26,"26","Mason",494.98800000000006,43.996635,-86.75081999999999,"Mason County","county"
-45013,45,"45","Beaufort",576.1696,32.358112,-80.68942,"Beaufort County","county"
-46135,46,"46","Yankton",521.20685,43.006603000000005,-97.38835999999999,"Yankton County","county"
-55105,55,"55","Rock",718.169,42.66988,-89.07529,"Rock County","county"
-45077,45,"45","Pickens",496.9942,34.88537,-82.72338,"Pickens County","county"
-53013,53,"53","Columbia",868.6145,46.29285,-117.91163999999999,"Columbia County","county"
-18023,18,"18","Clinton",405.08096,40.305943,-86.47757,"Clinton County","county"
-17027,17,"17","Clinton",473.95745999999997,38.606297,-89.42623,"Clinton County","county"
-16067,16,"16","Minidoka",757.02167,42.857212,-113.63983999999999,"Minidoka County","county"
-42113,42,"42","Sullivan",449.955,41.439285,-76.51172,"Sullivan County","county"
-28121,28,"28","Rankin",775.52136,32.267124,-89.94606,"Rankin County","county"
-48345,48,"48","Motley",989.59955,34.0579,-100.79315,"Motley County","county"
-41039,41,"41","Lane",4556.205,43.928329999999995,-122.89769,"Lane County","county"
-48485,48,"48","Wichita",627.6149,33.988213,-98.70801,"Wichita County","county"
-26155,26,"26","Shiawassee",530.9774,42.951546,-84.146355,"Shiawassee County","county"
-20089,20,"20","Jewell",910.0018,39.777,-98.22261999999999,"Jewell County","county"
-20123,20,"20","Mitchell",701.8158599999999,39.393024,-98.20736,"Mitchell County","county"
-12007,12,"12","Bradford",293.97357,29.952386999999998,-82.16668,"Bradford County","county"
-28091,28,"28","Marion",542.403,31.230166999999998,-89.82171,"Marion County","county"
-28039,28,"28","George",478.71227999999996,30.85543,-88.64226500000001,"George County","county"
-17085,17,"17","Jo Daviess",600.9442,42.362390000000005,-90.21146999999999,"Jo Daviess County","county"
-18059,18,"18","Hancock",305.967,39.82253,-85.77315,"Hancock County","county"
-51620,51,"51","Franklin city",8.277623,36.684013,-76.9414,"Franklin city","county"
-48329,48,"48","Midland",900.3882,31.81427,-102.00246,"Midland County","county"
-20171,20,"20","Scott",717.6095,38.481876,-100.90635999999999,"Scott County","county"
-30013,30,"30","Cascade",2698.2654,47.316573999999996,-111.35026599999999,"Cascade County","county"
-51660,51,"51","Harrisonburg city",17.339814999999998,38.436256,-78.87331,"Harrisonburg city","county"
-17199,17,"17","Williamson",420.2283,37.730354,-88.93001600000001,"Williamson County","county"
-30029,30,"30","Flathead",5087.3706,48.314679999999996,-114.0543,"Flathead County","county"
-72111,72,"72","Peñuelas Municipio",44.618927,18.026617,-66.72813000000001,"Peñuelas Municipio","county"
-20189,20,"20","Stevens",727.2844,37.2017,-101.31727,"Stevens County","county"
-21067,21,"21","Fayette",283.64648,38.040676,-84.458275,"Fayette County","county"
-21091,21,"21","Hancock",187.67963,37.843327,-86.79276,"Hancock County","county"
-46013,46,"46","Brown",1713.0886,45.589252,-98.35217,"Brown County","county"
-54001,54,"54","Barbour",341.07047,39.139725,-79.99695,"Barbour County","county"
-47181,47,"47","Wayne",734.1341,35.242847,-87.81985,"Wayne County","county"
-31013,31,"31","Box Butte",1075.3291,42.21038,-103.08178000000001,"Box Butte County","county"
-42097,42,"42","Northumberland",458.02286,40.851524,-76.70988,"Northumberland County","county"
-48469,48,"48","Victoria",882.13635,28.79637,-96.9712,"Victoria County","county"
-51530,51,"51","Buena Vista city",6.438375,37.729343,-79.35813,"Buena Vista city","county"
-26147,26,"26","St. Clair",721.3605,42.928802000000005,-82.668915,"St. Clair County","county"
-31173,31,"31","Thurston",393.59713999999997,42.15406,-96.53394,"Thurston County","county"
-50015,50,"50","Lamoille",458.88595999999995,44.603703,-72.63892,"Lamoille County","county"
-51067,51,"51","Franklin",690.6456,36.991188,-79.88271,"Franklin County","county"
-40011,40,"40","Blaine",928.5195,35.87778,-98.42893000000001,"Blaine County","county"
-53037,53,"53","Kittitas",2297.3872,47.12444,-120.67671000000001,"Kittitas County","county"
-18135,18,"18","Randolph",452.3946,40.164078,-85.00579,"Randolph County","county"
-49025,49,"49","Kane",3990.0818,37.275090000000006,-111.81533,"Kane County","county"
-54093,54,"54","Tucker",419.05865,39.111176,-79.55996999999999,"Tucker County","county"
-72113,72,"72","Ponce Municipio",114.94213,18.001717000000003,-66.60665999999999,"Ponce Municipio","county"
-55023,55,"55","Crawford",570.6672,43.24991,-90.95123000000001,"Crawford County","county"
-1071,1,"01","Jackson",1078.0239,34.764114,-85.98006,"Jackson County","county"
-19123,19,"19","Mahaska",570.8782,41.330795,-92.63637,"Mahaska County","county"
-20045,20,"20","Douglas",455.78018,38.896415999999995,-95.29095,"Douglas County","county"
-21059,21,"21","Daviess",458.40682999999996,37.73167,-87.087135,"Daviess County","county"
-21197,21,"21","Powell",178.98717,37.809906,-83.83135,"Powell County","county"
-29097,29,"29","Jasper",638.5279,37.205196,-94.33726,"Jasper County","county"
-41061,41,"41","Union",2037.0098,45.30408,-117.999146,"Union County","county"
-13151,13,"13","Henry",318.65958,33.452946000000004,-84.15401999999999,"Henry County","county"
-38001,38,"38","Adams",987.5802,46.096813,-102.53319499999999,"Adams County","county"
-37137,37,"37","Pamlico",336.5173,35.147575,-76.66526999999999,"Pamlico County","county"
-21083,21,"21","Graves",551.7747,36.723343,-88.649895,"Graves County","county"
-42021,42,"42","Cambria",688.38586,40.510222999999996,-78.71048,"Cambria County","county"
-47107,47,"47","McMinn",430.13138,35.424473,-84.61995,"McMinn County","county"
-26093,26,"26","Livingston",565.2714,42.60253,-83.91171999999999,"Livingston County","county"
-8001,8,"08","Adams",1166.3448,39.874325,-104.33187,"Adams County","county"
-42069,42,"42","Lackawanna",458.7873,41.440284999999996,-75.609665,"Lackawanna County","county"
-40123,40,"40","Pontotoc",720.42773,34.721447,-96.69197,"Pontotoc County","county"
-40037,40,"40","Creek",949.88495,35.907734000000005,-96.37979,"Creek County","county"
-48457,48,"48","Tyler",924.42126,30.769295,-94.375656,"Tyler County","county"
-47175,47,"47","Van Buren",273.42462,35.699234000000004,-85.45841,"Van Buren County","county"
-40125,40,"40","Pottawatomie",787.81836,35.21139,-96.95701,"Pottawatomie County","county"
-9013,9,"09","Tolland",410.3662,41.85808,-72.34098,"Tolland County","county"
-35053,35,"35","Socorro",6646.6123,33.991657000000004,-106.93913,"Socorro County","county"
-13003,13,"13","Atkinson",342.73013,31.296806,-82.87815,"Atkinson County","county"
-12031,12,"12","Duval",762.6553,30.335245,-81.64811,"Duval County","county"
-48145,48,"48","Falls",765.4909700000001,31.251929999999998,-96.93413000000001,"Falls County","county"
-5149,5,"05","Yell",930.1359,34.997715,-93.4083,"Yell County","county"
-20033,20,"20","Comanche",788.3243,37.181442,-99.25129,"Comanche County","county"
-21113,21,"21","Jessamine",172.17096,37.873290000000004,-84.58396,"Jessamine County","county"
-21171,21,"21","Monroe",329.44162,36.714077,-85.71351,"Monroe County","county"
-40075,40,"40","Kiowa",1015.1125,34.921490000000006,-98.98161,"Kiowa County","county"
-46079,46,"46","Lake",562.9105,44.02845,-97.12321999999999,"Lake County","county"
-37033,37,"37","Caswell",425.3812,36.3943,-79.33961,"Caswell County","county"
-48377,48,"48","Presidio",3855.3833,30.005892,-104.26162,"Presidio County","county"
-39057,39,"39","Greene",413.63876,39.687477,-83.8949,"Greene County","county"
-48489,48,"48","Willacy",590.6221,26.481861,-97.594734,"Willacy County","county"
-72021,72,"72","Bayamón Municipio",44.332314000000004,18.350721,-66.16775,"Bayamón Municipio","county"
-35028,35,"35","Los Alamos",109.21016000000002,35.87005,-106.30797,"Los Alamos County","county"
-2122,2,"02","Kenai Peninsula Borough",16023.735,60.360767,-152.05264,"Kenai Peninsula Borough","county"
-1003,1,"01","Baldwin",1589.8767,30.659218,-87.74606,"Baldwin County","county"
-19007,19,"19","Appanoose",497.30835,40.744296999999996,-92.87306,"Appanoose County","county"
-78010,78,"78","St. Croix Island",83.36808,17.735321,-64.74674,"St. Croix Island","county"
-51127,51,"51","New Kent",210.0429,37.51016,-76.99933,"New Kent County","county"
-13263,13,"13","Talbot",391.39072000000004,32.7046,-84.53003000000001,"Talbot County","county"
-36049,36,"36","Lewis",1274.6852,43.78268,-75.44414,"Lewis County","county"
-54015,54,"54","Clay",341.95038,38.459827000000004,-81.08185999999999,"Clay County","county"
-18077,18,"18","Jefferson",360.65157999999997,38.783604,-85.44009,"Jefferson County","county"
-51019,51,"51","Bedford",760.1085,37.312256,-79.52722,"Bedford County","county"
-35033,35,"35","Mora",1926.3148,35.98284,-104.9219,"Mora County","county"
-31011,31,"31","Boone",686.5771,41.703934000000004,-98.07047,"Boone County","county"
-29149,29,"29","Oregon",789.82336,36.68531,-91.401825,"Oregon County","county"
-47083,47,"47","Houston",200.30048,36.285779999999995,-87.7056,"Houston County","county"
-42131,42,"42","Wyoming",397.32108,41.525172999999995,-76.00873,"Wyoming County","county"
-37107,37,"37","Lenoir",399.10037,35.240066999999996,-77.63551,"Lenoir County","county"
-18167,18,"18","Vigo",403.56412,39.429142,-87.39036999999999,"Vigo County","county"
-18039,18,"18","Elkhart",463.18546,41.600693,-85.86398,"Elkhart County","county"
-51077,51,"51","Grayson",441.80037999999996,36.652229999999996,-81.215324,"Grayson County","county"
-48303,48,"48","Lubbock",895.6301,33.611470000000004,-101.81995,"Lubbock County","county"
-27093,27,"27","Meeker",608.0903,45.123154,-94.52734,"Meeker County","county"
-39005,39,"39","Ashland",422.97574000000003,40.843272999999996,-82.27013000000001,"Ashland County","county"
-31119,31,"31","Madison",572.64166,41.909929999999996,-97.60686,"Madison County","county"
-12085,12,"12","Martin",543.8383,27.083603000000004,-80.3982,"Martin County","county"
-8079,8,"08","Mineral",875.7902,37.54907,-107.003235,"Mineral County","county"
-13085,13,"13","Dawson",210.83527,34.442608,-84.17326,"Dawson County","county"
-13167,13,"13","Johnson",303.02917,32.694584000000006,-82.66396999999999,"Johnson County","county"
-5095,5,"05","Monroe",607.15393,34.679512,-91.20331,"Monroe County","county"
-29059,29,"29","Dallas",540.9697,37.683582,-93.03381,"Dallas County","county"
-51143,51,"51","Pittsylvania",969.03577,36.82172,-79.3985,"Pittsylvania County","county"
-2068,2,"02","Denali Borough",12637.391000000001,63.682037,-150.02702,"Denali Borough","county"
-20145,20,"20","Pawnee",754.28845,38.181477,-99.23477,"Pawnee County","county"
-20209,20,"20","Wyandotte",151.64268,39.115383,-94.76308399999999,"Wyandotte County","county"
-12029,12,"12","Dixie",705.1323,29.5809,-83.19566,"Dixie County","county"
-26157,26,"26","Tuscola",804.7283,43.487904,-83.436615,"Tuscola County","county"
-2240,2,"02","Southeast Fairbanks Census Area",24823.629,63.864998,-143.21863000000002,"Southeast Fairbanks Census Area","county"
-20065,20,"20","Graham",898.5574300000001,39.354973,-99.87989,"Graham County","county"
-22097,22,"22","St. Landry Parish",923.9441,30.583440000000003,-91.98926999999999,"St. Landry Parish","county"
-47055,47,"47","Giles",610.9521,35.202723999999996,-87.03532,"Giles County","county"
-39095,39,"39","Lucas",339.66672,41.682320000000004,-83.4689,"Lucas County","county"
-5093,5,"05","Mississippi",900.6068,35.766945,-90.05221,"Mississippi County","county"
-72117,72,"72","Rincón Municipio",14.288375,18.34056,-67.2773,"Rincón Municipio","county"
-18043,18,"18","Floyd",147.96999,38.31808,-85.91185,"Floyd County","county"
-20129,20,"20","Morton",729.7554299999999,37.18525,-101.80951999999999,"Morton County","county"
-21081,21,"21","Grant",257.9859,38.649165999999994,-84.62592,"Grant County","county"
-21217,21,"21","Taylor",266.37775,37.366209999999995,-85.32806,"Taylor County","county"
-37075,37,"37","Graham",291.97614,35.348366,-83.83091999999999,"Graham County","county"
-54045,54,"54","Logan",453.78545999999994,37.83059,-81.94085,"Logan County","county"
-54073,54,"54","Pleasants",130.12378,39.368134000000005,-81.16117,"Pleasants County","county"
-51071,51,"51","Giles",357.2359,37.318073,-80.69832,"Giles County","county"
-54019,54,"54","Fayette",661.6353,38.030933000000005,-81.08605,"Fayette County","county"
-53061,53,"53","Snohomish",2086.595,48.070465000000006,-121.93678,"Snohomish County","county"
-35015,35,"35","Eddy",4176.487,32.457836,-104.306435,"Eddy County","county"
-31117,31,"31","McPherson",859.00366,41.648415,-101.12085,"McPherson County","county"
-31145,31,"31","Red Willow",717.03015,40.16942,-100.468575,"Red Willow County","county"
-31149,31,"31","Rock",1008.327,42.39475,-99.42085,"Rock County","county"
-47085,47,"47","Humphreys",530.7806400000001,36.040820000000004,-87.79045,"Humphreys County","county"
-17125,17,"17","Mason",539.3702,40.236990000000006,-89.913574,"Mason County","county"
-51197,51,"51","Wythe",461.93976,36.899868,-81.083,"Wythe County","county"
-13303,13,"13","Washington",678.53656,32.971844,-82.79811,"Washington County","county"
-53077,53,"53","Yakima",4294.6577,46.456559999999996,-120.74014,"Yakima County","county"
-5143,5,"05","Washington",942.00916,35.978,-94.21727,"Washington County","county"
-48213,48,"48","Henderson",873.7841,32.21163,-95.85342,"Henderson County","county"
-55035,55,"55","Eau Claire",637.94403,44.726357,-91.286415,"Eau Claire County","county"
-47153,47,"47","Sequatchie",265.86002,35.372337,-85.41008000000001,"Sequatchie County","county"
-48471,48,"48","Walker",784.2484,30.743161999999998,-95.569824,"Walker County","county"
-4005,4,"04","Coconino",18617.416,35.829693,-111.77373,"Coconino County","county"
-20191,20,"20","Sumner",1181.6951,37.23666,-97.49335500000001,"Sumner County","county"
-26127,26,"26","Oceana",538.11646,43.647255,-86.80757,"Oceana County","county"
-27065,27,"27","Kanabec",521.6418,45.947759999999995,-93.29779,"Kanabec County","county"
-39007,39,"39","Ashtabula",702.0966,41.906634999999994,-80.74559,"Ashtabula County","county"
-6003,6,"06","Alpine",738.3654,38.621784000000005,-119.798355,"Alpine County","county"
-48167,48,"48","Galveston",378.91412,29.233454,-94.88846,"Galveston County","county"
-1011,1,"01","Bullock",622.8333,32.101757,-85.71726,"Bullock County","county"
-17105,17,"17","Livingston",1043.6635,40.894375,-88.55285,"Livingston County","county"
-39135,39,"39","Preble",424.24078,39.73881,-84.64475999999999,"Preble County","county"
-39079,39,"39","Jackson",420.3247,39.013477,-82.61414,"Jackson County","county"
-48201,48,"48","Harris",1706.2086,29.857273,-95.393036,"Harris County","county"
-25017,25,"25","Middlesex",817.87933,42.48172,-71.39491,"Middlesex County","county"
-72145,72,"72","Vega Baja Municipio",45.84929,18.455128,-66.39788,"Vega Baja Municipio","county"
-48115,48,"48","Dawson",900.33655,32.742527,-101.94877,"Dawson County","county"
-36069,36,"36","Ontario",644.0716,42.856358,-77.3035,"Ontario County","county"
-2261,2,"02","Valdez-Cordova Census Area",34223.023,61.349842,-145.0231,"Valdez-Cordova Census Area","county"
-1001,1,"01","Autauga",594.4639,32.532238,-86.64644,"Autauga County","county"
-20121,20,"20","Miami",575.8983,38.566772,-94.83296,"Miami County","county"
-13091,13,"13","Dodge",495.97335999999996,32.164367999999996,-83.16787,"Dodge County","county"
-36023,36,"36","Cortland",498.78983,42.59404,-76.07624,"Cortland County","county"
-13039,13,"13","Camden",630.3380000000001,30.913359000000003,-81.64202,"Camden County","county"
-26161,26,"26","Washtenaw",705.9876,42.252216,-83.84342,"Washtenaw County","county"
-18087,18,"18","LaGrange",379.64258,41.642464000000004,-85.42784,"LaGrange County","county"
-48371,48,"48","Pecos",4763.9966,30.773297999999997,-102.71815500000001,"Pecos County","county"
-13225,13,"13","Peach",150.28949,32.571323,-83.83198,"Peach County","county"
-13311,13,"13","White",240.75153999999998,34.643776,-83.743416,"White County","county"
-13163,13,"13","Jefferson",526.56885,33.058174,-82.420006,"Jefferson County","county"
-55083,55,"55","Oconto",997.5151,44.996574,-88.20651,"Oconto County","county"
-48347,48,"48","Nacogdoches",946.5896,31.620559999999998,-94.62025,"Nacogdoches County","county"
-44009,44,"44","Washington",329.28976,41.396793,-71.620285,"Washington County","county"
-53047,53,"53","Okanogan",5266.3667,48.548454,-119.74223,"Okanogan County","county"
-53063,53,"53","Spokane",1763.9539,47.620377000000005,-117.40337,"Spokane County","county"
-55041,55,"55","Forest",1014.27795,45.66688,-88.77332,"Forest County","county"
-55113,55,"55","Sawyer",1257.6686,45.864914,-91.14713,"Sawyer County","county"
-34017,34,"34","Hudson",46.195156,40.731377,-74.0786,"Hudson County","county"
-39151,39,"39","Stark",575.3337,40.814133,-81.36567,"Stark County","county"
-48187,48,"48","Guadalupe",711.2769,29.583532,-97.94677,"Guadalupe County","county"
-53029,53,"53","Island",208.51918,48.158553999999995,-122.67065,"Island County","county"
-54037,54,"54","Jefferson",209.30268999999998,39.3074,-77.86322,"Jefferson County","county"
-51153,51,"51","Prince William",335.75607,38.70112,-77.479576,"Prince William County","county"
-42029,42,"42","Chester",750.5543,39.97403,-75.74975,"Chester County","county"
-54055,54,"54","Mercer",418.97604,37.403446,-81.10645,"Mercer County","county"
-47145,47,"47","Roane",360.76987,35.84725,-84.523926,"Roane County","county"
-53009,53,"53","Clallam",1738.7423,48.110904999999995,-123.88986000000001,"Clallam County","county"
-53065,53,"53","Stevens",2477.4795,48.388725,-117.854454,"Stevens County","county"
-19177,19,"19","Van Buren",484.82425,40.754115999999996,-91.95294,"Van Buren County","county"
-31073,31,"31","Gosper",458.1707,40.509094,-99.823204,"Gosper County","county"
-28095,28,"28","Monroe",765.11456,33.890029999999996,-88.48504,"Monroe County","county"
-12033,12,"12","Escambia",656.9956,30.611639,-87.3389,"Escambia County","county"
-48439,48,"48","Tarrant",863.6872599999999,32.772118,-97.29122,"Tarrant County","county"
-24033,24,"24","Prince George's",482.66815,38.82929,-76.84818,"Prince George's County","county"
-51169,51,"51","Scott",535.8455,36.712776,-82.613625,"Scott County","county"
-48239,48,"48","Jackson",829.4709,28.959803000000004,-96.58908000000001,"Jackson County","county"
-40085,40,"40","Love",513.9291,33.957806,-97.245094,"Love County","county"
-13289,13,"13","Twiggs",359.27182,32.665848,-83.42588,"Twiggs County","county"
-39099,39,"39","Mahoning",411.51132,41.01088,-80.77039,"Mahoning County","county"
-1087,1,"01","Macon",608.8481,32.387028,-85.69289,"Macon County","county"
-17191,17,"17","Wayne",713.8539400000001,38.431858,-88.43243000000001,"Wayne County","county"
-48437,48,"48","Swisher",890.1899,34.526317999999996,-101.743866,"Swisher County","county"
-29151,29,"29","Osage",606.6004,38.464252,-91.859505,"Osage County","county"
-17089,17,"17","Kane",519.37756,41.939594,-88.42804,"Kane County","county"
-6017,6,"06","El Dorado",1707.9036,38.78561,-120.534225,"El Dorado County","county"
-45055,45,"45","Kershaw",726.6365,34.338356,-80.59088,"Kershaw County","county"
-37073,37,"37","Gates",340.62384,36.442135,-76.702354,"Gates County","county"
-8089,8,"08","Otero",1261.9886,37.884170000000005,-103.72126,"Otero County","county"
-41019,41,"41","Douglas",5035.8413,43.286327,-123.15446999999999,"Douglas County","county"
-42089,42,"42","Monroe",608.2781,41.05624,-75.32906,"Monroe County","county"
-5101,5,"05","Newton",820.9323,35.910744,-93.2159,"Newton County","county"
-38019,38,"38","Cavalier",1489.1042,48.768440000000005,-98.46379,"Cavalier County","county"
-40103,40,"40","Noble",731.9435,36.3849,-97.236336,"Noble County","county"
-20063,20,"20","Gove",1071.7024,38.91724,-100.48736,"Gove County","county"
-22077,22,"22","Pointe Coupee Parish",557.23816,30.708319,-91.60462,"Pointe Coupee Parish","county"
-31067,31,"31","Gage",851.4905,40.255234,-96.68346,"Gage County","county"
-1115,1,"01","St. Clair",631.6023,33.712963,-86.31567,"St. Clair County","county"
-28123,28,"28","Scott",609.25214,32.41196,-89.533485,"Scott County","county"
-13095,13,"13","Dougherty",328.65497,31.532587,-84.20904,"Dougherty County","county"
-18061,18,"18","Harrison",484.532,38.186455,-86.10377,"Harrison County","county"
-16017,16,"16","Bonner",1733.2932,48.316795,-116.612366,"Bonner County","county"
-13047,13,"13","Catoosa",162.16798,34.900220000000004,-85.13939,"Catoosa County","county"
-22059,22,"22","LaSalle Parish",624.70575,31.680082000000002,-92.1616,"LaSalle Parish","county"
-23027,23,"23","Waldo",729.9955,44.505833,-69.138954,"Waldo County","county"
-24027,24,"24","Howard",250.95647000000002,39.252262,-76.92441,"Howard County","county"
-49035,49,"49","Salt Lake",742.0918,40.66788,-111.92424,"Salt Lake County","county"
-9003,9,"09","Hartford",734.9874,41.806053000000006,-72.73292,"Hartford County","county"
-9015,9,"09","Windham",512.9458599999999,41.824996999999996,-71.9907,"Windham County","county"
-12087,12,"12","Monroe",983.06287,24.768883,-80.95326999999999,"Monroe County","county"
-39157,39,"39","Tuscarawas",567.45105,40.44749,-81.47111,"Tuscarawas County","county"
-36085,36,"36","Richmond",57.522255,40.561264,-74.1399,"Richmond County","county"
-39071,39,"39","Highland",553.1024,39.18442,-83.60136,"Highland County","county"
-27077,27,"27","Lake of the Woods",1297.8761,48.7681,-94.90463000000001,"Lake of the Woods County","county"
-16011,16,"16","Bingham",2093.8638,43.216359999999995,-112.39921000000001,"Bingham County","county"
-72023,72,"72","Cabo Rojo Municipio",70.36865,18.008873,-67.209885,"Cabo Rojo Municipio","county"
-72069,72,"72","Humacao Municipio",44.719162,18.135403,-65.78623,"Humacao Municipio","county"
-72077,72,"72","Juncos Municipio",26.4896,18.224133,-65.90854,"Juncos Municipio","county"
-45045,45,"45","Greenville",785.1582,34.892647,-82.37208000000001,"Greenville County","county"
-46085,46,"46","Lyman",1642.2024,43.894814000000004,-99.84193,"Lyman County","county"
-55121,55,"55","Trempealeau",733.02936,44.30305,-91.358864,"Trempealeau County","county"
-6113,6,"06","Yolo",1014.7669,38.679596000000004,-121.90243999999998,"Yolo County","county"
-48431,48,"48","Sterling",923.4807,31.835773,-101.05490999999999,"Sterling County","county"
-48495,48,"48","Winkler",841.2974,31.832859999999997,-103.054924,"Winkler County","county"
-46071,46,"46","Jackson",1863.9459,43.677505,-101.62631999999999,"Jackson County","county"
-49041,49,"49","Sevier",1910.4985,38.746826,-111.81193,"Sevier County","county"
-51036,51,"51","Charles City",182.90726999999998,37.361053000000005,-77.05417,"Charles City County","county"
-1023,1,"01","Choctaw",913.49854,31.990953,-88.248886,"Choctaw County","county"
-18083,18,"18","Knox",516.0378400000001,38.688393,-87.42036,"Knox County","county"
-31047,31,"31","Dawson",1013.123,40.86738,-99.815155,"Dawson County","county"
-20057,20,"20","Ford",1098.3081,37.688416,-99.88475,"Ford County","county"
-38105,38,"38","Williams",2077.667,48.355765999999996,-103.501335,"Williams County","county"
-38017,38,"38","Cass",1764.9944,46.927002,-97.25237,"Cass County","county"
-17069,17,"17","Hardin",177.39491,37.517853,-88.26615,"Hardin County","county"
-31005,31,"31","Arthur",715.37885,41.57193,-101.695915,"Arthur County","county"
-48163,48,"48","Frio",1133.5393,28.869334999999996,-99.10879,"Frio County","county"
-19103,19,"19","Johnson",613.0121,41.67067,-91.59053,"Johnson County","county"
-20133,20,"20","Neosho",571.50073,37.56428,-95.31568,"Neosho County","county"
-21089,21,"21","Greenup",344.47402999999997,38.563559999999995,-82.93382,"Greenup County","county"
-20107,20,"20","Linn",594.1012,38.21655,-94.84493,"Linn County","county"
-49017,49,"49","Garfield",5175.3240000000005,37.831665,-111.450905,"Garfield County","county"
-32011,32,"32","Eureka",4175.83,39.977787,-116.27221000000002,"Eureka County","county"
-31085,31,"31","Hayes",713.08606,40.537234999999995,-101.047966,"Hayes County","county"
-8095,8,"08","Phillips",687.95123,40.59471,-102.34510999999999,"Phillips County","county"
-5013,5,"05","Calhoun",628.5862,33.56046,-92.51388,"Calhoun County","county"
-2090,2,"02","Fairbanks North Star Borough",7329.8369999999995,64.67604,-146.54816,"Fairbanks North Star Borough","county"
-21101,21,"21","Henderson",436.5071,37.79254,-87.57258,"Henderson County","county"
-28051,28,"28","Holmes",756.6998,33.125941999999995,-90.09119399999999,"Holmes County","county"
-28105,28,"28","Oktibbeha",458.25487999999996,33.422314,-88.87615,"Oktibbeha County","county"
-72037,72,"72","Ceiba Municipio",29.036507,18.273748,-65.53089,"Ceiba Municipio","county"
-72047,72,"72","Corozal Municipio",42.568645000000004,18.303910000000002,-66.32618000000001,"Corozal Municipio","county"
-30027,30,"30","Fergus",4339.477,47.22522,-109.23213999999999,"Fergus County","county"
-24023,24,"24","Garrett",649.09937,39.5473,-79.27462,"Garrett County","county"
-22119,22,"22","Webster Parish",593.20325,32.73215,-93.33981999999999,"Webster Parish","county"
-26059,26,"26","Hillsdale",598.17255,41.927459999999996,-84.63748000000001,"Hillsdale County","county"
-21141,21,"21","Logan",552.2314,36.859608,-86.88129,"Logan County","county"
-46033,46,"46","Custer",1556.9998,43.684944,-103.46225,"Custer County","county"
-33013,33,"33","Merrimack",932.91364,43.29958,-71.68004,"Merrimack County","county"
-42133,42,"42","York",904.3978,39.921753,-76.72889,"York County","county"
-37161,37,"37","Rutherford",565.4566,35.40275,-81.919586,"Rutherford County","county"
-46005,46,"46","Beadle",1258.7516,44.418265999999996,-98.27942,"Beadle County","county"
-1043,1,"01","Cullman",734.7661,34.131924,-86.86927,"Cullman County","county"
-13097,13,"13","Douglas",200.1448,33.701240000000006,-84.76731,"Douglas County","county"
-31097,31,"31","Johnson",376.0853,40.395008000000004,-96.265366,"Johnson County","county"
-37187,37,"37","Washington",346.52158,35.84471,-76.57229,"Washington County","county"
-46075,46,"46","Jones",969.7049,43.951992,-100.68614000000001,"Jones County","county"
-37007,37,"37","Anson",531.47925,34.97497,-80.109764,"Anson County","county"
-2100,2,"02","Haines Borough",2344.607,59.098404,-135.57578999999998,"Haines Borough","county"
-38007,38,"38","Billings",1148.5275,47.007046,-103.36401,"Billings County","county"
-31003,31,"31","Antelope",857.18585,42.183223999999996,-98.05804,"Antelope County","county"
-29073,29,"29","Gasconade",519.0224599999999,38.441179999999996,-91.50578,"Gasconade County","county"
-21031,21,"21","Butler",426.10602,37.207012,-86.68247,"Butler County","county"
-78020,78,"78","St. John Island",19.691292,18.330435,-64.73526,"St. John Island","county"
-56005,56,"56","Campbell",4802.2285,44.192,-105.51701000000001,"Campbell County","county"
-13211,13,"13","Morgan",347.4152,33.598694,-83.49943499999999,"Morgan County","county"
-5037,5,"05","Cross",616.4029,35.28569,-90.76398499999999,"Cross County","county"
-5107,5,"05","Phillips",695.65204,34.423687,-90.85559,"Phillips County","county"
-22093,22,"22","St. James Parish",242.84956,30.024776,-90.79395,"St. James Parish","county"
-6115,6,"06","Yuba",632.0375,39.27013,-121.34426,"Yuba County","county"
-1117,1,"01","Shelby",785.4106,33.263042,-86.67809,"Shelby County","county"
-8091,8,"08","Ouray",541.6114,38.15473,-107.78848,"Ouray County","county"
-35009,35,"35","Curry",1405.5607,34.572983,-103.34605400000001,"Curry County","county"
-40149,40,"40","Washita",1003.12354,35.289497,-98.99143000000001,"Washita County","county"
-37135,37,"37","Orange",397.57245,36.062527,-79.12003,"Orange County","county"
-18131,18,"18","Pulaski",433.68964000000005,41.045273,-86.69253499999999,"Pulaski County","county"
-26019,26,"26","Benzie",319.70905,44.64862,-86.49432,"Benzie County","county"
-36029,36,"36","Erie",1042.7617,42.752758,-78.77819000000001,"Erie County","county"
-24031,24,"24","Montgomery",493.0797,39.137383,-77.203064,"Montgomery County","county"
-51685,51,"51","Manassas Park city",2.5246994,38.768944,-77.44877,"Manassas Park city","county"
-51013,51,"51","Arlington",25.998297,38.878338,-77.1007,"Arlington County","county"
-51035,51,"51","Carroll",474.76055999999994,36.731964000000005,-80.72783000000001,"Carroll County","county"
-29183,29,"29","St. Charles",560.53076,38.7811,-90.67491,"St. Charles County","county"
-6069,6,"06","San Benito",1388.6989,36.611652,-121.08581000000001,"San Benito County","county"
-24035,24,"24","Queen Anne's",371.70285,39.040690000000005,-76.08240500000001,"Queen Anne's County","county"
-20013,20,"20","Brown",570.8908,39.82593,-95.56991,"Brown County","county"
-13031,13,"13","Bulloch",675.97406,32.391712,-81.74401999999999,"Bulloch County","county"
-21071,21,"21","Floyd",393.29556,37.552456,-82.73971999999999,"Floyd County","county"
-30007,30,"30","Broadwater",1192.3997,46.32985,-111.49786999999999,"Broadwater County","county"
-13309,13,"13","Wheeler",295.4996,32.105259999999994,-82.73385,"Wheeler County","county"
-37049,37,"37","Craven",706.5966,35.11683,-77.08131999999999,"Craven County","county"
-29087,29,"29","Holt",462.70883,40.095721999999995,-95.21907,"Holt County","county"
-48295,48,"48","Lipscomb",932.2455,36.2802,-100.27268000000001,"Lipscomb County","county"
-41009,41,"41","Columbia",658.1368,45.941933,-123.08108,"Columbia County","county"
-45041,45,"45","Florence",800.5376,34.028534,-79.710236,"Florence County","county"
-38061,38,"38","Mountrail",1825.3207,48.21007,-102.3649,"Mountrail County","county"
-49053,49,"49","Washington",2427.5212,37.26253,-113.4878,"Washington County","county"
-30003,30,"30","Big Horn",4997.9844,45.407866999999996,-107.518166,"Big Horn County","county"
-42047,42,"42","Elk",827.4001,41.42733,-78.65394,"Elk County","county"
-31165,31,"31","Sioux",2066.769,42.47067,-103.73217,"Sioux County","county"
-28031,28,"28","Covington",413.83255,31.633331,-89.5489,"Covington County","county"
-72099,72,"72","Moca Municipio",50.343090000000004,18.377638,-67.079575,"Moca Municipio","county"
-18013,18,"18","Brown",311.99807999999996,39.195114000000004,-86.23012,"Brown County","county"
-18019,18,"18","Clark",372.85065,38.47622,-85.71112,"Clark County","county"
-21021,21,"21","Boyle",180.35605,37.618103000000005,-84.86835500000001,"Boyle County","county"
-21065,21,"21","Estill",253.10242000000002,37.692448,-83.96398,"Estill County","county"
-48087,48,"48","Collingsworth",918.4717400000001,34.963356,-100.27213,"Collingsworth County","county"
-48089,48,"48","Colorado",960.3189,29.596296000000002,-96.508934,"Colorado County","county"
-17063,17,"17","Grundy",418.1399,41.292408,-88.401054,"Grundy County","county"
-27081,27,"27","Lincoln",536.7998,44.408237,-96.27203,"Lincoln County","county"
-13109,13,"13","Evans",182.90085,32.153084,-81.89015,"Evans County","county"
-48497,48,"48","Wise",904.4245,33.219093,-97.654,"Wise County","county"
-2050,2,"02","Bethel Census Area",40632.0,60.929142000000006,-160.15261999999998,"Bethel Census Area","county"
-13307,13,"13","Webster",209.36368000000002,32.046690000000005,-84.553825,"Webster County","county"
-13169,13,"13","Jones",393.95505,33.021664,-83.56219499999999,"Jones County","county"
-13135,13,"13","Gwinnett",430.6377,33.959145,-84.02309,"Gwinnett County","county"
-55095,55,"55","Polk",914.3510000000001,45.46204,-92.44707,"Polk County","county"
-55045,55,"55","Green",584.0639,42.67552,-89.60507,"Green County","county"
-72107,72,"72","Orocovis Municipio",63.627304,18.218733,-66.4369,"Orocovis Municipio","county"
-36079,36,"36","Putnam",230.33437,41.427906,-73.74386,"Putnam County","county"
-51700,51,"51","Newport News city",68.99455999999999,37.076138,-76.52198,"Newport News city","county"
-8011,8,"08","Bent",1512.8982,37.931892,-103.07758000000001,"Bent County","county"
-40065,40,"40","Jackson",802.6798,34.594006,-99.41223000000001,"Jackson County","county"
-30089,30,"30","Sanders",2760.4946,47.756496000000006,-115.180305,"Sanders County","county"
-48173,48,"48","Glasscock",900.2483,31.868006,-101.52149,"Glasscock County","county"
-5047,5,"05","Franklin",608.86896,35.508556,-93.887665,"Franklin County","county"
-40093,40,"40","Major",955.0325,36.313117999999996,-98.542015,"Major County","county"
-47125,47,"47","Montgomery",539.1832,36.500355,-87.38089000000001,"Montgomery County","county"
-53051,53,"53","Pend Oreille",1400.3063,48.543822999999996,-117.23218999999999,"Pend Oreille County","county"
-38055,38,"38","McLean",2110.331,47.53046,-101.35309000000001,"McLean County","county"
-41027,41,"41","Hood River",522.10645,45.511776,-121.655975,"Hood River County","county"
-19197,19,"19","Wright",580.4351,42.733006,-93.73473,"Wright County","county"
-48419,48,"48","Shelby",795.6161,31.79014,-94.14258000000001,"Shelby County","county"
-29055,29,"29","Crawford",742.502,37.96656,-91.313934,"Crawford County","county"
-51017,51,"51","Bath",529.2196700000001,38.068366999999995,-79.7312,"Bath County","county"
-27111,27,"27","Otter Tail",1971.9241,46.405727,-95.714584,"Otter Tail County","county"
-22075,22,"22","Plaquemines Parish",780.3203,29.282448,-89.576065,"Plaquemines Parish","county"
-28115,28,"28","Pontotoc",497.78045999999995,34.22708,-89.03724,"Pontotoc County","county"
-22067,22,"22","Morehouse Parish",794.9574,32.820007000000004,-91.8004,"Morehouse Parish","county"
-21029,21,"21","Bullitt",297.0411,37.969944,-85.70264,"Bullitt County","county"
-1047,1,"01","Dallas",978.77124,32.333538,-87.11435999999999,"Dallas County","county"
-48093,48,"48","Comanche",937.78485,31.951645000000003,-98.549614,"Comanche County","county"
-30053,30,"30","Lincoln",3612.6582,48.552383,-115.46319,"Lincoln County","county"
-72129,72,"72","San Lorenzo Municipio",53.109375,18.147108,-65.976166,"San Lorenzo Municipio","county"
-72135,72,"72","Toa Alta Municipio",27.017483000000002,18.364555,-66.24467,"Toa Alta Municipio","county"
-27021,27,"27","Cass",2021.5422,46.951744,-94.3337,"Cass County","county"
-8007,8,"08","Archuleta",1350.134,37.202396,-107.05086499999999,"Archuleta County","county"
-28163,28,"28","Yazoo",922.37054,32.765675,-90.38793000000001,"Yazoo County","county"
-55087,55,"55","Outagamie",637.60004,44.418224,-88.46499,"Outagamie County","county"
-29107,29,"29","Lafayette",628.4571,39.068707,-93.802635,"Lafayette County","county"
-37195,37,"37","Wilson",367.5612,35.700356,-77.9216,"Wilson County","county"
-39117,39,"39","Morrow",406.14737,40.525265000000005,-82.79773,"Morrow County","county"
-30039,30,"30","Granite",1727.2207,46.395953999999996,-113.42735,"Granite County","county"
-38031,38,"38","Foster",634.1012599999999,47.47143,-98.87288000000001,"Foster County","county"
-5033,5,"05","Crawford",593.7873,35.583009999999994,-94.23621999999999,"Crawford County","county"
-48053,48,"48","Burnet",994.3098,30.78963,-98.20119,"Burnet County","county"
-29186,29,"29","Ste. Genevieve",499.17004000000003,37.885845,-90.16153,"Ste. Genevieve County","county"
-48179,48,"48","Gray",926.0055,35.402542,-100.81237,"Gray County","county"
-17109,17,"17","McDonough",589.3431,40.455807,-90.678955,"McDonough County","county"
-19137,19,"19","Montgomery",424.11127,41.021736,-95.15779,"Montgomery County","county"
-5067,5,"05","Jackson",633.8583,35.596466,-91.223206,"Jackson County","county"
-48229,48,"48","Hudspeth",4570.6807,31.450869,-105.37755,"Hudspeth County","county"
-22079,22,"22","Rapides Parish",1320.3892,31.193203000000004,-92.53595,"Rapides Parish","county"
-31111,31,"31","Lincoln",2564.2197,41.050323,-100.744484,"Lincoln County","county"
-48067,48,"48","Cass",936.9976,33.0837,-94.35758,"Cass County","county"
-47079,47,"47","Henry",561.92145,36.325294,-88.300285,"Henry County","county"
-51840,51,"51","Winchester city",9.193211,39.17387,-78.17635,"Winchester city","county"
-37061,37,"37","Duplin",814.7866,34.934402,-77.93354000000001,"Duplin County","county"
-37087,37,"37","Haywood",553.57886,35.558884,-82.98131,"Haywood County","county"
-27037,27,"27","Dakota",562.56354,44.670895,-93.062485,"Dakota County","county"
-41025,41,"41","Harney",10134.782,43.06445,-118.98716999999999,"Harney County","county"
-72095,72,"72","Maunabo Municipio",21.165573000000002,17.999786,-65.8964,"Maunabo Municipio","county"
-55001,55,"55","Adams",645.6682,43.97376,-89.76723,"Adams County","county"
-29045,29,"29","Clark",504.62363,40.407276,-91.72946999999999,"Clark County","county"
-21015,21,"21","Boone",246.2927,38.9589,-84.736374,"Boone County","county"
-21229,21,"21","Washington",296.9822,37.754208,-85.175415,"Washington County","county"
-22009,22,"22","Avoyelles Parish",832.0631,31.088503000000003,-91.98328000000001,"Avoyelles Parish","county"
-28137,28,"28","Tate",404.77722,34.64955,-89.94311,"Tate County","county"
-29227,29,"29","Worth",266.6377,40.4805,-94.4192,"Worth County","county"
-31163,31,"31","Sherman",565.8478,41.218742,-98.97285,"Sherman County","county"
-46021,46,"46","Campbell",733.7018,45.785576,-100.00210600000001,"Campbell County","county"
-46063,46,"46","Harding",2671.6604,45.59661,-103.47386999999999,"Harding County","county"
-26057,26,"26","Gratiot",568.3999,43.292324,-84.60469,"Gratiot County","county"
-19175,19,"19","Union",423.65952000000004,41.02855,-94.245094,"Union County","county"
-17127,17,"17","Massac",237.24988,37.216118,-88.70566,"Massac County","county"
-31113,31,"31","Logan",570.67993,41.542156,-100.443665,"Logan County","county"
-31121,31,"31","Merrick",485.86832000000004,41.16979,-98.03106,"Merrick County","county"
-31161,31,"31","Sheridan",2441.0429999999997,42.512287,-102.36828,"Sheridan County","county"
-21039,21,"21","Carlisle",189.44643,36.85718,-88.976616,"Carlisle County","county"
-56025,56,"56","Natrona",5340.719,42.977646,-106.76822,"Natrona County","county"
-13321,13,"13","Worth",570.73157,31.551772999999997,-83.84996,"Worth County","county"
-18109,18,"18","Morgan",403.85376,39.482647,-86.44745999999999,"Morgan County","county"
-48139,48,"48","Ellis",935.6919,32.346878000000004,-96.79694,"Ellis County","county"
-13229,13,"13","Pierce",340.46117999999996,31.353997999999997,-82.21037,"Pierce County","county"
-60010,60,"60","Eastern District",25.145706,-14.268114,-170.6257,"Eastern District","county"
-18053,18,"18","Grant",414.10266,40.51576,-85.654945,"Grant County","county"
-12035,12,"12","Flagler",485.16152999999997,29.474891999999997,-81.28625500000001,"Flagler County","county"
-28077,28,"28","Lawrence",430.61664,31.550009000000003,-90.10753000000001,"Lawrence County","county"
-22127,22,"22","Winn Parish",950.1185,31.941187,-92.641266,"Winn Parish","county"
-17073,17,"17","Henry",823.08136,41.35002,-90.13084,"Henry County","county"
-41041,41,"41","Lincoln",981.0357,44.641059999999996,-123.91121000000001,"Lincoln County","county"
-23031,23,"23","York",991.1096,43.426018,-70.66843,"York County","county"
-46029,46,"46","Codington",687.6084,44.966286,-97.19884,"Codington County","county"
-13231,13,"13","Pike",216.09346000000002,33.081223,-84.38985,"Pike County","county"
-13259,13,"13","Stewart",458.76407,32.073223,-84.83491500000001,"Stewart County","county"
-34025,34,"34","Monmouth",468.19772,40.28705,-74.15244,"Monmouth County","county"
-5021,5,"05","Clay",639.48975,36.367302,-90.4187,"Clay County","county"
-5045,5,"05","Faulkner",647.9786,35.14655,-92.33693000000001,"Faulkner County","county"
-40041,40,"40","Delaware",738.0539,36.393375,-94.80821999999999,"Delaware County","county"
-19107,19,"19","Keokuk",579.2007,41.331179999999996,-92.167725,"Keokuk County","county"
-17061,17,"17","Greene",543.0576,39.35544,-90.38768,"Greene County","county"
-27075,27,"27","Lake",2109.3376,47.517113,-91.411705,"Lake County","county"
-13285,13,"13","Troup",414.02158,33.03448,-85.02835999999999,"Troup County","county"
-6023,6,"06","Humboldt",3568.256,40.706654,-123.92618,"Humboldt County","county"
-47043,47,"47","Dickson",489.91492,36.14553,-87.36415,"Dickson County","county"
-27003,27,"27","Anoka",421.97787,45.27411,-93.24271999999999,"Anoka County","county"
-46009,46,"46","Bon Homme",563.5686,42.985797999999996,-97.8842,"Bon Homme County","county"
-47059,47,"47","Greene",622.1899400000001,36.179485,-82.84753,"Greene County","county"
-51183,51,"51","Sussex",490.2425,36.926646999999996,-77.25973499999999,"Sussex County","county"
-18141,18,"18","St. Joseph",457.9097,41.61772,-86.28805,"St. Joseph County","county"
-38067,38,"38","Pembina",1118.7160000000001,48.766895,-97.5454,"Pembina County","county"
-46007,46,"46","Bennett",1184.682,43.186913,-101.67718,"Bennett County","county"
-22115,22,"22","Vernon Parish",1327.9626,31.110563,-93.18151999999999,"Vernon Parish","county"
-23019,23,"23","Penobscot",3397.3125,45.409283,-68.66662,"Penobscot County","county"
-24041,24,"24","Talbot",268.567,38.74835,-76.178474,"Talbot County","county"
-13257,13,"13","Stephens",179.1563,34.552914,-83.290215,"Stephens County","county"
-6065,6,"06","Riverside",7209.2407,33.729828000000005,-116.00223500000001,"Riverside County","county"
-5005,5,"05","Baxter",554.2701,36.28027,-92.32995,"Baxter County","county"
-28007,28,"28","Attala",734.98175,33.09047,-89.58861999999999,"Attala County","county"
-19169,19,"19","Story",572.5631,42.037537,-93.466095,"Story County","county"
-20011,20,"20","Bourbon",635.49243,37.8561,-94.85093,"Bourbon County","county"
-51049,51,"51","Cumberland",297.51184,37.520187,-78.25284,"Cumberland County","county"
-45085,45,"45","Sumter",665.09644,33.916138000000004,-80.38238,"Sumter County","county"
-2164,2,"02","Lake and Peninsula Borough",23905.535,58.10850500000001,-156.4134,"Lake and Peninsula Borough","county"
-54109,54,"54","Wyoming",499.48682,37.60366,-81.54903399999999,"Wyoming County","county"
-6029,6,"06","Kern",8132.5693,35.34663,-118.72951,"Kern County","county"
-48097,48,"48","Cooke",874.8485,33.6392,-97.21034,"Cooke County","county"
-45075,45,"45","Orangeburg",1106.3835,33.436134,-80.80291,"Orangeburg County","county"
-55119,55,"55","Taylor",975.0844,45.211655,-90.50485,"Taylor County","county"
-27099,27,"27","Mower",711.35266,43.66625,-92.759514,"Mower County","county"
-27101,27,"27","Murray",704.6888,44.015594,-95.76158000000001,"Murray County","county"
-44007,44,"44","Providence",409.49987999999996,41.869766,-71.57862,"Providence County","county"
-29161,29,"29","Phelps",671.8093,37.866325,-91.79035,"Phelps County","county"
-28117,28,"28","Prentiss",414.99927,34.620567,-88.52219000000001,"Prentiss County","county"
-21235,21,"21","Whitley",437.84573,36.758022,-84.144646,"Whitley County","county"
-18149,18,"18","Starke",309.15472,41.284477,-86.64464,"Starke County","county"
-48491,48,"48","Williamson",1118.3778,30.649082,-97.605064,"Williamson County","county"
-72109,72,"72","Patillas Municipio",46.60244,18.00031,-65.98664000000001,"Patillas Municipio","county"
-19131,19,"19","Mitchell",469.14902,43.348564,-92.78447,"Mitchell County","county"
-13107,13,"13","Emanuel",680.5947,32.5911,-82.29977,"Emanuel County","county"
-22025,22,"22","Catahoula Parish",708.05164,31.666517,-91.8467,"Catahoula Parish","county"
-42025,42,"42","Carbon",381.26273,40.918365,-75.70504,"Carbon County","county"
-31133,31,"31","Pawnee",431.0893,40.137848,-96.245224,"Pawnee County","county"
-47171,47,"47","Unicoi",186.0701,36.10013,-82.41821999999999,"Unicoi County","county"
-45083,45,"45","Spartanburg",807.77185,34.93327,-81.99105,"Spartanburg County","county"
-55073,55,"55","Marathon",1545.2306,44.898037,-89.75782,"Marathon County","county"
-32007,32,"32","Elko",17174.03,41.141132,-115.351425,"Elko County","county"
-54007,54,"54","Braxton",510.75195,38.699329999999996,-80.73165999999999,"Braxton County","county"
-26165,26,"26","Wexford",564.9441,44.331375,-85.570045,"Wexford County","county"
-48079,48,"48","Cochran",775.10864,33.60844,-102.83045,"Cochran County","county"
-42013,42,"42","Blair",525.8192,40.498653000000004,-78.3096,"Blair County","county"
-29085,29,"29","Hickory",398.82172,37.93691,-93.32299,"Hickory County","county"
-29009,29,"29","Barry",778.1011,36.699375,-93.834335,"Barry County","county"
-27123,27,"27","Ramsey",152.24837,45.015205,-93.09997,"Ramsey County","county"
-5081,5,"05","Little River",532.2643400000001,33.699496999999994,-94.229774,"Little River County","county"
-32019,32,"32","Lyon",2001.3025,39.022213,-119.19742600000001,"Lyon County","county"
-12071,12,"12","Lee",781.4833,26.559034000000004,-81.89199,"Lee County","county"
-41033,41,"41","Josephine",1638.7045,42.386982,-123.57162,"Josephine County","county"
-72091,72,"72","Manatí Municipio",45.1419,18.444647,-66.49288,"Manatí Municipio","county"
-28113,28,"28","Pike",409.03143,31.177515000000003,-90.39773000000001,"Pike County","county"
-47031,47,"47","Coffee",428.9781,35.488766,-86.0782,"Coffee County","county"
-16059,16,"16","Lemhi",4563.848,44.928505,-113.88703999999998,"Lemhi County","county"
-21183,21,"21","Ohio",587.3045,37.47786,-86.84487,"Ohio County","county"
-31153,31,"31","Sarpy",238.16038999999998,41.115063,-96.10911999999999,"Sarpy County","county"
-13071,13,"13","Colquitt",547.0554,31.189707000000002,-83.769775,"Colquitt County","county"
-27167,27,"27","Wilkin",751.0251,46.362334999999995,-96.47665400000001,"Wilkin County","county"
-17157,17,"17","Randolph",575.3867,38.056515000000005,-89.82121,"Randolph County","county"
-23011,23,"23","Kennebec",867.4987,44.41701,-69.76576,"Kennebec County","county"
-51173,51,"51","Smyth",451.36575,36.84232,-81.53979,"Smyth County","county"
-35041,35,"35","Roosevelt",2446.134,34.021206,-103.48299999999999,"Roosevelt County","county"
-42111,42,"42","Somerset",1074.3944,39.981297,-79.02849,"Somerset County","county"
-51191,51,"51","Washington",561.1799,36.747814,-81.950325,"Washington County","county"
-37081,37,"37","Guilford",645.9473,36.079063,-79.788666,"Guilford County","county"
-16001,16,"16","Ada",1052.0485,43.451477000000004,-116.24438,"Ada County","county"
-40039,40,"40","Custer",988.8127,35.6456,-98.99738,"Custer County","county"
-39101,39,"39","Marion",403.82178,40.588035999999995,-83.1688,"Marion County","county"
-17149,17,"17","Pike",831.3799,39.625107,-90.88904000000001,"Pike County","county"
-17203,17,"17","Woodford",527.7508,40.789787,-89.21059,"Woodford County","county"
-13245,13,"13","Richmond",324.34302,33.361484999999995,-82.075,"Richmond County","county"
-1107,1,"01","Pickens",881.37537,33.296795,-88.09685999999999,"Pickens County","county"
-40045,40,"40","Ellis",1231.5188,36.22426,-99.75014,"Ellis County","county"
-17145,17,"17","Perry",441.85797,38.084379999999996,-89.36851999999999,"Perry County","county"
-19075,19,"19","Grundy",501.8718,42.40334,-92.790245,"Grundy County","county"
-8107,8,"08","Routt",2362.1,40.483665,-106.9877,"Routt County","county"
-34035,34,"34","Somerset",301.87667999999996,40.565529999999995,-74.619934,"Somerset County","county"
-6011,6,"06","Colusa",1150.7521,39.17774,-122.23756399999999,"Colusa County","county"
-17087,17,"17","Johnson",343.7464,37.46071,-88.88213,"Johnson County","county"
-8053,8,"08","Hinsdale",1117.2688,37.821166999999996,-107.338264,"Hinsdale County","county"
-16031,16,"16","Cassia",2565.6968,42.282314,-113.62633000000001,"Cassia County","county"
-27059,27,"27","Isanti",435.7549,45.56243,-93.29634,"Isanti County","county"
-42049,42,"42","Erie",799.0854,42.11795,-80.09638000000001,"Erie County","county"
-28029,28,"28","Copiah",777.3114,31.866915000000002,-90.44876,"Copiah County","county"
-48467,48,"48","Van Zandt",842.5993699999999,32.55879,-95.83691,"Van Zandt County","county"
-51161,51,"51","Roanoke",250.55264,37.343586,-79.94399,"Roanoke County","county"
-51015,51,"51","Augusta",967.1062,38.17191,-79.14756,"Augusta County","county"
-2060,2,"02","Bristol Bay Borough",481.99698,58.741645999999996,-156.9669,"Bristol Bay Borough","county"
-49031,49,"49","Piute",758.4639999999999,38.335879999999996,-112.12938,"Piute County","county"
-21161,21,"21","Mason",240.13452,38.594134999999994,-83.828125,"Mason County","county"
-27009,27,"27","Benton",408.3105,45.701225,-94.00144,"Benton County","county"
-48129,48,"48","Donley",926.9377400000001,34.955036,-100.81585,"Donley County","county"
-12005,12,"12","Bay",758.61755,30.238218,-85.63168,"Bay County","county"
-1077,1,"01","Lauderdale",668.0359,34.90412,-87.65099000000001,"Lauderdale County","county"
-18045,18,"18","Fountain",395.68106,40.121235,-87.23487,"Fountain County","county"
-17173,17,"17","Shelby",758.53613,39.384926,-88.79885999999999,"Shelby County","county"
-17051,17,"17","Fayette",716.4628,39.001125,-89.01791999999999,"Fayette County","county"
-39127,39,"39","Perry",407.94785,39.743187,-82.23795,"Perry County","county"
-51590,51,"51","Danville city",42.798767,36.583332,-79.40807,"Danville city","county"
-13011,13,"13","Banks",232.06392999999997,34.35192,-83.49844,"Banks County","county"
-13305,13,"13","Wayne",641.9585599999999,31.547846000000003,-81.91238,"Wayne County","county"
-40109,40,"40","Oklahoma",708.8815,35.55461,-97.4094,"Oklahoma County","county"
-40069,40,"40","Johnston",643.0706,34.313454,-96.65425,"Johnston County","county"
-37099,37,"37","Jackson",491.12363,35.28105,-83.11996500000001,"Jackson County","county"
-49043,49,"49","Summit",1870.6426,40.87206,-110.96848,"Summit County","county"
-29167,29,"29","Polk",635.5481599999999,37.61676,-93.40082,"Polk County","county"
-32015,32,"32","Lander",5519.4346,39.900209999999994,-117.04723999999999,"Lander County","county"
-19191,19,"19","Winneshiek",689.8593,43.292988,-91.85078399999999,"Winneshiek County","county"
-21023,21,"21","Bracken",202.72346000000002,38.680367,-84.115234,"Bracken County","county"
-55037,55,"55","Florence",488.1395,45.871826,-88.40699000000001,"Florence County","county"
-54087,54,"54","Roane",483.57944000000003,38.74295,-81.35449,"Roane County","county"
-27159,27,"27","Wadena",536.295,46.586987,-94.98861,"Wadena County","county"
-51670,51,"51","Hopewell city",10.3547125,37.291008000000005,-77.29894,"Hopewell city","county"
-17201,17,"17","Winnebago",513.17365,42.337395,-89.16121,"Winnebago County","county"
-4007,4,"04","Gila",4758.1577,33.78962,-110.81187,"Gila County","county"
-24045,24,"24","Wicomico",374.43323,38.36737,-75.63208,"Wicomico County","county"
-21043,21,"21","Carter",409.5089,38.309546999999995,-83.0488,"Carter County","county"
-37097,37,"37","Iredell",574.3158599999999,35.806248,-80.87451999999999,"Iredell County","county"
-51083,51,"51","Halifax",817.75867,36.766459999999995,-78.93961,"Halifax County","county"
-37091,37,"37","Hertford",353.17554,36.363518,-76.98161,"Hertford County","county"
-36057,36,"36","Montgomery",403.13022,42.900890000000004,-74.435356,"Montgomery County","county"
-27113,27,"27","Pennington",616.59863,48.06925,-96.03773000000001,"Pennington County","county"
-53073,53,"53","Whatcom",2107.9482,48.84265,-121.83643000000001,"Whatcom County","county"
-41021,41,"41","Gilliam",1204.7623,45.43059,-120.3199,"Gilliam County","county"
-34029,34,"34","Ocean",628.359,39.86567,-74.258865,"Ocean County","county"
-5009,5,"05","Boone",590.01526,36.3043,-93.07924,"Boone County","county"
-40031,40,"40","Comanche",1069.4058,34.66263,-98.47661,"Comanche County","county"
-48253,48,"48","Jones",928.6022300000001,32.74371,-99.87443,"Jones County","county"
-48185,48,"48","Grimes",787.4934,30.543232,-95.98808000000001,"Grimes County","county"
-26049,26,"26","Genesee",636.95654,43.021076,-83.706375,"Genesee County","county"
-22007,22,"22","Assumption Parish",338.63467,29.898853000000003,-91.05247,"Assumption Parish","county"
-28013,28,"28","Calhoun",586.59344,33.936634000000005,-89.33711,"Calhoun County","county"
-28041,28,"28","Greene",712.7624,31.212845,-88.63481,"Greene County","county"
-30017,30,"30","Custer",3783.437,46.261414,-105.550354,"Custer County","county"
-46109,46,"46","Roberts",1101.086,45.623398,-96.94755,"Roberts County","county"
-17141,17,"17","Ogle",758.6794,42.041885,-89.320175,"Ogle County","county"
-38077,38,"38","Richland",1435.723,46.26522,-96.93796,"Richland County","county"
-55005,55,"55","Barron",863.0707,45.43719,-91.85289,"Barron County","county"
-55051,55,"55","Iron",758.2344,46.32655,-90.2613,"Iron County","county"
-27157,27,"27","Wabasha",522.9684,44.289691999999995,-92.23334,"Wabasha County","county"
-6015,6,"06","Del Norte",1006.262,41.763958,-124.00362,"Del Norte County","county"
-40127,40,"40","Pushmataha",1395.5845,34.3779,-95.40808,"Pushmataha County","county"
-53007,53,"53","Chelan",2921.278,47.860973,-120.61903999999998,"Chelan County","county"
-26141,26,"26","Presque Isle",658.73956,45.489513,-83.38401999999999,"Presque Isle County","county"
-40027,40,"40","Cleveland",538.806,35.206375,-97.32309000000001,"Cleveland County","county"
-36105,36,"36","Sullivan",968.1701,41.719994,-74.771576,"Sullivan County","county"
-37149,37,"37","Polk",237.695,35.2779,-82.16762,"Polk County","county"
-37165,37,"37","Scotland",319.15134,34.840022999999995,-79.47733000000001,"Scotland County","county"
-37085,37,"37","Harnett",595.0423599999999,35.368633,-78.87161,"Harnett County","county"
-37105,37,"37","Lee",255.07062000000002,35.476337,-79.17211999999999,"Lee County","county"
-18159,18,"18","Tipton",260.54967999999997,40.31023,-86.056206,"Tipton County","county"
-20027,20,"20","Clay",645.3204,39.344963,-97.16885,"Clay County","county"
-40145,40,"40","Wagoner",561.7006,35.963478,-95.5141,"Wagoner County","county"
-30083,30,"30","Richland",2084.6267,47.785633000000004,-104.56341,"Richland County","county"
-5003,5,"05","Ashley",925.3905,33.190834,-91.77226999999999,"Ashley County","county"
-5041,5,"05","Desha",768.16156,33.82875,-91.2441,"Desha County","county"
-72147,72,"72","Vieques Municipio",50.790146,18.125418,-65.43247,"Vieques Municipio","county"
-47135,47,"47","Perry",414.77603,35.663754,-87.86932,"Perry County","county"
-27163,27,"27","Washington",384.42368,45.037929999999996,-92.890114,"Washington County","county"
-51740,51,"51","Portsmouth city",33.301753999999995,36.85934,-76.35696999999999,"Portsmouth city","county"
-42051,42,"42","Fayette",790.3807,39.918907,-79.64012,"Fayette County","county"
-54023,54,"54","Grant",477.38845999999995,39.105988,-79.19506,"Grant County","county"
-51171,51,"51","Shenandoah",508.08925999999997,38.856204999999996,-78.57399000000001,"Shenandoah County","county"
-48235,48,"48","Irion",1051.5796,31.303425,-100.9813,"Irion County","county"
-29025,29,"29","Caldwell",426.40665,39.658997,-93.97918,"Caldwell County","county"
-12107,12,"12","Putnam",727.89185,29.593897,-81.73204,"Putnam County","county"
-18025,18,"18","Crawford",305.6237,38.289433,-86.44086999999999,"Crawford County","county"
-29111,29,"29","Lewis",505.0591,40.084559999999996,-91.728806,"Lewis County","county"
-31075,31,"31","Grant",776.8954,41.913956,-101.75596999999999,"Grant County","county"
-72087,72,"72","Loíza Municipio",19.362873,18.475039000000002,-65.90328000000001,"Loíza Municipio","county"
-16071,16,"16","Oneida",1198.992,42.183895,-112.52045,"Oneida County","county"
-17139,17,"17","Moultrie",335.97217,39.636894,-88.625725,"Moultrie County","county"
-21107,21,"21","Hopkins",542.0843,37.31107,-87.5422,"Hopkins County","county"
-16035,16,"16","Clearwater",2457.3972,46.67257,-115.6535,"Clearwater County","county"
-21013,21,"21","Bell",359.07397000000003,36.728928,-83.68072,"Bell County","county"
-27035,27,"27","Crow Wing",998.39825,46.491653,-94.07072,"Crow Wing County","county"
-60050,60,"60","Western District",27.992784999999998,-14.335467999999999,-170.78423999999998,"Western District","county"
-72011,72,"72","Añasco Municipio",39.286235999999995,18.286904999999997,-67.13128,"Añasco Municipio","county"
-4009,4,"04","Graham",4622.034000000001,32.931828,-109.87831000000001,"Graham County","county"
-5123,5,"05","St. Francis",634.78094,35.02284,-90.7515,"St. Francis County","county"
-13101,13,"13","Echols",420.42145,30.714008000000003,-82.89738,"Echols County","county"
-2070,2,"02","Dillingham Census Area",18332.264,59.543327000000005,-158.26712,"Dillingham Census Area","county"
-20105,20,"20","Lincoln",719.42035,39.04728,-98.21429,"Lincoln County","county"
-20183,20,"20","Smith",895.49475,39.784659999999995,-98.78543,"Smith County","county"
-12065,12,"12","Jefferson",598.0976,30.424559000000002,-83.89086,"Jefferson County","county"
-72041,72,"72","Cidra Municipio",36.022438,18.174404,-66.16162,"Cidra Municipio","county"
-28005,28,"28","Amite",730.12506,31.203934000000004,-90.79554,"Amite County","county"
-5097,5,"05","Montgomery",779.94696,34.545654,-93.66415400000001,"Montgomery County","county"
-26025,26,"26","Calhoun",706.28455,42.24299,-85.01238000000001,"Calhoun County","county"
-1029,1,"01","Cleburne",560.1235,33.671963,-85.51613,"Cleburne County","county"
-8123,8,"08","Weld",3985.0645,40.55596,-104.38367,"Weld County","county"
-40009,40,"40","Beckham",901.7099,35.2706,-99.69005600000001,"Beckham County","county"
-6049,6,"06","Modoc",3948.0662,41.59292,-120.71837,"Modoc County","county"
-19153,19,"19","Polk",572.2328,41.684814,-93.56897,"Polk County","county"
-13179,13,"13","Liberty",516.4880400000001,31.807459,-81.45787,"Liberty County","county"
-48349,48,"48","Navarro",1009.68207,32.048446999999996,-96.476906,"Navarro County","county"
-48047,48,"48","Brooks",943.3866,27.034994,-98.21528,"Brooks County","county"
-47187,47,"47","Williamson",582.8888,35.894806,-86.89806999999999,"Williamson County","county"
-56021,56,"56","Laramie",2685.955,41.29283,-104.66039,"Laramie County","county"
-53003,53,"53","Asotin",636.0971,46.18186,-117.22778000000001,"Asotin County","county"
-27155,27,"27","Traverse",573.89124,45.769936,-96.47483000000001,"Traverse County","county"
-17017,17,"17","Cass",375.76672,39.969204,-90.245705,"Cass County","county"
-13247,13,"13","Rockdale",129.82289,33.65208,-84.02637,"Rockdale County","county"
-42067,42,"42","Juniata",391.4035,40.530674,-77.40044,"Juniata County","county"
-42083,42,"42","McKean",979.2146,41.81459,-78.572464,"McKean County","county"
-40049,40,"40","Garvin",802.1365400000001,34.70935,-97.31272,"Garvin County","county"
-31021,31,"31","Burt",491.6025,41.85418,-96.337746,"Burt County","county"
-35045,35,"35","San Juan",5517.391,36.511623,-108.32458000000001,"San Juan County","county"
-36073,36,"36","Orleans",391.27643,43.502285,-78.22973,"Orleans County","county"
-22031,22,"22","De Soto Parish",876.4557,32.059246,-93.7408,"De Soto Parish","county"
-6019,6,"06","Fresno",5958.585,36.761005,-119.65502,"Fresno County","county"
-13105,13,"13","Elbert",351.10956,34.116413,-82.84191,"Elbert County","county"
-1005,1,"01","Barbour",885.0381,31.870253,-85.405106,"Barbour County","county"
-37017,37,"37","Bladen",874.8939,34.591938,-78.53949,"Bladen County","county"
-48111,48,"48","Dallam",1503.1836,36.28637,-102.59402,"Dallam County","county"
-17167,17,"17","Sangamon",868.29785,39.756865999999995,-89.66242,"Sangamon County","county"
-40035,40,"40","Craig",761.2734,36.76389,-95.20155,"Craig County","county"
-47035,47,"47","Cumberland",681.3567,35.9524,-84.99476,"Cumberland County","county"
-26137,26,"26","Otsego",515.0239,45.021786,-84.57661,"Otsego County","county"
-19161,19,"19","Sac",575.04156,42.387527,-95.105225,"Sac County","county"
-49015,49,"49","Emery",4462.428,39.009026,-110.7211,"Emery County","county"
-53019,53,"53","Ferry",2203.3135,48.473255,-118.53358999999999,"Ferry County","county"
-30109,30,"30","Wibaux",889.60175,46.962967,-104.27452,"Wibaux County","county"
-35027,35,"35","Lincoln",4831.2793,33.740840000000006,-105.44981000000001,"Lincoln County","county"
-40021,40,"40","Cherokee",749.0266,35.904365999999996,-94.996796,"Cherokee County","county"
-27173,27,"27","Yellow Medicine",759.12695,44.715736,-95.862755,"Yellow Medicine County","county"
-48231,48,"48","Hunt",840.44385,33.123306,-96.08423,"Hunt County","county"
-48335,48,"48","Mitchell",911.1205,32.304115,-100.92439,"Mitchell County","county"
-48499,48,"48","Wood",645.26465,32.783590000000004,-95.382164,"Wood County","county"
-40113,40,"40","Osage",2246.681,36.6243,-96.40811,"Osage County","county"
-37039,37,"37","Cherokee",455.55643,35.13715,-84.06145,"Cherokee County","county"
-26107,26,"26","Mecosta",555.1461,43.635296000000004,-85.33275,"Mecosta County","county"
-21195,21,"21","Pike",786.7569599999999,37.48603,-82.41091,"Pike County","county"
-12067,12,"12","Lafayette",543.36316,29.990067,-83.17851,"Lafayette County","county"
-37035,37,"37","Catawba",401.38647000000003,35.661884,-81.214905,"Catawba County","county"
-21025,21,"21","Breathitt",492.4332,37.517807,-83.31716,"Breathitt County","county"
-48075,48,"48","Childress",696.5345,34.524623999999996,-100.20817,"Childress County","county"
-29181,29,"29","Ripley",629.5527,36.65017,-90.87483,"Ripley County","county"
-17179,17,"17","Tazewell",646.4866,40.508076,-89.51626,"Tazewell County","county"
-48243,48,"48","Jeff Davis",2264.6328,30.625357,-104.19187,"Jeff Davis County","county"
-51678,51,"51","Lexington city",2.4993243,37.782333,-79.44431999999999,"Lexington city","county"
-5135,5,"05","Sharp",604.4255,36.173396999999994,-91.47107,"Sharp County","county"
-8069,8,"08","Larimer",2595.8628,40.658091999999996,-105.48676,"Larimer County","county"
-37177,37,"37","Tyrrell",390.7888,35.87042,-76.16534399999999,"Tyrrell County","county"
-27131,27,"27","Rice",495.8551,44.350735,-93.29851,"Rice County","county"
-29219,29,"29","Warren",428.62185999999997,38.7619,-91.15930999999999,"Warren County","county"
-21227,21,"21","Warren",541.73834,36.995632,-86.42358,"Warren County","county"
-22017,22,"22","Caddo Parish",879.0971699999999,32.577194,-93.88242,"Caddo Parish","county"
-46121,46,"46","Todd",1388.6427,43.208794,-100.70766400000001,"Todd County","county"
-19127,19,"19","Marshall",572.5225,42.04169,-92.98145,"Marshall County","county"
-40141,40,"40","Tillman",871.1637599999999,34.371086,-98.9317,"Tillman County","county"
-37113,37,"37","Macon",515.5969,35.152958,-83.4219,"Macon County","county"
-54063,54,"54","Monroe",472.7699,37.55406,-80.55033,"Monroe County","county"
-18155,18,"18","Switzerland",220.67485,38.825855,-85.02968,"Switzerland County","county"
-21105,21,"21","Hickman",242.2827,36.675896,-88.972084,"Hickman County","county"
-1061,1,"01","Geneva",574.50006,31.092382,-85.82101999999999,"Geneva County","county"
-17099,17,"17","LaSalle",1135.2063,41.343340000000005,-88.88593,"LaSalle County","county"
-19055,19,"19","Delaware",577.70154,42.47294,-91.36676999999999,"Delaware County","county"
-20127,20,"20","Morris",695.36633,38.688206,-96.65145,"Morris County","county"
-19051,19,"19","Davis",502.20544,40.748090000000005,-92.41035,"Davis County","county"
-16015,16,"16","Boise",1899.6202,43.987274,-115.71511000000001,"Boise County","county"
-55081,55,"55","Monroe",900.93427,43.945175,-90.61997,"Monroe County","county"
-37143,37,"37","Perquimans",247.17917999999997,36.180896999999995,-76.403244,"Perquimans County","county"
-12047,12,"12","Hamilton",513.7996,30.491186,-82.95107,"Hamilton County","county"
-2170,2,"02","Matanuska-Susitna Borough",24714.955,62.279095,-149.6191,"Matanuska-Susitna Borough","county"
-18035,18,"18","Delaware",392.11407,40.227543,-85.39926,"Delaware County","county"
-12075,12,"12","Levy",1118.2605,29.284456,-82.78345999999999,"Levy County","county"
-72063,72,"72","Gurabo Municipio",27.885738,18.272581,-65.98118000000001,"Gurabo Municipio","county"
-72065,72,"72","Hatillo Municipio",41.777924,18.441141000000002,-66.79821,"Hatillo Municipio","county"
-28045,28,"28","Hancock",473.9802,30.391641999999997,-89.48279000000001,"Hancock County","county"
-13315,13,"13","Wilcox",377.8236,31.962719,-83.438255,"Wilcox County","county"
-22081,22,"22","Red River Parish",389.10497999999995,32.101209999999995,-93.34905,"Red River Parish","county"
-47093,47,"47","Knox",508.3435,35.992725,-83.93772,"Knox County","county"
-23017,23,"23","Oxford",2077.024,44.4945,-70.73442,"Oxford County","county"
-29095,29,"29","Jackson",604.5368,39.005337,-94.34316,"Jackson County","county"
-13281,13,"13","Towns",166.4696,34.90253,-83.73226,"Towns County","county"
-28129,28,"28","Smith",636.2895,32.019028000000006,-89.49486999999999,"Smith County","county"
-16075,16,"16","Payette",406.90612999999996,44.00243,-116.75023999999999,"Payette County","county"
-16079,16,"16","Shoshone",2637.5144,47.347694,-115.88508999999999,"Shoshone County","county"
-37095,37,"37","Hyde",612.3661,35.408157,-76.15369,"Hyde County","county"
-19067,19,"19","Floyd",500.61782999999997,43.052741999999995,-92.78737,"Floyd County","county"
-21145,21,"21","McCracken",248.73192000000003,37.054109999999994,-88.712456,"McCracken County","county"
-21225,21,"21","Union",342.8676,37.658028,-87.95165,"Union County","county"
-46125,46,"46","Turner",617.085,43.30867,-97.150185,"Turner County","county"
-47029,47,"47","Cocke",436.14987,35.9162,-83.119225,"Cocke County","county"
-47067,47,"47","Hancock",222.3314,36.521355,-83.22749,"Hancock County","county"
-47071,47,"47","Hardin",577.3478,35.201893,-88.1857,"Hardin County","county"
-45067,45,"45","Marion",489.27472,34.08362,-79.354004,"Marion County","county"
-72057,72,"72","Guayama Municipio",64.990616,17.973928,-66.13747,"Guayama Municipio","county"
-22117,22,"22","Washington Parish",669.6187,30.852144,-90.04626,"Washington Parish","county"
-29207,29,"29","Stoddard",823.2459,36.851555,-89.94748,"Stoddard County","county"
-13093,13,"13","Dooly",392.64398,32.151996999999994,-83.80717,"Dooly County","county"
-27145,27,"27","Stearns",1342.8424,45.555233,-94.61048000000001,"Stearns County","county"
-31155,31,"31","Saunders",749.3158,41.22339,-96.6421,"Saunders County","county"
-27141,27,"27","Sherburne",432.9242,45.453175,-93.76913,"Sherburne County","county"
-46035,46,"46","Davison",435.64807,43.680440000000004,-98.15587,"Davison County","county"
-47025,47,"47","Claiborne",434.61492999999996,36.50157,-83.6607,"Claiborne County","county"
-48337,48,"48","Montague",930.9373,33.678356,-97.72501,"Montague County","county"
-48049,48,"48","Brown",944.4844400000001,31.764136999999998,-98.99846,"Brown County","county"
-55101,55,"55","Racine",332.60098,42.75412,-87.420876,"Racine County","county"
-55115,55,"55","Shawano",893.25525,44.789642,-88.75581,"Shawano County","county"
-19009,19,"19","Audubon",442.9764,41.679176,-94.90431,"Audubon County","county"
-48207,48,"48","Haskell",903.1637599999999,33.175964,-99.730774,"Haskell County","county"
-40083,40,"40","Logan",743.8676,35.91415,-97.45076999999999,"Logan County","county"
-36065,36,"36","Oneida",1212.3718,43.24273,-75.43428,"Oneida County","county"
-8065,8,"08","Lake",376.9319,39.20534,-106.35008,"Lake County","county"
-40121,40,"40","Pittsburg",1305.5643,34.925540000000005,-95.74813,"Pittsburg County","county"
-54017,54,"54","Doddridge",319.73373,39.26348,-80.70123000000001,"Doddridge County","county"
-54105,54,"54","Wirt",232.51904,39.020035,-81.38297,"Wirt County","county"
-33003,33,"33","Carroll",931.8936,43.867775,-71.20156,"Carroll County","county"
-54095,54,"54","Tyler",256.3105,39.465633000000004,-80.87722,"Tyler County","county"
-69085,69,"69","Northern Islands Municipality",61.804367000000006,16.028783999999998,146.002,"Northern Islands Municipality","county"
-27079,27,"27","Le Sueur",448.6852,44.373425,-93.73014,"Le Sueur County","county"
-53017,53,"53","Douglas",1819.325,47.741764,-119.69462,"Douglas County","county"
-36009,36,"36","Cattaraugus",1308.3225,42.239098,-78.66233000000001,"Cattaraugus County","county"
-55027,55,"55","Dodge",875.72687,43.429626,-88.70194000000001,"Dodge County","county"
-19105,19,"19","Jones",575.6379400000001,42.12512,-91.11691,"Jones County","county"
-20007,20,"20","Barber",1134.1136,37.222904,-98.68505,"Barber County","county"
-29169,29,"29","Pulaski",547.1304299999999,37.824833,-92.20702,"Pulaski County","county"
-1045,1,"01","Dale",561.11993,31.430654999999998,-85.609474,"Dale County","county"
-20109,20,"20","Logan",1073.0298,38.913270000000004,-101.1574,"Logan County","county"
-6039,6,"06","Madera",2137.0005,37.20982,-119.7498,"Madera County","county"
-29075,29,"29","Gentry",491.43857,40.208126,-94.40531999999999,"Gentry County","county"
-31009,31,"31","Blaine",710.7124,41.931946,-99.99641,"Blaine County","county"
-49009,49,"49","Daggett",697.0099,40.8901,-109.50578,"Daggett County","county"
-56031,56,"56","Platte",2081.5193,42.13159,-104.95396399999998,"Platte County","county"
-37071,37,"37","Gaston",355.76132,35.293343,-81.17725,"Gaston County","county"
-35019,35,"35","Guadalupe",3029.8745,34.86978,-104.784966,"Guadalupe County","county"
-30037,30,"30","Golden Valley",1174.4625,46.380623,-109.17458,"Golden Valley County","county"
-37101,37,"37","Johnston",791.2477,35.51342,-78.36735,"Johnston County","county"
-6085,6,"06","Santa Clara",1291.1274,37.220695,-121.690506,"Santa Clara County","county"
-45019,45,"45","Charleston",917.9749,32.800457,-79.94248,"Charleston County","county"
-53005,53,"53","Benton",1700.1547,46.228127,-119.51666000000002,"Benton County","county"
-29001,29,"29","Adair",567.3431400000001,40.190666,-92.60359,"Adair County","county"
-39043,39,"39","Erie",251.3879,41.554005,-82.525894,"Erie County","county"
-17183,17,"17","Vermilion",898.3493,40.186752,-87.726776,"Vermilion County","county"
-29189,29,"29","St. Louis",507.45715,38.64069,-90.446075,"St. Louis County","county"
-17007,17,"17","Boone",280.77557,42.318985,-88.82429499999999,"Boone County","county"
-6103,6,"06","Tehama",2949.237,40.126156,-122.23228,"Tehama County","county"
-55025,55,"55","Dane",1196.5261,43.067467,-89.417854,"Dane County","county"
-48151,48,"48","Fisher",898.98145,32.740475,-100.40312,"Fisher County","county"
-22085,22,"22","Sabine Parish",866.68854,31.560402000000003,-93.55958000000001,"Sabine Parish","county"
-17137,17,"17","Morgan",568.9733,39.717667,-90.205,"Morgan County","county"
-13235,13,"13","Pulaski",249.26984,32.238803999999995,-83.48184,"Pulaski County","county"
-37015,37,"37","Bertie",699.2002,36.059044,-76.96236400000001,"Bertie County","county"
-37167,37,"37","Stanly",395.1468,35.310448,-80.25437,"Stanly County","county"
-47143,47,"47","Rhea",315.39365,35.600590000000004,-84.94955,"Rhea County","county"
-37079,37,"37","Greene",266.74374,35.48196,-77.68169,"Greene County","county"
-21131,21,"21","Leslie",400.86722000000003,37.087845,-83.38861999999999,"Leslie County","county"
-24039,24,"24","Somerset",319.75955,38.07445,-75.853325,"Somerset County","county"
-17123,17,"17","Marshall",386.827,41.03112,-89.34236999999999,"Marshall County","county"
-21143,21,"21","Lyon",213.84942999999998,37.023975,-88.08339000000001,"Lyon County","county"
-48095,48,"48","Concho",983.7886,31.318884000000004,-99.86365,"Concho County","county"
-48081,48,"48","Coke",911.6773699999999,31.87711,-100.63523,"Coke County","county"
-47133,47,"47","Overton",433.49994000000004,36.34485,-85.28307,"Overton County","county"
-26063,26,"26","Huron",836.0498,43.907616,-82.85705,"Huron County","county"
-26069,26,"26","Iosco",549.12305,44.329483,-82.84944,"Iosco County","county"
-13069,13,"13","Coffee",592.2734,31.549246000000004,-82.84494000000001,"Coffee County","county"
-13299,13,"13","Ware",899.2551,31.05088,-82.42151,"Ware County","county"
-38037,38,"38","Grant",1659.2894,46.357826,-101.639046,"Grant County","county"
-22051,22,"22","Jefferson Parish",295.70624,29.522282,-90.081,"Jefferson Parish","county"
-22103,22,"22","St. Tammany Parish",845.22705,30.410023,-89.951965,"St. Tammany Parish","county"
-19083,19,"19","Hardin",569.3290000000001,42.390209999999996,-93.24167,"Hardin County","county"
-22023,22,"22","Cameron Parish",1284.913,29.871813,-93.16495,"Cameron Parish","county"
-39027,39,"39","Clinton",408.6988,39.430225,-83.79568499999999,"Clinton County","county"
-27137,27,"27","St. Louis",6247.53,47.578635999999996,-92.51456999999999,"St. Louis County","county"
-39093,39,"39","Lorain",491.21414000000004,41.438805,-82.179726,"Lorain County","county"
-72143,72,"72","Vega Alta Municipio",27.729364,18.436163,-66.33667,"Vega Alta Municipio","county"
-19015,19,"19","Boone",571.5776400000001,42.038643,-93.938354,"Boone County","county"
-48373,48,"48","Polk",1057.0807,30.784552,-94.83734,"Polk County","county"
-31051,31,"31","Dixon",476.1265,42.485279999999996,-96.85585999999999,"Dixon County","county"
-24025,24,"24","Harford",437.13968,39.53743,-76.29979,"Harford County","county"
-45037,45,"45","Edgefield",500.76324000000005,33.776497,-81.96825,"Edgefield County","county"
-51001,51,"51","Accomack",449.32562,37.76594,-75.757805,"Accomack County","county"
-55015,55,"55","Calumet",318.29193,44.07841,-88.212135,"Calumet County","county"
-21121,21,"21","Knox",386.3173,36.8885,-83.85555,"Knox County","county"
-26067,26,"26","Ionia",571.339,42.94465,-85.07377,"Ionia County","county"
-37129,37,"37","New Hanover",192.25746,34.183440000000004,-77.86421,"New Hanover County","county"
-47131,47,"47","Obion",544.8659700000001,36.357994,-89.150024,"Obion County","county"
-21035,21,"21","Calloway",385.04355,36.620979999999996,-88.274086,"Calloway County","county"
-51003,51,"51","Albemarle",720.49414,38.024184999999996,-78.553505,"Albemarle County","county"
-47147,47,"47","Robertson",476.33047,36.527508000000005,-86.869354,"Robertson County","county"
-51043,51,"51","Clarke",175.9389,39.115307,-77.990746,"Clarke County","county"
-53023,53,"53","Garfield",710.8594400000001,46.429478,-117.53671000000001,"Garfield County","county"
-21109,21,"21","Jackson",345.2069,37.403458,-84.02058000000001,"Jackson County","county"
-27031,27,"27","Cook",1452.6177,47.53857,-90.29019,"Cook County","county"
-45073,45,"45","Oconee",626.5392,34.748764,-83.06154000000001,"Oconee County","county"
-22033,22,"22","East Baton Rouge Parish",455.40775,30.54393,-91.09313,"East Baton Rouge Parish","county"
-28021,28,"28","Claiborne",487.43195,31.972809,-90.91542,"Claiborne County","county"
-24037,24,"24","St. Mary's",358.70932,38.220290000000006,-76.53038000000001,"St. Mary's County","county"
-26081,26,"26","Kent",848.904,43.032497,-85.54745,"Kent County","county"
-37147,37,"37","Pitt",652.3917,35.592490000000005,-77.37274000000001,"Pitt County","county"
-30009,30,"30","Carbon",2047.7743,45.224470000000004,-109.02856000000001,"Carbon County","county"
-31167,31,"31","Stanton",427.62296,41.905045,-97.17711,"Stanton County","county"
-13001,13,"13","Appling",508.29117,31.739712,-82.2901,"Appling County","county"
-19099,19,"19","Jasper",730.4378,41.68555,-93.054146,"Jasper County","county"
-28153,28,"28","Wayne",810.7439,31.642504,-88.67821500000001,"Wayne County","county"
-48101,48,"48","Cottle",900.5941,34.091908000000004,-100.27644000000001,"Cottle County","county"
-51081,51,"51","Greensville",295.2371,36.680336,-77.56028,"Greensville County","county"
-12105,12,"12","Polk",1797.5999,27.95365,-81.693535,"Polk County","county"
-48503,48,"48","Young",914.5294,33.15878,-98.67839000000001,"Young County","county"
-1123,1,"01","Tallapoosa",716.54614,32.863308,-85.799614,"Tallapoosa County","county"
-33015,33,"33","Rockingham",695.4101,42.988663,-71.09908,"Rockingham County","county"
-8105,8,"08","Rio Grande",911.9873699999999,37.485855,-106.453125,"Rio Grande County","county"
-19149,19,"19","Plymouth",862.8577,42.737587,-96.215866,"Plymouth County","county"
-36123,36,"36","Yates",338.16033999999996,42.638237,-77.104324,"Yates County","county"
-53033,53,"53","King",2115.3547,47.4906,-121.834,"King County","county"
-41017,41,"41","Deschutes",3017.719,43.91512,-121.22558000000001,"Deschutes County","county"
-19155,19,"19","Pottawattamie",950.5432,41.340183,-95.54491,"Pottawattamie County","county"
-29229,29,"29","Wright",681.79785,37.26763,-92.47999,"Wright County","county"
-30101,30,"30","Toole",1915.0812,48.645126,-111.733475,"Toole County","county"
-36107,36,"36","Tioga",518.6279,42.178055,-76.297455,"Tioga County","county"
-48287,48,"48","Lee",629.04297,30.321499,-96.97681999999999,"Lee County","county"
-13121,13,"13","Fulton",526.7417,33.790034999999996,-84.46818,"Fulton County","county"
-48073,48,"48","Cherokee",1052.9911,31.843882,-95.15634,"Cherokee County","county"
-29007,29,"29","Audrain",692.2684,39.21448,-91.84342,"Audrain County","county"
-45029,45,"45","Colleton",1056.5164,32.83502,-80.65524,"Colleton County","county"
-55055,55,"55","Jefferson",556.5103,43.013805,-88.77399,"Jefferson County","county"
-5055,5,"05","Greene",577.70795,36.120605,-90.566345,"Greene County","county"
-48191,48,"48","Hall",883.5219999999999,34.655623999999996,-100.76389,"Hall County","county"
-55013,55,"55","Burnett",821.5888,45.866898,-92.37573,"Burnett County","county"
-35057,35,"35","Torrance",3345.3267,34.554977,-105.89056000000001,"Torrance County","county"
-53049,53,"53","Pacific",933.6411,46.556587,-123.78242,"Pacific County","county"
-37141,37,"37","Pender",871.32526,34.512558,-77.88811,"Pender County","county"
-48221,48,"48","Hood",420.7229,32.43015,-97.83168,"Hood County","county"
-46117,46,"46","Stanley",1444.4807,44.415546,-100.74916,"Stanley County","county"
-32031,32,"32","Washoe",6316.375,40.731320000000004,-119.66327,"Washoe County","county"
-21007,21,"21","Ballard",246.87727,37.051323,-89.01037,"Ballard County","county"
-48009,48,"48","Archer",903.3199,33.616306,-98.68726,"Archer County","county"
-48023,48,"48","Baylor",867.5102,33.6188,-99.20819,"Baylor County","county"
-48405,48,"48","San Augustine",530.675,31.38245,-94.16318000000001,"San Augustine County","county"
-32029,32,"32","Storey",263.9796,39.438385,-119.52463999999999,"Storey County","county"
-13249,13,"13","Schley",166.91425,32.263443,-84.32271,"Schley County","county"
-9001,9,"09","Fairfield",624.9892,41.227413,-73.36706,"Fairfield County","county"
-48313,48,"48","Madison",466.08112,30.966879,-95.930374,"Madison County","county"
-6077,6,"06","San Joaquin",1392.3811,37.934982,-121.27225,"San Joaquin County","county"
-28159,28,"28","Winston",607.2718,33.078724,-89.03739,"Winston County","county"
-21103,21,"21","Henry",286.3046,38.45138,-85.119644,"Henry County","county"
-21167,21,"21","Mercer",249.0698,37.812084000000006,-84.87969,"Mercer County","county"
-31183,31,"31","Wheeler",575.2029,41.922573,-98.52085,"Wheeler County","county"
-21135,21,"21","Lewis",482.85593,38.535046,-83.37014,"Lewis County","county"
-27051,27,"27","Grant",547.8149400000001,45.930744,-96.0107,"Grant County","county"
-28053,28,"28","Humphreys",418.52862999999996,33.130997,-90.52342,"Humphreys County","county"
-1025,1,"01","Clarke",1238.4625,31.68552,-87.81863,"Clarke County","county"
-20017,20,"20","Chase",773.0798,38.299477,-96.59403,"Chase County","county"
-21221,21,"21","Trigg",441.57599999999996,36.807682,-87.85865,"Trigg County","county"
-1069,1,"01","Houston",579.8755,31.158184000000002,-85.29641,"Houston County","county"
-46003,46,"46","Aurora",708.4841,43.72472,-98.57759,"Aurora County","county"
-2013,2,"02","Aleutians East Borough",6985.406,55.245045,-161.99748,"Aleutians East Borough","county"
-31061,31,"31","Franklin",575.8353,40.183205,-98.96208,"Franklin County","county"
-24029,24,"24","Kent",277.04407000000003,39.241279999999996,-76.125984,"Kent County","county"
-20037,20,"20","Crawford",589.7905,37.50582,-94.8539,"Crawford County","county"
-27023,27,"27","Chippewa",581.2040400000001,45.028625,-95.56411,"Chippewa County","county"
-46103,46,"46","Pennington",2776.8596,44.00235,-102.8238,"Pennington County","county"
-45049,45,"45","Hampton",559.9937,32.778335999999996,-81.14381999999999,"Hampton County","county"
-16043,16,"16","Fremont",1864.023,44.218090000000004,-111.48443,"Fremont County","county"
-13029,13,"13","Bryan",437.56244000000004,32.01797,-81.43854499999999,"Bryan County","county"
-51053,51,"51","Dinwiddie",503.90128,37.073498,-77.63549,"Dinwiddie County","county"
-12111,12,"12","St. Lucie",571.67,27.379814,-80.443535,"St. Lucie County","county"
-36055,36,"36","Monroe",656.89026,43.464484999999996,-77.66466,"Monroe County","county"
-46083,46,"46","Lincoln",577.3127,43.27942,-96.72228,"Lincoln County","county"
-55017,55,"55","Chippewa",1008.3897,45.06909,-91.28350999999999,"Chippewa County","county"
-20207,20,"20","Woodson",497.83557,37.88819,-95.75846999999999,"Woodson County","county"
-21157,21,"21","Marshall",302.21555,36.882015,-88.332756,"Marshall County","county"
-13065,13,"13","Clinch",815.02344,30.917654,-82.702614,"Clinch County","county"
-13185,13,"13","Lowndes",497.17602999999997,30.833145000000002,-83.26899999999999,"Lowndes County","county"
-15005,15,"15","Kalawao",11.991816,21.218764999999998,-156.97401000000002,"Kalawao County","county"
-15007,15,"15","Kauai",619.90515,22.01204,-159.70596,"Kauai County","county"
-26099,26,"26","Macomb",479.1886,42.67155,-82.91145,"Macomb County","county"
-13287,13,"13","Turner",285.425,31.7248,-83.62031999999999,"Turner County","county"
-17079,17,"17","Jasper",494.63055,39.004875,-88.150764,"Jasper County","county"
-48331,48,"48","Milam",1016.9566,30.791242999999998,-96.9844,"Milam County","county"
-18147,18,"18","Spencer",396.78125,38.009696999999996,-87.01037600000001,"Spencer County","county"
-21099,21,"21","Hart",412.57583999999997,37.309096999999994,-85.882126,"Hart County","county"
-21137,21,"21","Lincoln",332.8546,37.457172,-84.65833,"Lincoln County","county"
-30005,30,"30","Blaine",4227.266,48.428284000000005,-108.96763999999999,"Blaine County","county"
-51710,51,"51","Norfolk city",53.276737,36.923016,-76.244644,"Norfolk city","county"
-48389,48,"48","Reeves",2635.4429999999998,31.308366999999997,-103.71271,"Reeves County","county"
-51155,51,"51","Pulaski",319.84902999999997,37.063385,-80.71345,"Pulaski County","county"
-37179,37,"37","Union",632.7448,34.991820000000004,-80.530426,"Union County","county"
-38053,38,"38","McKenzie",2760.2273,47.742474,-103.40321,"McKenzie County","county"
-12091,12,"12","Okaloosa",930.2568,30.665852,-86.594185,"Okaloosa County","county"
-6001,6,"06","Alameda",737.3315,37.647137,-121.91248999999999,"Alameda County","county"
-17013,17,"17","Calhoun",253.84085,39.16426,-90.6663,"Calhoun County","county"
-18085,18,"18","Kosciusko",531.4538,41.244293,-85.86157,"Kosciusko County","county"
-28103,28,"28","Noxubee",695.182,33.106506,-88.566,"Noxubee County","county"
-5147,5,"05","Woodruff",586.8063400000001,35.192776,-91.24454,"Woodruff County","county"
-34015,34,"34","Gloucester",321.98776000000004,39.722874,-75.145676,"Gloucester County","county"
-33011,33,"33","Hillsborough",876.558,42.911533,-71.72305,"Hillsborough County","county"
-30045,30,"30","Judith Basin",1869.7505,47.03256,-110.30532,"Judith Basin County","county"
-37121,37,"37","Mitchell",221.25806,36.013103,-82.16355,"Mitchell County","county"
-30077,30,"30","Powell",2326.121,46.844227000000004,-112.9311,"Powell County","county"
-41053,41,"41","Polk",740.9488,44.900375,-123.398674,"Polk County","county"
-41065,41,"41","Wasco",2381.2163,45.164536,-121.16507,"Wasco County","county"
-46105,46,"46","Perkins",2870.5576,45.483387,-102.467995,"Perkins County","county"
-19173,19,"19","Taylor",531.91974,40.73795,-94.69710500000001,"Taylor County","county"
-1129,1,"01","Washington",1080.2426,31.405217999999998,-88.19756,"Washington County","county"
-39039,39,"39","Defiance",411.4637,41.32168,-84.486435,"Defiance County","county"
-54025,54,"54","Greenbrier",1019.84766,37.92442,-80.45059,"Greenbrier County","county"
-17121,17,"17","Marion",572.5570700000001,38.648235,-88.920364,"Marion County","county"
-51051,51,"51","Dickenson",330.4618,37.1367,-82.34921999999999,"Dickenson County","county"
-51007,51,"51","Amelia",355.37253,37.33193,-77.97746,"Amelia County","county"
-13243,13,"13","Randolph",428.2506,31.762651,-84.75231,"Randolph County","county"
-35029,35,"35","Luna",2965.2793,32.184525,-107.74718999999999,"Luna County","county"
-48355,48,"48","Nueces",838.3246,27.740032,-97.51621,"Nueces County","county"
-56045,56,"56","Weston",2398.0864,43.846214,-104.57002,"Weston County","county"
-72137,72,"72","Toa Baja Municipio",23.244795,18.45691,-66.19319,"Toa Baja Municipio","county"
-17187,17,"17","Warren",542.4025,40.85044,-90.620224,"Warren County","county"
-1089,1,"01","Madison",801.6186,34.764236,-86.55108,"Madison County","county"
-47189,47,"47","Wilson",571.10724,36.14953,-86.29124499999999,"Wilson County","county"
-48063,48,"48","Camp",195.85428000000002,32.974583,-94.97909,"Camp County","county"
-40067,40,"40","Jefferson",758.98145,34.105083,-97.83889,"Jefferson County","county"
-54085,54,"54","Ritchie",452.00543,39.177113,-81.066315,"Ritchie County","county"
-19145,19,"19","Page",534.9618,40.739090000000004,-95.14429,"Page County","county"
-20087,20,"20","Jefferson",532.5885,39.239643,-95.37531,"Jefferson County","county"
-22045,22,"22","Iberia Parish",574.11285,30.007126,-91.97678,"Iberia Parish","county"
-2158,2,"02","Kusilvak Census Area",17074.797,62.283590000000004,-163.19017,"Kusilvak Census Area","county"
-37133,37,"37","Onslow",762.0969,34.763107,-77.499466,"Onslow County","county"
-27043,27,"27","Faribault",712.5021,43.676520000000004,-93.94723499999999,"Faribault County","county"
-47057,47,"47","Grainger",280.59607,36.277508000000005,-83.50954399999999,"Grainger County","county"
-48161,48,"48","Freestone",877.7605,31.701748,-96.14496,"Freestone County","county"
-42087,42,"42","Mifflin",411.0592,40.601616,-77.65183,"Mifflin County","county"
-1041,1,"01","Crenshaw",608.8856,31.732826,-86.31922,"Crenshaw County","county"
-51520,51,"51","Bristol city",12.904041000000001,36.616955,-82.15756,"Bristol city","county"
-48399,48,"48","Runnels",1051.106,31.84512,-99.98271,"Runnels County","county"
-48443,48,"48","Terrell",2358.0376,30.232342,-102.07251,"Terrell County","county"
-20153,20,"20","Rawlins",1069.4528,39.786198,-101.07674,"Rawlins County","county"
-20193,20,"20","Thomas",1074.723,39.35771,-101.08339000000001,"Thomas County","county"
-13161,13,"13","Jeff Davis",330.92914,31.811615000000003,-82.636826,"Jeff Davis County","county"
-19035,19,"19","Cherokee",576.9262,42.742737,-95.63325999999999,"Cherokee County","county"
-5145,5,"05","White",1035.1088,35.25512,-91.75304,"White County","county"
-28083,28,"28","Leflore",594.0946700000001,33.54979,-90.29494,"Leflore County","county"
-29053,29,"29","Cooper",564.77234,38.845387,-92.812325,"Cooper County","county"
-26043,26,"26","Dickinson",760.97345,46.012825,-87.86612,"Dickinson County","county"
-17197,17,"17","Will",835.8993,41.448475,-87.97845500000001,"Will County","county"
-48117,48,"48","Deaf Smith",1496.8727,34.940765,-102.60757,"Deaf Smith County","county"
-46011,46,"46","Brookings",792.2533599999999,44.376675,-96.7978,"Brookings County","county"
-29047,29,"29","Clay",397.6789,39.31555,-94.4215,"Clay County","county"
-28027,28,"28","Coahoma",552.5075,34.22867,-90.603165,"Coahoma County","county"
-18011,18,"18","Boone",422.92633,40.05089,-86.46902,"Boone County","county"
-19057,19,"19","Des Moines",416.14285,40.91534,-91.18693,"Des Moines County","county"
-19163,19,"19","Scott",458.1018,41.64208,-90.62229,"Scott County","county"
-20143,20,"20","Ottawa",720.75494,39.137962,-97.6548,"Ottawa County","county"
-12023,12,"12","Columbia",797.5784,30.221651,-82.623375,"Columbia County","county"
-12059,12,"12","Holmes",478.8729,30.862007000000002,-85.81594,"Holmes County","county"
-28047,28,"28","Harrison",573.6614,30.416535999999997,-89.08337399999999,"Harrison County","county"
-72141,72,"72","Utuado Municipio",113.53542,18.270864000000003,-66.70299,"Utuado Municipio","county"
-47011,47,"47","Bradley",328.77297999999996,35.153915000000005,-84.85941,"Bradley County","county"
-27017,27,"27","Carlton",861.33325,46.603817,-92.67104,"Carlton County","county"
-48315,48,"48","Marion",380.89697,32.798183,-94.35685,"Marion County","county"
-36095,36,"36","Schoharie",621.8401,42.591293,-74.43817,"Schoharie County","county"
-40117,40,"40","Pawnee",568.37067,36.313705,-96.69667,"Pawnee County","county"
-36007,36,"36","Broome",705.8425,42.161976,-75.83028399999999,"Broome County","county"
-48291,48,"48","Liberty",1158.3828,30.158508,-94.84406,"Liberty County","county"
-39009,39,"39","Athens",503.64374000000004,39.332603000000006,-82.045845,"Athens County","county"
-39081,39,"39","Jefferson",408.13815,40.399384000000005,-80.76353,"Jefferson County","county"
-54083,54,"54","Randolph",1039.7355,38.781094,-79.86779,"Randolph County","county"
-54049,54,"54","Marion",308.7636,39.50584,-80.2434,"Marion County","county"
-34011,34,"34","Cumberland",483.37708,39.328434,-75.12163000000001,"Cumberland County","county"
-6057,6,"06","Nevada",957.7927,39.297509999999996,-120.77134,"Nevada County","county"
-55031,55,"55","Douglas",1304.3369,46.46322,-91.89248,"Douglas County","county"
-21199,21,"21","Pulaski",658.4328,37.107372,-84.57695,"Pulaski County","county"
-37065,37,"37","Edgecombe",505.44995,35.917076,-77.602745,"Edgecombe County","county"
-48241,48,"48","Jasper",938.68695,30.752932,-94.02229,"Jasper County","county"
-49001,49,"49","Beaver",2582.9885,38.357535999999996,-113.238945,"Beaver County","county"
-13213,13,"13","Murray",344.50565,34.797096,-84.73799,"Murray County","county"
-18075,18,"18","Jay",383.91832999999997,40.434956,-85.002335,"Jay County","county"
-26117,26,"26","Montcalm",705.3529,43.312782,-85.14947,"Montcalm County","county"
-36083,36,"36","Rensselaer",652.4777,42.71042,-73.51385,"Rensselaer County","county"
-12021,12,"12","Collier",1997.006,26.118786,-81.40095500000001,"Collier County","county"
-35031,35,"35","McKinley",5450.8643,35.583878000000006,-108.25326499999998,"McKinley County","county"
-13017,13,"13","Ben Hill",250.13034,31.740771999999996,-83.147194,"Ben Hill County","county"
-5077,5,"05","Lee",602.6417,34.779507,-90.77972,"Lee County","county"
-12003,12,"12","Baker",585.25,30.324441999999998,-82.302284,"Baker County","county"
-13173,13,"13","Lanier",196.54283,31.038196999999997,-83.06316,"Lanier County","county"
-20159,20,"20","Rice",726.2582,38.34718,-98.20141600000001,"Rice County","county"
-1015,1,"01","Calhoun",605.8903,33.770515,-85.82791,"Calhoun County","county"
-28059,28,"28","Jackson",722.82166,30.456004999999998,-88.6251,"Jackson County","county"
-21037,21,"21","Campbell",151.34506000000002,38.946979999999996,-84.37958499999999,"Campbell County","county"
-21057,21,"21","Cumberland",305.20602,36.78237,-85.38848,"Cumberland County","county"
-28107,28,"28","Panola",685.19836,34.365204,-89.963066,"Panola County","county"
-48195,48,"48","Hansford",919.8412,36.272846,-101.35693,"Hansford County","county"
-48071,48,"48","Chambers",597.173,29.696375,-94.66945,"Chambers County","county"
-13239,13,"13","Quitman",151.24255,31.862938,-85.0048,"Quitman County","county"
-48199,48,"48","Hardin",890.6183,30.329649,-94.39318,"Hardin County","county"
-9005,9,"09","Litchfield",920.5453,41.79188,-73.235405,"Litchfield County","county"
-39143,39,"39","Sandusky",408.25937000000005,41.35532,-83.14278,"Sandusky County","county"
-23021,23,"23","Piscataquis",3961.1638,45.915638,-69.102234,"Piscataquis County","county"
-17153,17,"17","Pulaski",199.32245,37.215614,-89.12775400000001,"Pulaski County","county"
-40107,40,"40","Okfuskee",618.467,35.466805,-96.32776,"Okfuskee County","county"
-26145,26,"26","Saginaw",800.7312,43.328266,-84.05541,"Saginaw County","county"
-35039,35,"35","Rio Arriba",5861.071999999999,36.50967,-106.69398500000001,"Rio Arriba County","county"
-50005,50,"50","Caledonia",649.0415,44.468792,-72.11216999999999,"Caledonia County","county"
-51023,51,"51","Botetourt",541.2952,37.565483,-79.79755,"Botetourt County","county"
-17119,17,"17","Madison",715.5304,38.827118,-89.90023000000001,"Madison County","county"
-48085,48,"48","Collin",841.4307,33.19453,-96.57944499999999,"Collin County","county"
-45001,45,"45","Abbeville",491.44363,34.229042,-82.45405600000001,"Abbeville County","county"
-31053,31,"31","Dodge",529.082,41.577007,-96.64585,"Dodge County","county"
-12115,12,"12","Sarasota",556.0053,27.184385,-82.36584,"Sarasota County","county"
-55077,55,"55","Marquette",455.72733,43.826054,-89.40909599999999,"Marquette County","county"
-4015,4,"04","Mohave",13332.313,35.717705,-113.74968999999999,"Mohave County","county"
-4025,4,"04","Yavapai",8123.3745,34.63107,-112.577225,"Yavapai County","county"
-45051,45,"45","Horry",1133.0375,33.90927,-78.97668,"Horry County","county"
-42091,42,"42","Montgomery",482.98287999999997,40.21,-75.3702,"Montgomery County","county"
-16061,16,"16","Lewis",478.83777000000003,46.23633,-116.42376000000002,"Lewis County","county"
-72013,72,"72","Arecibo Municipio",125.942924,18.434004,-66.674995,"Arecibo Municipio","county"
-51720,51,"51","Norton city",7.4775524,36.93155,-82.626,"Norton city","county"
-34027,34,"34","Morris",460.97475999999995,40.858894,-74.54729499999999,"Morris County","county"
-29211,29,"29","Sullivan",648.0038,40.209587,-93.10978,"Sullivan County","county"
-20135,20,"20","Ness",1074.776,38.48044,-99.908745,"Ness County","county"
-48039,48,"48","Brazoria",1363.3168,29.167818,-95.43465,"Brazoria County","county"
-51790,51,"51","Staunton city",19.921162,38.157978,-79.061874,"Staunton city","county"
-31029,31,"31","Chase",894.449,40.530390000000004,-101.69419,"Chase County","county"
-39113,39,"39","Montgomery",461.53375,39.753735,-84.29059000000001,"Montgomery County","county"
-48447,48,"48","Throckmorton",912.5833,33.170696,-99.205795,"Throckmorton County","county"
-13221,13,"13","Oglethorpe",439.0773,33.866806,-83.07408000000001,"Oglethorpe County","county"
-5029,5,"05","Conway",552.29474,35.2657,-92.68925,"Conway County","county"
-29147,29,"29","Nodaway",876.99396,40.361137,-94.88315,"Nodaway County","county"
-38073,38,"38","Ransom",862.5016,46.449276,-97.64755,"Ransom County","county"
-26017,26,"26","Bay",442.2561,43.699709999999996,-83.9787,"Bay County","county"
-47157,47,"47","Shelby",763.5857,35.183796,-89.89539,"Shelby County","county"
-6007,6,"06","Butte",1636.545,39.66596,-121.60191999999999,"Butte County","county"
-27115,27,"27","Pine",1411.3367,46.10094,-92.76309,"Pine County","county"
-48021,48,"48","Bastrop",888.2349,30.10077,-97.31064,"Bastrop County","county"
-53039,53,"53","Klickitat",1871.7001,45.870445000000004,-120.77930500000001,"Klickitat County","county"
-53055,53,"53","San Juan",173.91756999999998,48.50719,-123.10377,"San Juan County","county"
-55009,55,"55","Brown",530.1105,44.474026,-87.99613000000001,"Brown County","county"
-20205,20,"20","Wilson",570.4412,37.558514,-95.74518,"Wilson County","county"
-22069,22,"22","Natchitoches Parish",1252.3174,31.732552000000002,-93.08261,"Natchitoches Parish","county"
-22109,22,"22","Terrebonne Parish",1229.8698,29.33413,-90.84366999999999,"Terrebonne Parish","county"
-13155,13,"13","Irwin",354.3748,31.604305,-83.27704,"Irwin County","county"
-2185,2,"02","North Slope Borough",88827.46,69.44934,-153.47281999999998,"North Slope Borough","county"
-26011,26,"26","Arenac",363.19073,44.03683,-83.74068,"Arenac County","county"
-19111,19,"19","Lee",517.5677,40.647587,-91.47716,"Lee County","county"
-20141,20,"20","Osborne",892.546,39.348259999999996,-98.767944,"Osborne County","county"
-26047,26,"26","Emmet",467.53638,45.590096,-84.986824,"Emmet County","county"
-19071,19,"19","Fremont",511.1841,40.74259,-95.59918,"Fremont County","county"
-23015,23,"23","Lincoln",455.88208,43.99478,-69.513626,"Lincoln County","county"
-36099,36,"36","Seneca",323.72046,42.782295,-76.82709,"Seneca County","county"
-21125,21,"21","Laurel",434.00300000000004,37.113265999999996,-84.11939,"Laurel County","county"
-47121,47,"47","Meigs",195.14177,35.512203,-84.8161,"Meigs County","county"
-29213,29,"29","Taney",632.39197,36.649826000000004,-93.042816,"Taney County","county"
-13269,13,"13","Taylor",376.69912999999997,32.55467,-84.25143,"Taylor County","county"
-51830,51,"51","Williamsburg city",8.940619,37.26948,-76.70819,"Williamsburg city","county"
-48415,48,"48","Scurry",905.4753,32.744354,-100.91334499999999,"Scurry County","county"
-8047,8,"08","Gilpin",150.0277,39.861156,-105.52888,"Gilpin County","county"
-40087,40,"40","McClain",570.7364,35.016438,-97.44981,"McClain County","county"
-54071,54,"54","Pendleton",696.0730599999999,38.67445,-79.340614,"Pendleton County","county"
-51139,51,"51","Page",310.03116,38.623207,-78.491875,"Page County","county"
-40079,40,"40","Le Flore",1589.2501,34.897358000000004,-94.695076,"Le Flore County","county"
-54089,54,"54","Summers",360.60474,37.656,-80.85632,"Summers County","county"
-37119,37,"37","Mecklenburg",523.5989400000001,35.24686,-80.83383,"Mecklenburg County","county"
-34013,34,"34","Essex",126.08883,40.7874,-74.24629,"Essex County","county"
-29115,29,"29","Linn",615.6093,39.86444,-93.10802,"Linn County","county"
-13209,13,"13","Montgomery",241.15335,32.172108,-82.53335,"Montgomery County","county"
-41055,41,"41","Sherman",823.6424599999999,45.399215999999996,-120.67851,"Sherman County","county"
-13133,13,"13","Greene",387.67645,33.57674,-83.16660999999999,"Greene County","county"
-46017,46,"46","Buffalo",471.4212,44.044308,-99.20399499999999,"Buffalo County","county"
-46095,46,"46","Mellette",1307.3699,43.58469,-100.76095600000001,"Mellette County","county"
-48135,48,"48","Ector",897.8425,31.865301000000002,-102.5425,"Ector County","county"
-48293,48,"48","Limestone",905.4609,31.547543,-96.59362,"Limestone County","county"
-53027,53,"53","Grays Harbor",1901.5276,47.11373,-123.82673999999999,"Grays Harbor County","county"
-54003,54,"54","Berkeley",321.15945,39.447936999999996,-78.03775,"Berkeley County","county"
-72149,72,"72","Villalba Municipio",35.637890000000006,18.130717999999998,-66.47224399999999,"Villalba Municipio","county"
-30067,30,"30","Park",2802.5657,45.42143,-110.53276000000001,"Park County","county"
-48121,48,"48","Denton",879.6072,33.20513,-97.12114,"Denton County","county"
-45021,45,"45","Cherokee",393.34955,35.049797,-81.60764,"Cherokee County","county"
-37199,37,"37","Yancey",312.6028,35.889324,-82.303955,"Yancey County","county"
-48387,48,"48","Red River",1043.9116,33.619625,-95.04843000000001,"Red River County","county"
-48321,48,"48","Matagorda",1092.9393,28.774759999999997,-96.00153,"Matagorda County","county"
-27149,27,"27","Stevens",563.62964,45.59346,-95.99231999999999,"Stevens County","county"
-13301,13,"13","Warren",284.36758,33.41917,-82.68800999999999,"Warren County","county"
-48197,48,"48","Hardeman",695.1378,34.2899,-99.7457,"Hardeman County","county"
-17133,17,"17","Monroe",385.33865,38.277985,-90.17908,"Monroe County","county"
-13165,13,"13","Jenkins",347.33673,32.794563000000004,-81.97153,"Jenkins County","county"
-21085,21,"21","Grayson",499.94504000000006,37.458576,-86.34401,"Grayson County","county"
-48363,48,"48","Palo Pinto",952.5814,32.752205,-98.31796999999999,"Palo Pinto County","county"
-13149,13,"13","Heard",295.98233,33.291348,-85.137886,"Heard County","county"
-1079,1,"01","Lawrence",690.7078,34.529778,-87.32186999999999,"Lawrence County","county"
-72061,72,"72","Guaynabo Municipio",27.585866999999997,18.344357000000002,-66.11405,"Guaynabo Municipio","county"
-28093,28,"28","Marshall",706.20917,34.76619,-89.504234,"Marshall County","county"
-20025,20,"20","Clark",974.6709599999999,37.23383,-99.813866,"Clark County","county"
-20081,20,"20","Haskell",577.5407,37.554977,-100.87995,"Haskell County","county"
-22013,22,"22","Bienville Parish",811.3083,32.34095,-93.04115,"Bienville Parish","county"
-13295,13,"13","Walker",446.40536,34.7358,-85.30546,"Walker County","county"
-19095,19,"19","Iowa",586.47504,41.683918,-92.05912,"Iowa County","county"
-31019,31,"31","Buffalo",968.2533,40.855225,-99.07498000000001,"Buffalo County","county"
-40007,40,"40","Beaver",1814.8993,36.748333,-100.48305500000001,"Beaver County","county"
-19023,19,"19","Butler",580.1578400000001,42.734756,-92.78015,"Butler County","county"
-30085,30,"30","Roosevelt",2354.6824,48.282745,-104.99517,"Roosevelt County","county"
-72017,72,"72","Barceloneta Municipio",18.696434,18.46999,-66.55823000000001,"Barceloneta Municipio","county"
-53015,53,"53","Cowlitz",1141.212,46.196785,-122.67846000000002,"Cowlitz County","county"
-48297,48,"48","Live Oak",1039.7301,28.351536,-98.12696,"Live Oak County","county"
-29135,29,"29","Moniteau",415.0421,38.633038,-92.58364,"Moniteau County","county"
-51193,51,"51","Westmoreland",229.33345,38.10931,-76.80393000000001,"Westmoreland County","county"
-37197,37,"37","Yadkin",334.95352,36.158764,-80.66516,"Yadkin County","county"
-6047,6,"06","Merced",1936.1777,37.194805,-120.7228,"Merced County","county"
-40043,40,"40","Dewey",999.6687599999999,35.977959999999996,-99.01438,"Dewey County","county"
-37023,37,"37","Burke",506.25388,35.746179999999995,-81.70618,"Burke County","county"
-37191,37,"37","Wayne",553.9377400000001,35.35419,-78.00867,"Wayne County","county"
-42123,42,"42","Warren",884.16864,41.834297,-79.29818,"Warren County","county"
-5061,5,"05","Howard",588.58655,34.083065000000005,-93.99093,"Howard County","county"
-37059,37,"37","Davie",263.7034,35.929356,-80.54255,"Davie County","county"
-37111,37,"37","McDowell",439.96964,35.68227,-82.04804,"McDowell County","county"
-5099,5,"05","Nevada",617.8641,33.6667,-93.30507,"Nevada County","county"
-8125,8,"08","Yuma",2364.4788,40.00077,-102.421646,"Yuma County","county"
-48421,48,"48","Sherman",922.89105,36.27859,-101.89926,"Sherman County","county"
-48463,48,"48","Uvalde",1551.9734,29.350307,-99.768425,"Uvalde County","county"
-39011,39,"39","Auglaize",401.4017,40.56131,-84.224014,"Auglaize County","county"
-22015,22,"22","Bossier Parish",840.3432,32.698483,-93.626564,"Bossier Parish","county"
-19063,19,"19","Emmet",395.90305,43.377983,-94.66937,"Emmet County","county"
-20169,20,"20","Saline",720.2665,38.791805,-97.65148,"Saline County","county"
-21153,21,"21","Magoffin",308.45468,37.698982,-83.06971999999999,"Magoffin County","county"
-48017,48,"48","Bailey",826.99994,34.06752,-102.830345,"Bailey County","county"
-29027,29,"29","Callaway",834.5952,38.83555,-91.92345,"Callaway County","county"
-56001,56,"56","Albany",4274.472,41.665516,-105.72188600000001,"Albany County","county"
-56029,56,"56","Park",6939.275,44.492385999999996,-109.5936,"Park County","county"
-42093,42,"42","Montour",130.24683000000002,41.029284999999994,-76.66521999999999,"Montour County","county"
-36081,36,"36","Queens",108.78198,40.658566,-73.83802,"Queens County","county"
-12121,12,"12","Suwannee",688.5757,30.189242999999998,-82.99275,"Suwannee County","county"
-26031,26,"26","Cheboygan",715.29865,45.47602,-84.49543,"Cheboygan County","county"
-26051,26,"26","Gladwin",501.80334000000005,43.98975,-84.38982,"Gladwin County","county"
-21173,21,"21","Montgomery",197.35619,38.038109999999996,-83.912415,"Montgomery County","county"
-45057,45,"45","Lancaster",549.087,34.686817,-80.70369000000001,"Lancaster County","county"
-21123,21,"21","Larue",261.56186,37.544464000000005,-85.69684000000001,"Larue County","county"
-19193,19,"19","Woodbury",872.9259599999999,42.39322,-96.0533,"Woodbury County","county"
-12123,12,"12","Taylor",1043.3531,30.009909000000004,-83.60948,"Taylor County","county"
-17003,17,"17","Alexander",235.40205,37.183659999999996,-89.34952,"Alexander County","county"
-29099,29,"29","Jefferson",656.48956,38.25763,-90.54368000000001,"Jefferson County","county"
-29113,29,"29","Lincoln",626.5916,39.062256,-90.96291,"Lincoln County","county"
-13051,13,"13","Chatham",433.1314,31.980403999999997,-81.08518000000001,"Chatham County","county"
-12125,12,"12","Union",243.56328,30.05428,-82.36692,"Union County","county"
-36037,36,"36","Genesee",492.9555,43.000908,-78.19278,"Genesee County","county"
-19041,19,"19","Clay",567.2572,43.081223,-95.14986999999999,"Clay County","county"
-30025,30,"30","Fallon",1620.6497,46.318184,-104.405716,"Fallon County","county"
-46107,46,"46","Potter",861.16705,45.05271,-99.962006,"Potter County","county"
-48109,48,"48","Culberson",3812.2861,31.445908000000003,-104.52695,"Culberson County","county"
-23005,23,"23","Cumberland",835.9734,43.80835,-70.330376,"Cumberland County","county"
-48013,48,"48","Atascosa",1219.5825,28.891478000000003,-98.53538,"Atascosa County","county"
-20095,20,"20","Kingman",863.4484,37.55295,-98.14453,"Kingman County","county"
-13241,13,"13","Rabun",370.1527,34.883934,-83.40486999999999,"Rabun County","county"
-54097,54,"54","Upshur",354.64957000000004,38.90253,-80.231606,"Upshur County","county"
-29215,29,"29","Texas",1177.3057,37.314254999999996,-91.96448000000001,"Texas County","county"
-5119,5,"05","Pulaski",758.4617,34.770309999999995,-92.312996,"Pulaski County","county"
-19047,19,"19","Crawford",714.2139999999999,42.043118,-95.38909,"Crawford County","county"
-16005,16,"16","Bannock",1112.5292,42.69292,-112.22898,"Bannock County","county"
-39055,39,"39","Geauga",400.3141,41.499320000000004,-81.17351,"Geauga County","county"
-72035,72,"72","Cayey Municipio",51.93632,18.103624,-66.15166500000001,"Cayey Municipio","county"
-6107,6,"06","Tulare",4824.468,36.228832000000004,-118.78105,"Tulare County","county"
-72015,72,"72","Arroyo Municipio",15.008104000000001,17.97206,-66.04195,"Arroyo Municipio","county"
-72125,72,"72","San Germán Municipio",54.49825,18.1078,-67.03726,"San Germán Municipio","county"
-36117,36,"36","Wayne",603.8507,43.45876,-77.06316,"Wayne County","county"
-51163,51,"51","Rockbridge",596.5628,37.814518,-79.447754,"Rockbridge County","county"
-38095,38,"38","Towner",1024.9437,48.682182,-99.24816,"Towner County","county"
-42045,42,"42","Delaware",183.82106000000002,39.916686999999996,-75.39882,"Delaware County","county"
-36063,36,"36","Niagara",522.3706,43.45673,-78.79214499999999,"Niagara County","county"
-50003,50,"50","Bennington",675.0193,43.035323999999996,-73.11146,"Bennington County","county"
-12019,12,"12","Clay",604.63586,29.986584000000004,-81.865036,"Clay County","county"
-37183,37,"37","Wake",834.8569,35.789845,-78.65063,"Wake County","county"
-39061,39,"39","Hamilton",405.42096000000004,39.196926,-84.54419,"Hamilton County","county"
-34003,34,"34","Bergen",232.7932,40.959697999999996,-74.07473,"Bergen County","county"
-32017,32,"32","Lincoln",10633.747,37.634605,-114.86303999999998,"Lincoln County","county"
-2180,2,"02","Nome Census Area",22970.799,64.78368,-164.18892,"Nome Census Area","county"
-30055,30,"30","McCone",2642.3152,47.629627,-105.757225,"McCone County","county"
-19019,19,"19","Buchanan",571.09937,42.47033,-91.83867,"Buchanan County","county"
-17043,17,"17","DuPage",327.7701,41.852059999999994,-88.08604,"DuPage County","county"
-46047,46,"46","Fall River",1739.9482,43.22162,-103.51261,"Fall River County","county"
-27069,27,"27","Kittson",1098.8516,48.77604,-96.78035,"Kittson County","county"
-13219,13,"13","Oconee",184.3411,33.834126,-83.43773,"Oconee County","county"
-48493,48,"48","Wilson",803.76184,29.173883,-98.08673,"Wilson County","county"
-31059,31,"31","Fillmore",575.3901,40.525040000000004,-97.5967,"Fillmore County","county"
-12079,12,"12","Madison",696.55255,30.447233,-83.47041,"Madison County","county"
-72031,72,"72","Carolina Municipio",45.372017,18.396776000000003,-65.96878000000001,"Carolina Municipio","county"
-18153,18,"18","Sullivan",447.18747,39.089226000000004,-87.41584,"Sullivan County","county"
-4012,4,"04","La Paz",4496.5103,33.72761,-114.0388,"La Paz County","county"
-13027,13,"13","Brooks",493.20099999999996,30.822933000000003,-83.58191,"Brooks County","county"
-2016,2,"02","Aleutians West Census Area",4394.5977,51.948963,179.62118999999998,"Aleutians West Census Area","county"
-2150,2,"02","Kodiak Island Borough",6615.5884,57.7044,-153.91836999999998,"Kodiak Island Borough","county"
-20185,20,"20","Stafford",792.07294,38.03563,-98.71989,"Stafford County","county"
-13271,13,"13","Telfair",437.32232999999997,31.913641,-82.93106,"Telfair County","county"
-26115,26,"26","Monroe",549.3688400000001,41.916096,-83.48711,"Monroe County","county"
-18181,18,"18","White",505.15732,40.75095,-86.864296,"White County","county"
-18113,18,"18","Noble",410.858,41.40468,-85.417274,"Noble County","county"
-21139,21,"21","Livingston",313.139,37.20952,-88.36343000000001,"Livingston County","county"
-13201,13,"13","Miller",282.43242999999995,31.162931,-84.7304,"Miller County","county"
-47103,47,"47","Lincoln",570.3615,35.142784000000006,-86.59340999999999,"Lincoln County","county"
-21211,21,"21","Shelby",379.78722999999997,38.23901,-85.22825,"Shelby County","county"
-31185,31,"31","York",572.5295,40.873055,-97.59674,"York County","county"
-42001,42,"42","Adams",518.70575,39.869473,-77.21773,"Adams County","county"
-45005,45,"45","Allendale",408.1045,32.979755,-81.36326600000001,"Allendale County","county"
-47037,47,"47","Davidson",503.46902,36.169129999999996,-86.78479,"Davidson County","county"
-49047,49,"49","Uintah",4482.5356,40.125890000000005,-109.517746,"Uintah County","county"
-49049,49,"49","Utah",2004.1359,40.120426,-111.66851000000001,"Utah County","county"
-18021,18,"18","Clay",357.61462,39.39393,-87.11586,"Clay County","county"
-36047,36,"36","Kings",69.37384,40.635044,-73.95064,"Kings County","county"
-29141,29,"29","Morgan",597.65497,38.420807,-92.87483,"Morgan County","county"
-39075,39,"39","Holmes",422.56683,40.565598,-81.93,"Holmes County","county"
-19143,19,"19","Osceola",398.70026,43.378544,-95.63379,"Osceola County","county"
-18079,18,"18","Jennings",376.61005,38.996227000000005,-85.628105,"Jennings County","county"
-16083,16,"16","Twin Falls",1921.7731,42.352309999999996,-114.66564,"Twin Falls County","county"
-17165,17,"17","Saline",380.0032,37.751507000000004,-88.54502,"Saline County","county"
-26077,26,"26","Kalamazoo",561.99994,42.246265,-85.53285,"Kalamazoo County","county"
-45061,45,"45","Lee",410.1982,34.158640000000005,-80.251205,"Lee County","county"
-56019,56,"56","Johnson",4154.2935,44.04405,-106.58854,"Johnson County","county"
-18027,18,"18","Daviess",429.51334,38.696090000000005,-87.07694000000001,"Daviess County","county"
-26055,26,"26","Grand Traverse",464.35193,44.71869,-85.55385,"Grand Traverse County","county"
-22003,22,"22","Allen Parish",761.8378,30.652744000000002,-92.8196,"Allen Parish","county"
-46065,46,"46","Hughes",741.55225,44.384453,-99.975685,"Hughes County","county"
-46069,46,"46","Hyde",860.6586,44.537174,-99.47273,"Hyde County","county"
-45027,45,"45","Clarendon",606.9808,33.66468,-80.21789,"Clarendon County","county"
-30095,30,"30","Stillwater",1796.8073,45.658546,-109.38158,"Stillwater County","county"
-47007,47,"47","Bledsoe",406.44226000000003,35.593563,-85.20591,"Bledsoe County","county"
-21219,21,"21","Todd",374.51572000000004,36.840340000000005,-87.18364,"Todd County","county"
-47183,47,"47","Weakley",580.3729,36.303596,-88.72119,"Weakley County","county"
-29077,29,"29","Greene",675.3498,37.258194,-93.34064000000001,"Greene County","county"
-42077,42,"42","Lehigh",345.30606,40.614243,-75.59063,"Lehigh County","county"
-31159,31,"31","Seward",571.4490000000001,40.871944,-97.14038000000001,"Seward County","county"
-36015,36,"36","Chemung",407.3664,42.15528,-76.74718,"Chemung County","county"
-36121,36,"36","Wyoming",592.7717,42.701363,-78.22856999999999,"Wyoming County","county"
-6099,6,"06","Stanislaus",1496.0684,37.562317,-121.00283,"Stanislaus County","county"
-42095,42,"42","Northampton",369.7945,40.752792,-75.30745,"Northampton County","county"
-1103,1,"01","Morgan",579.6196,34.454483,-86.846405,"Morgan County","county"
-21027,21,"21","Breckinridge",569.82526,37.77799,-86.43292,"Breckinridge County","county"
-28043,28,"28","Grenada",422.1364,33.77003,-89.80274,"Grenada County","county"
-21213,21,"21","Simpson",234.21336000000002,36.740936,-86.581795,"Simpson County","county"
-50013,50,"50","Grand Isle",81.81074,44.801790000000004,-73.30076,"Grand Isle County","county"
-39029,39,"39","Columbiana",531.935,40.770073,-80.77846,"Columbiana County","county"
-51125,51,"51","Nelson",470.76122999999995,37.789078,-78.88344000000001,"Nelson County","county"
-12097,12,"12","Osceola",1327.6084,28.059027,-81.13931,"Osceola County","county"
-5053,5,"05","Grant",631.8330000000001,34.28557,-92.42298000000001,"Grant County","county"
-13175,13,"13","Laurens",807.35736,32.39322,-82.926315,"Laurens County","county"
-36061,36,"36","New York",22.661299,40.77664,-73.970184,"New York County","county"
-5007,5,"05","Benton",847.93,36.33782,-94.2563,"Benton County","county"
-72071,72,"72","Isabela Municipio",55.313269999999996,18.48387,-67.01414,"Isabela Municipio","county"
-12083,12,"12","Marion",1588.4701,29.202804999999998,-82.0431,"Marion County","county"
-51135,51,"51","Nottoway",314.4004,37.141166999999996,-78.05386,"Nottoway County","county"
-34041,34,"34","Warren",356.54828,40.853493,-75.0095,"Warren County","county"
-36021,36,"36","Columbia",634.6850599999999,42.24773,-73.62680999999999,"Columbia County","county"
-51690,51,"51","Martinsville city",10.956643,36.683525,-79.86365,"Martinsville city","county"
-40023,40,"40","Choctaw",770.3348,34.027645,-95.55421,"Choctaw County","county"
-20041,20,"20","Dickinson",847.0961,38.867737,-97.15794,"Dickinson County","county"
-48427,48,"48","Starr",1223.2207,26.530903000000002,-98.740234,"Starr County","county"
-13103,13,"13","Effingham",478.83495999999997,32.36168,-81.34337,"Effingham County","county"
-40129,40,"40","Roger Mills",1141.1649,35.708553,-99.74157,"Roger Mills County","county"
-55103,55,"55","Richland",586.16943,43.376197999999995,-90.43569000000001,"Richland County","county"
-35025,35,"35","Lea",4391.619000000001,32.795685,-103.41327,"Lea County","county"
-1075,1,"01","Lamar",604.8668,33.787085999999995,-88.08743,"Lamar County","county"
-72054,72,"72","Florida Municipio",15.209660999999999,18.373953,-66.56008,"Florida Municipio","county"
-47117,47,"47","Marshall",375.47485,35.468340000000005,-86.76586,"Marshall County","county"
-51011,51,"51","Appomattox",334.23007,37.370723999999996,-78.81094,"Appomattox County","county"
-5087,5,"05","Madison",834.2873,36.012547,-93.72405,"Madison County","county"
-56033,56,"56","Sheridan",2523.4468,44.78137,-106.88121000000001,"Sheridan County","county"
-42041,42,"42","Cumberland",545.4973,40.164806,-77.26344,"Cumberland County","county"
-42055,42,"42","Franklin",772.3254,39.926773,-77.72452,"Franklin County","county"
-42079,42,"42","Luzerne",889.9962,41.172787,-75.976036,"Luzerne County","county"
-26039,26,"26","Crawford",556.4222,44.680176,-84.61134,"Crawford County","county"
-1113,1,"01","Russell",641.1919,32.289809999999996,-85.18698,"Russell County","county"
-39019,39,"39","Carroll",394.62192000000005,40.579884,-81.09079,"Carroll County","county"
-51065,51,"51","Fluvanna",287.12708,37.830585,-78.28349,"Fluvanna County","county"
-17097,17,"17","Lake",443.91504000000003,42.326443,-87.435974,"Lake County","county"
-13195,13,"13","Madison",282.3374,34.128525,-83.203735,"Madison County","county"
-5039,5,"05","Dallas",667.409,33.967822999999996,-92.654,"Dallas County","county"
-8057,8,"08","Jackson",1613.7805,40.663433000000005,-106.32925,"Jackson County","county"
-8063,8,"08","Kit Carson",2160.895,39.30534,-102.60302,"Kit Carson County","county"
-16073,16,"16","Owyhee",7668.467,42.57285,-116.18968999999998,"Owyhee County","county"
-55141,55,"55","Wood",793.0427,44.461414000000005,-90.038826,"Wood County","county"
-36013,36,"36","Chautauqua",1060.2909,42.304214,-79.40759,"Chautauqua County","county"
-13067,13,"13","Cobb",339.8017,33.93993,-84.57411,"Cobb County","county"
-47091,47,"47","Johnson",298.4502,36.4532,-81.861244,"Johnson County","county"
-39013,39,"39","Belmont",532.1437400000001,40.01768,-80.96773,"Belmont County","county"
-51195,51,"51","Wise",403.45306,36.97456,-82.62156,"Wise County","county"
-29035,29,"29","Carter",507.37573,36.94486,-90.9457,"Carter County","county"
-40013,40,"40","Bryan",904.2726,33.964005,-96.26414,"Bryan County","county"
-31035,31,"31","Clay",572.30896,40.52367,-98.05086,"Clay County","county"
-24017,24,"24","Charles",457.8125,38.472854999999996,-77.01543000000001,"Charles County","county"
-19033,19,"19","Cerro Gordo",568.3192,43.074974,-93.25095999999999,"Cerro Gordo County","county"
-19073,19,"19","Greene",569.63715,42.042496,-94.3887,"Greene County","county"
-21205,21,"21","Rowan",279.84924,38.204266,-83.42808000000001,"Rowan County","county"
-49055,49,"49","Wayne",2461.1033,38.259842,-110.990875,"Wayne County","county"
-29031,29,"29","Cape Girardeau",578.5607,37.38414,-89.68565,"Cape Girardeau County","county"
-53071,53,"53","Walla Walla",1270.0757,46.254604,-118.48037,"Walla Walla County","county"
-29133,29,"29","Mississippi",411.59713999999997,36.826263,-89.29593,"Mississippi County","county"
-5025,5,"05","Cleveland",597.799,33.8932,-92.18871,"Cleveland County","county"
-48113,48,"48","Dallas",872.40436,32.766987,-96.77843,"Dallas County","county"
-72079,72,"72","Lajas Municipio",59.95900699999999,17.978512,-67.04011,"Lajas Municipio","county"
-18033,18,"18","DeKalb",362.84488,41.401188,-85.00018,"DeKalb County","county"
-22073,22,"22","Ouachita Parish",610.4225,32.48093,-92.15158000000001,"Ouachita Parish","county"
-22095,22,"22","St. John the Baptist Parish",214.32724,30.144068,-90.49096,"St. John the Baptist Parish","county"
-22091,22,"22","St. Helena Parish",408.4222,30.822538,-90.70830500000001,"St. Helena Parish","county"
-29197,29,"29","Schuyler",307.3155,40.469359999999995,-92.51901,"Schuyler County","county"
-1059,1,"01","Franklin",633.94006,34.441990000000004,-87.84281,"Franklin County","county"
-21041,21,"21","Carroll",128.5748,38.668392,-85.12402,"Carroll County","county"
-8019,8,"08","Clear Creek",395.0863,39.66973,-105.69256999999999,"Clear Creek County","county"
-48267,48,"48","Kimble",1251.0275,30.479471000000004,-99.7464,"Kimble County","county"
-26097,26,"26","Mackinac",1021.8994,46.16787,-85.303764,"Mackinac County","county"
-48307,48,"48","McCulloch",1065.6371,31.205477000000002,-99.35985600000001,"McCulloch County","county"
-28141,28,"28","Tishomingo",424.3171,34.737697999999995,-88.23606,"Tishomingo County","county"
-48105,48,"48","Crockett",2807.4192,30.717531,-101.40420999999999,"Crockett County","county"
-48217,48,"48","Hill",958.88904,31.982681,-97.13067,"Hill County","county"
-8075,8,"08","Logan",1838.6609,40.728092,-103.09046,"Logan County","county"
-20055,20,"20","Finney",1302.0417,38.04981,-100.73997,"Finney County","county"
-20125,20,"20","Montgomery",643.6156,37.189537,-95.7424,"Montgomery County","county"
-45039,45,"45","Fairfield",686.3281,34.395668,-81.127,"Fairfield County","county"
-31033,31,"31","Cheyenne",1196.3271,41.214237,-103.01193,"Cheyenne County","county"
-27091,27,"27","Martin",712.3549,43.677116,-94.537254,"Martin County","county"
-47155,47,"47","Sevier",592.5087,35.795345000000005,-83.51849,"Sevier County","county"
-47139,47,"47","Polk",434.62015,35.109435999999995,-84.541115,"Polk County","county"
-48263,48,"48","Kent",902.53754,33.184779999999996,-100.76971999999999,"Kent County","county"
-30099,30,"30","Teton",2271.6804,47.819035,-112.28171999999999,"Teton County","county"
-31069,31,"31","Garden",1705.5037,41.633365999999995,-102.302986,"Garden County","county"
-17117,17,"17","Macoupin",863.00305,39.265915,-89.92633000000001,"Macoupin County","county"
-39141,39,"39","Ross",689.21063,39.3239,-83.05954,"Ross County","county"
-17195,17,"17","Whiteside",684.1225,41.750675,-89.911,"Whiteside County","county"
-48141,48,"48","El Paso",1013.2814300000001,31.766479999999998,-106.241425,"El Paso County","county"
-48301,48,"48","Loving",668.8405,31.844935999999997,-103.561226,"Loving County","county"
-40077,40,"40","Latimer",722.1168,34.875137,-95.27226,"Latimer County","county"
-39167,39,"39","Washington",631.99554,39.450676,-81.49064,"Washington County","county"
-29091,29,"29","Howell",927.2799699999999,36.774370000000005,-91.88736999999999,"Howell County","county"
-20047,20,"20","Edwards",621.9156,37.883595,-99.30475,"Edwards County","county"
-21111,21,"21","Jefferson",380.72213999999997,38.189533000000004,-85.65762,"Jefferson County","county"
-17107,17,"17","Logan",618.0771,40.129276000000004,-89.36531,"Logan County","county"
-55139,55,"55","Winnebago",434.71167,44.08571,-88.66815,"Winnebago County","county"
-21075,21,"21","Fulton",205.93822,36.552513,-89.18766,"Fulton County","county"
-20079,20,"20","Harvey",539.7742,38.050144,-97.43670999999999,"Harvey County","county"
-30021,30,"30","Dawson",2371.9983,47.26613,-104.89827,"Dawson County","county"
-54091,54,"54","Taylor",172.77696,39.332478,-80.046555,"Taylor County","county"
-26111,26,"26","Midland",516.29675,43.648205,-84.37942,"Midland County","county"
-28119,28,"28","Quitman",405.02547999999996,34.252834,-90.29016999999999,"Quitman County","county"
-21093,21,"21","Hardin",623.4177,37.695834999999995,-85.96318000000001,"Hardin County","county"
-17081,17,"17","Jefferson",571.22363,38.300779999999996,-88.92421,"Jefferson County","county"
-46057,46,"46","Hamlin",506.97574000000003,44.680620000000005,-97.1786,"Hamlin County","county"
-55069,55,"55","Lincoln",878.73376,45.338417,-89.74231,"Lincoln County","county"
-36033,36,"36","Franklin",1629.2692,44.594376000000004,-74.31067,"Franklin County","county"
-51630,51,"51","Fredericksburg city",10.451047,38.29927,-77.48666,"Fredericksburg city","county"
-54081,54,"54","Raleigh",605.3784,37.76247,-81.26467,"Raleigh County","county"
-35005,35,"35","Chaves",6067.38,33.361603,-104.46984,"Chaves County","county"
-35049,35,"35","Santa Fe",1910.4429,35.51453,-105.963974,"Santa Fe County","county"
-6059,6,"06","Orange",792.83673,33.675686,-117.77721000000001,"Orange County","county"
-4023,4,"04","Santa Cruz",1236.2767,31.525734000000003,-110.84523,"Santa Cruz County","county"
-37053,37,"37","Currituck",261.92136,36.372173,-75.94122,"Currituck County","county"
-17101,17,"17","Lawrence",372.19125,38.718956,-87.73021999999999,"Lawrence County","county"
-18067,18,"18","Howard",293.08414,40.483536,-86.11412,"Howard County","county"
-18125,18,"18","Pike",334.31372000000005,38.39796,-87.23254399999999,"Pike County","county"
-21047,21,"21","Christian",717.53394,36.89206,-87.49299,"Christian County","county"
-26045,26,"26","Eaton",575.222,42.589529999999996,-84.84645,"Eaton County","county"
-19179,19,"19","Wapello",431.8519,41.031277,-92.40947,"Wapello County","county"
-6025,6,"06","Imperial",4175.68,33.040813,-115.3554,"Imperial County","county"
-26027,26,"26","Cass",490.12198,41.917244000000004,-86.00014499999999,"Cass County","county"
-28157,28,"28","Wilkinson",678.12933,31.16109,-91.32461500000001,"Wilkinson County","county"
-2282,2,"02","Yakutat City and Borough",7623.536999999999,60.017452,-140.41695,"Yakutat City and Borough","county"
-20179,20,"20","Sheridan",895.9876,39.350547999999996,-100.44123,"Sheridan County","county"
-28079,28,"28","Leake",582.9172,32.76063,-89.52225,"Leake County","county"
-72025,72,"72","Caguas Municipio",58.604637,18.21111,-66.05096400000001,"Caguas Municipio","county"
-72027,72,"72","Camuy Municipio",46.3565,18.445469,-66.86314,"Camuy Municipio","county"
-28025,28,"28","Clay",410.07993,33.65967,-88.78246999999999,"Clay County","county"
-28037,28,"28","Franklin",563.98267,31.477771999999998,-90.895454,"Franklin County","county"
-28099,28,"28","Neshoba",570.15375,32.752518,-89.11928,"Neshoba County","county"
-46045,46,"46","Edmunds",1126.0189,45.41168,-99.20536,"Edmunds County","county"
-72119,72,"72","Río Grande Municipio",60.62341,18.37637,-65.79843000000001,"Río Grande Municipio","county"
-1035,1,"01","Conecuh",850.2289,31.430925,-86.98872,"Conecuh County","county"
-18029,18,"18","Dearborn",305.0972,39.14832,-84.973495,"Dearborn County","county"
-18071,18,"18","Jackson",509.99158,38.911957,-86.04252,"Jackson County","county"
-28081,28,"28","Lee",449.9804,34.29237,-88.68244,"Lee County","county"
-22125,22,"22","West Feliciana Parish",403.33215,30.872702,-91.42100500000001,"West Feliciana Parish","county"
-5035,5,"05","Crittenden",610.4031,35.21188,-90.31533,"Crittenden County","county"
-12063,12,"12","Jackson",918.2077,30.78925,-85.20881999999999,"Jackson County","county"
-48125,48,"48","Dickens",901.7547599999999,33.615364,-100.78761999999999,"Dickens County","county"
-51115,51,"51","Mathews",85.91315,37.425346000000005,-76.26881,"Mathews County","county"
-38075,38,"38","Renville",877.29395,48.71278,-101.65815,"Renville County","county"
-48283,48,"48","La Salle",1486.7546,28.351096999999996,-99.09676999999999,"La Salle County","county"
-36067,36,"36","Onondaga",778.4135,43.006516,-76.19614,"Onondaga County","county"
-19087,19,"19","Henry",434.30212,40.984802,-91.54726,"Henry County","county"
-31083,31,"31","Harlan",553.48517,40.17877,-99.40342,"Harlan County","county"
-30075,30,"30","Powder River",3298.3083,45.408928,-105.55533999999999,"Powder River County","county"
-72075,72,"72","Juana Díaz Municipio",60.2792,17.997974,-66.49049000000001,"Juana Díaz Municipio","county"
-55091,55,"55","Pepin",232.01456000000002,44.627438,-91.83489,"Pepin County","county"
-4001,4,"04","Apache",11198.13,35.385082000000004,-109.49016999999999,"Apache County","county"
-29121,29,"29","Macon",801.2348,39.829796,-92.56434,"Macon County","county"
-48279,48,"48","Lamb",1016.2159,34.068863,-102.348015,"Lamb County","county"
-20097,20,"20","Kiowa",722.6641,37.56123,-99.28654,"Kiowa County","county"
-48015,48,"48","Austin",646.5137,29.891901,-96.27017,"Austin County","county"
-29061,29,"29","Daviess",563.30115,39.962837,-93.970055,"Daviess County","county"
-13253,13,"13","Seminole",237.54397999999998,30.93396,-84.86768000000001,"Seminole County","county"
-26101,26,"26","Manistee",542.3439,44.350384000000005,-86.60297,"Manistee County","county"
-19119,19,"19","Lyon",587.6702,43.38358,-96.2072,"Lyon County","county"
-48233,48,"48","Hutchinson",887.45056,35.837047999999996,-101.36275,"Hutchinson County","county"
-40139,40,"40","Texas",2041.3428,36.746315,-101.48385999999999,"Texas County","county"
-40153,40,"40","Woodward",1242.8281,36.425616999999995,-99.27365999999999,"Woodward County","county"
-19003,19,"19","Adams",423.44732999999997,41.021656,-94.69691,"Adams County","county"
-6101,6,"06","Sutter",602.5509,39.036190000000005,-121.70393999999999,"Sutter County","county"
-42105,42,"42","Potter",1081.3594,41.748585,-77.89443,"Potter County","county"
-48465,48,"48","Val Verde",3144.8564,29.875286,-101.143326,"Val Verde County","county"
-20077,20,"20","Harper",801.30133,37.188183,-98.06659,"Harper County","county"
-19133,19,"19","Monona",694.09546,42.04943,-95.95656600000001,"Monona County","county"
-49023,49,"49","Juab",3391.7942,39.71412,-112.790474,"Juab County","county"
-40137,40,"40","Stephens",870.2260000000001,34.481359999999995,-97.85560600000001,"Stephens County","county"
-36017,36,"36","Chenango",893.62286,42.478024,-75.60224000000001,"Chenango County","county"
-17143,17,"17","Peoria",618.7359,40.785973,-89.76699,"Peoria County","county"
-19091,19,"19","Humboldt",434.38544,42.782222999999995,-94.202774,"Humboldt County","county"
-31177,31,"31","Washington",389.9707,41.533974,-96.22458,"Washington County","county"
-55049,55,"55","Iowa",762.7244,43.001022,-90.13369,"Iowa County","county"
-27097,27,"27","Morrison",1125.1326,46.020485,-94.26661999999999,"Morrison County","county"
-42003,42,"42","Allegheny",730.1419,40.469757,-79.98045,"Allegheny County","county"
-29205,29,"29","Shelby",500.88043,39.79753,-92.08872,"Shelby County","county"
-39097,39,"39","Madison",465.82718,39.896606,-83.40089,"Madison County","county"
-20201,20,"20","Washington",894.79083,39.776714,-97.09561,"Washington County","county"
-17019,17,"17","Champaign",996.1466,40.138985,-88.196976,"Champaign County","county"
-16087,16,"16","Washington",1452.9019,44.448223,-116.79778999999999,"Washington County","county"
-17045,17,"17","Edgar",623.3448,39.679035,-87.74710999999999,"Edgar County","county"
-8121,8,"08","Washington",2518.1694,39.965790000000005,-103.20975,"Washington County","county"
-39065,39,"39","Hardin",470.32574000000005,40.660416,-83.66408,"Hardin County","county"
-26113,26,"26","Missaukee",564.807,44.325424,-85.08547,"Missaukee County","county"
-38093,38,"38","Stutsman",2221.979,46.972225,-98.95612,"Stutsman County","county"
-29203,29,"29","Shannon",1003.85516,37.1525,-91.39133000000001,"Shannon County","county"
-48423,48,"48","Smith",921.5044,32.377014,-95.27004000000001,"Smith County","county"
-40143,40,"40","Tulsa",570.10004,36.12032,-95.94181,"Tulsa County","county"
-40091,40,"40","McIntosh",618.30927,35.369106,-95.67178,"McIntosh County","county"
-48395,48,"48","Robertson",855.137,31.025479999999998,-96.51494,"Robertson County","county"
-48171,48,"48","Gillespie",1058.2377,30.325090000000003,-98.94185,"Gillespie County","county"
-26125,26,"26","Oakland",867.1874,42.66045,-83.38421,"Oakland County","county"
-38033,38,"38","Golden Valley",1000.9191,46.938922999999996,-103.84461,"Golden Valley County","county"
-56027,56,"56","Niobrara",2626.1172,43.06216,-104.468376,"Niobrara County","county"
-27117,27,"27","Pipestone",465.07175,44.01536,-96.25701,"Pipestone County","county"
-51099,51,"51","King George",179.63397,38.27718,-77.16263599999999,"King George County","county"
-53025,53,"53","Grant",2679.5916,47.213634000000006,-119.46779,"Grant County","county"
-27129,27,"27","Renville",982.9509,44.723698,-94.95562,"Renville County","county"
-12001,12,"12","Alachua",875.5685,29.675741,-82.35722,"Alachua County","county"
-31091,31,"31","Hooker",721.18463,41.920320000000004,-101.117325,"Hooker County","county"
-51147,51,"51","Prince Edward",349.97336,37.22488,-78.43296,"Prince Edward County","county"
-49007,49,"49","Carbon",1479.2339,39.673283000000005,-110.588486,"Carbon County","county"
-42017,42,"42","Bucks",604.4223,40.336887,-75.10706,"Bucks County","county"
-46059,46,"46","Hand",1436.6985,44.546715,-99.00458,"Hand County","county"
-42081,42,"42","Lycoming",1228.8063,41.343884,-77.05526,"Lycoming County","county"
-16057,16,"16","Latah",1075.9037,46.81892,-116.73097,"Latah County","county"
-13237,13,"13","Putnam",344.69354,33.321059999999996,-83.37179,"Putnam County","county"
-51640,51,"51","Galax city",8.236641,36.665638,-80.91431,"Galax city","county"
-35037,35,"35","Quay",2874.0525,35.107018,-103.54807,"Quay County","county"
-48269,48,"48","King",910.90344,33.61427,-100.245346,"King County","county"
-5073,5,"05","Lafayette",528.3131,33.240629999999996,-93.61151,"Lafayette County","county"
-48451,48,"48","Tom Green",1522.0531,31.398822999999997,-100.46379,"Tom Green County","county"
-12049,12,"12","Hardee",637.5966,27.492846000000004,-81.82158000000001,"Hardee County","county"
-39025,39,"39","Clermont",452.13455,39.052054999999996,-84.14948000000001,"Clermont County","county"
-48501,48,"48","Yoakum",799.74225,33.1624,-102.832245,"Yoakum County","county"
-41071,41,"41","Yamhill",715.9231,45.247826,-123.3164,"Yamhill County","county"
-19115,19,"19","Louisa",401.7854,41.218212,-91.256996,"Louisa County","county"
-20049,20,"20","Elk",644.2862,37.456024,-96.244644,"Elk County","county"
-39121,39,"39","Noble",398.02557,39.76723,-81.45249,"Noble County","county"
-39137,39,"39","Putnam",482.56055,41.024532,-84.12988,"Putnam County","county"
-48425,48,"48","Somervell",186.47398,32.218070000000004,-97.76921999999999,"Somervell County","county"
-42075,42,"42","Lebanon",361.8247,40.37145,-76.46481999999999,"Lebanon County","county"
-30035,30,"30","Glacier",2995.048,48.70567,-112.9905,"Glacier County","county"
-32027,32,"32","Pershing",6036.7935,40.439640000000004,-118.40948,"Pershing County","county"
-27087,27,"27","Mahnomen",557.8857,47.32839,-95.81109000000001,"Mahnomen County","county"
-34031,34,"34","Passaic",186.01772,41.037890000000004,-74.29828,"Passaic County","county"
-30047,30,"30","Lake",1490.5173,47.642902,-114.08368999999999,"Lake County","county"
-48261,48,"48","Kenedy",1458.5026,26.890213,-97.59114,"Kenedy County","county"
-48033,48,"48","Borden",897.47327,32.73859,-101.4392,"Borden County","county"
-29157,29,"29","Perry",474.37127999999996,37.71113,-89.80212399999999,"Perry County","county"
-48411,48,"48","San Saba",1135.3516,31.155138,-98.81929000000001,"San Saba County","county"
-40073,40,"40","Kingfisher",898.10645,35.949436,-97.934555,"Kingfisher County","county"
-48051,48,"48","Burleson",659.0559,30.493485999999997,-96.62209,"Burleson County","county"
-36035,36,"36","Fulton",495.47652999999997,43.11561,-74.423676,"Fulton County","county"
-28133,28,"28","Sunflower",697.78253,33.60553,-90.59509,"Sunflower County","county"
-27053,27,"27","Hennepin",553.8634,45.006122999999995,-93.47523000000001,"Hennepin County","county"
-42027,42,"42","Centre",1108.7312,40.909126,-77.84788,"Centre County","county"
-48025,48,"48","Bee",880.2693,28.416077,-97.742584,"Bee County","county"
-47077,47,"47","Henderson",520.02655,35.653996,-88.38767,"Henderson County","county"
-19171,19,"19","Tama",721.0357700000001,42.07485,-92.52941,"Tama County","county"
-20175,20,"20","Seward",639.6746,37.18096,-100.855255,"Seward County","county"
-19135,19,"19","Monroe",433.73132000000004,41.028847,-92.869644,"Monroe County","county"
-31147,31,"31","Richardson",551.8597,40.123740000000005,-95.71860500000001,"Richardson County","county"
-17021,17,"17","Christian",709.51373,39.545525,-89.27959399999999,"Christian County","county"
-12089,12,"12","Nassau",648.7025,30.605963,-81.76508000000001,"Nassau County","county"
-12133,12,"12","Washington",584.6967,30.602217,-85.662796,"Washington County","county"
-13007,13,"13","Baker",341.96896,31.31958,-84.45488,"Baker County","county"
-13275,13,"13","Thomas",544.6415,30.864620000000002,-83.919815,"Thomas County","county"
-21005,21,"21","Anderson",202.17293999999998,38.005398,-84.98642,"Anderson County","county"
-21185,21,"21","Oldham",187.2479,38.400127000000005,-85.456154,"Oldham County","county"
-13057,13,"13","Cherokee",421.09772000000004,34.244316,-84.47506,"Cherokee County","county"
-38065,38,"38","Oliver",722.4284700000001,47.11808,-101.33142,"Oliver County","county"
-26133,26,"26","Osceola",566.3054,43.99755,-85.32228,"Osceola County","county"
-47109,47,"47","McNairy",562.8609,35.175377000000005,-88.56373599999999,"McNairy County","county"
-53001,53,"53","Adams",1925.0546,47.01124,-118.51286,"Adams County","county"
-29057,29,"29","Dade",490.02704000000006,37.43235,-93.85488000000001,"Dade County","county"
-22101,22,"22","St. Mary Parish",555.6032,29.629348999999998,-91.463806,"St. Mary Parish","county"
-50007,50,"50","Chittenden",536.6038,44.46333,-73.06940999999999,"Chittenden County","county"
-72045,72,"72","Comerío Municipio",28.401556,18.22503,-66.21948,"Comerío Municipio","county"
-15009,15,"15","Maui",1161.5695,20.855929999999997,-156.60155,"Maui County","county"
-22057,22,"22","Lafourche Parish",1068.3959,29.491993,-90.39485,"Lafourche Parish","county"
-19139,19,"19","Muscatine",437.4598,41.483776,-91.1187,"Muscatine County","county"
-12113,12,"12","Santa Rosa",1012.4139,30.70127,-87.01289,"Santa Rosa County","county"
-18101,18,"18","Martin",335.7719,38.705321999999995,-86.80185,"Martin County","county"
-21203,21,"21","Rockcastle",316.5581,37.36105,-84.31437,"Rockcastle County","county"
-21223,21,"21","Trimble",151.65313999999998,38.62004,-85.35120400000001,"Trimble County","county"
-13055,13,"13","Chattooga",313.33734,34.47418,-85.34529,"Chattooga County","county"
-45033,45,"45","Dillon",405.08087,34.39017,-79.37496,"Dillon County","county"
-37103,37,"37","Jones",471.38382,35.032270000000004,-77.35619,"Jones County","county"
-29199,29,"29","Scotland",436.522,40.447685,-92.14282,"Scotland County","county"
-20131,20,"20","Nemaha",717.4516,39.791042,-96.00538,"Nemaha County","county"
-20137,20,"20","Norton",878.07355,39.783867,-99.89924,"Norton County","county"
-72007,72,"72","Aguas Buenas Municipio",30.085907000000002,18.256523,-66.12849399999999,"Aguas Buenas Municipio","county"
-72033,72,"72","Cataño Municipio",4.8763623,18.444614,-66.14882,"Cataño Municipio","county"
-31065,31,"31","Furnas",719.15607,40.191864,-99.90966,"Furnas County","county"
-13087,13,"13","Decatur",597.1921,30.880644,-84.58389,"Decatur County","county"
-18177,18,"18","Wayne",401.76813,39.86309,-85.00674000000001,"Wayne County","county"
-21009,21,"21","Barren",487.60074000000003,36.962807,-85.932106,"Barren County","county"
-31093,31,"31","Howard",569.3573,41.21685,-98.51334,"Howard County","county"
-38025,38,"38","Dunn",2008.5599,47.354557,-102.61232,"Dunn County","county"
-6005,6,"06","Amador",594.5919,38.44355,-120.65385400000001,"Amador County","county"
-47049,47,"47","Fentress",498.63574000000006,36.369892,-84.93777,"Fentress County","county"
-20031,20,"20","Coffey",626.906,38.23645,-95.72913,"Coffey County","county"
-26023,26,"26","Branch",506.43094,41.918453,-85.06689,"Branch County","county"
-51031,51,"51","Campbell",503.22443,37.21015,-79.09543000000001,"Campbell County","county"
-39105,39,"39","Meigs",430.11618,39.089806,-82.0284,"Meigs County","county"
-54067,54,"54","Nicholas",646.86835,38.29143,-80.797516,"Nicholas County","county"
-40053,40,"40","Grant",1000.7739,36.788253999999995,-97.788155,"Grant County","county"
-46115,46,"46","Spink",1503.5627,44.923770000000005,-98.33961500000001,"Spink County","county"
-50027,50,"50","Windsor",969.6113,43.572685,-72.59881999999999,"Windsor County","county"
-48455,48,"48","Trinity",693.82007,31.096676000000002,-95.15169,"Trinity County","county"
-35001,35,"35","Bernalillo",1161.2977,35.053627,-106.66908000000001,"Bernalillo County","county"
-13205,13,"13","Mitchell",512.1754,31.228996000000002,-84.19204,"Mitchell County","county"
-15001,15,"15","Hawaii",4028.5862,19.597765,-155.50243999999998,"Hawaii County","county"
-21147,21,"21","McCreary",426.8183,36.731136,-84.49105,"McCreary County","county"
-21191,21,"21","Pendleton",277.16766,38.696284999999996,-84.35194399999999,"Pendleton County","county"
-21215,21,"21","Spencer",186.72974,38.02541,-85.31718000000001,"Spencer County","county"
-30041,30,"30","Hill",2899.2686,48.631958000000004,-110.10632,"Hill County","county"
-31175,31,"31","Valley",568.1311,41.564095,-98.98348,"Valley County","county"
-48069,48,"48","Castro",894.47485,34.53362,-102.25879,"Castro County","county"
-24043,24,"24","Washington",457.7828,39.603621999999994,-77.814674,"Washington County","county"
-21133,21,"21","Letcher",337.94186,37.118534000000004,-82.86125,"Letcher County","county"
-34033,34,"34","Salem",331.87282999999996,39.57383,-75.35735,"Salem County","county"
-51680,51,"51","Lynchburg city",48.975840000000005,37.399017,-79.19546,"Lynchburg city","county"
-5125,5,"05","Saline",723.5983,34.648525,-92.67446,"Saline County","county"
-54053,54,"54","Mason",430.782,38.770912,-82.02901,"Mason County","county"
-54021,54,"54","Gilmer",338.5141,38.915867,-80.84940999999999,"Gilmer County","county"
-28063,28,"28","Jefferson",519.9508,31.733633,-91.04388,"Jefferson County","county"
-38079,38,"38","Rolette",902.922,48.768271999999996,-99.84046,"Rolette County","county"
-30103,30,"30","Treasure",977.8339,46.229442999999996,-107.285774,"Treasure County","county"
-21049,21,"21","Clark",252.4959,37.970314,-84.14511999999999,"Clark County","county"
-72101,72,"72","Morovis Municipio",38.872616,18.319027,-66.42055500000001,"Morovis Municipio","county"
-26005,26,"26","Allegan",825.2812,42.595787,-86.63474000000001,"Allegan County","county"
-47005,47,"47","Benton",394.3196,36.07095,-88.071236,"Benton County","county"
-27015,27,"27","Brown",611.1301,44.24654,-94.73365,"Brown County","county"
-47137,47,"47","Pickett",162.98434,36.559364,-85.075745,"Pickett County","county"
-51109,51,"51","Louisa",496.14917,37.972706,-77.95979,"Louisa County","county"
-18145,18,"18","Shelby",411.15247,39.524136,-85.792175,"Shelby County","county"
-39049,39,"39","Franklin",532.4291400000001,39.969875,-83.00909,"Franklin County","county"
-49021,49,"49","Iron",3296.4495,37.909306,-113.30673999999999,"Iron County","county"
-32009,32,"32","Esmeralda",3582.011,37.778965,-117.63238500000001,"Esmeralda County","county"
-26083,26,"26","Keweenaw",540.13025,47.681973,-88.14879599999999,"Keweenaw County","county"
-49039,49,"49","Sanpete",1589.9847,39.382529999999996,-111.57288,"Sanpete County","county"
-20093,20,"20","Kearny",870.5729,37.99446,-101.308136,"Kearny County","county"
-12009,12,"12","Brevard",1015.0173300000001,28.298310999999998,-80.70033000000001,"Brevard County","county"
-18105,18,"18","Monroe",394.53528,39.16073,-86.52331,"Monroe County","county"
-19117,19,"19","Lucas",430.61804000000006,41.033344,-93.33147,"Lucas County","county"
-21239,21,"21","Woodford",190.11786,38.043102000000005,-84.748856,"Woodford County","county"
-45053,45,"45","Jasper",655.1841,32.43059,-81.02163,"Jasper County","county"
-48043,48,"48","Brewster",6183.972,29.808996,-103.25246,"Brewster County","county"
-45065,45,"45","McCormick",359.14133,33.8976,-82.31619,"McCormick County","county"
-45087,45,"45","Union",514.1884,34.690395,-81.6159,"Union County","county"
-27103,27,"27","Nicollet",448.62505999999996,44.35882,-94.24568000000001,"Nicollet County","county"
-55075,55,"55","Marinette",1399.5132,45.346897,-87.991196,"Marinette County","county"
-53011,53,"53","Clark",628.5052,45.77173,-122.485954,"Clark County","county"
-55099,55,"55","Price",1254.0978,45.679072999999995,-90.35965,"Price County","county"
-18103,18,"18","Miami",373.85495,40.772884000000005,-86.04426,"Miami County","county"
-20053,20,"20","Ellsworth",715.5995,38.700844000000004,-98.20535,"Ellsworth County","county"
-22123,22,"22","West Carroll Parish",359.65814,32.79248,-91.451996,"West Carroll Parish","county"
-12077,12,"12","Liberty",835.5917400000001,30.25985,-84.86858000000001,"Liberty County","county"
-20083,20,"20","Hodgeman",860.0213,38.087494,-99.89841,"Hodgeman County","county"
-20119,20,"20","Meade",978.1159,37.243885,-100.36009,"Meade County","county"
-21149,21,"21","McLean",252.53522999999998,37.526707,-87.265594,"McLean County","county"
-28001,28,"28","Adams",462.35925,31.486225,-91.3518,"Adams County","county"
-72083,72,"72","Las Marías Municipio",46.361565,18.227594,-66.97758,"Las Marías Municipio","county"
-28057,28,"28","Itawamba",532.81323,34.281075,-88.36313,"Itawamba County","county"
-21073,21,"21","Franklin",207.84805,38.23492,-84.86879,"Franklin County","county"
-23009,23,"23","Hancock",1587.1798,44.564907,-68.370705,"Hancock County","county"
-23013,23,"23","Knox",365.1482,44.042046,-69.03851,"Knox County","county"
-13217,13,"13","Newton",273.8101,33.54404,-83.85519000000001,"Newton County","county"
-46049,46,"46","Faulk",981.725,45.065475,-99.153564,"Faulk County","county"
-26061,26,"26","Houghton",1009.1349,46.99843,-88.6519,"Houghton County","county"
-30061,30,"30","Mineral",1219.6609,47.151943,-115.06563,"Mineral County","county"
-47051,47,"47","Franklin",554.5138,35.155926,-86.099205,"Franklin County","county"
-22029,22,"22","Concordia Parish",697.00464,31.469804999999997,-91.62631,"Concordia Parish","county"
-22063,22,"22","Livingston Parish",648.1956,30.44042,-90.72747,"Livingston Parish","county"
-25009,25,"25","Essex",492.5322,42.642708,-70.86491,"Essex County","county"
-46019,46,"46","Butte",2250.094,44.896225,-103.501434,"Butte County","county"
-8035,8,"08","Douglas",840.2798,39.325413,-104.92598999999998,"Douglas County","county"
-45079,45,"45","Richland",757.35156,34.029095,-80.89804000000001,"Richland County","county"
-18095,18,"18","Madison",451.93542,40.166203,-85.72246,"Madison County","county"
-40099,40,"40","Murray",416.38766,34.485766999999996,-97.071556,"Murray County","county"
-54009,54,"54","Brooke",89.19873,40.272644,-80.57869000000001,"Brooke County","county"
-54013,54,"54","Calhoun",279.25903,38.844159999999995,-81.11548,"Calhoun County","county"
-51021,51,"51","Bland",357.66292999999996,37.13061,-81.125854,"Bland County","county"
-30111,30,"30","Yellowstone",2633.5627,45.936985,-108.27666,"Yellowstone County","county"
-54043,54,"54","Lincoln",437.0553,38.17177,-82.07762,"Lincoln County","county"
-6033,6,"06","Lake",1256.5539999999999,39.094803000000006,-122.74676000000001,"Lake County","county"
-13131,13,"13","Grady",454.5168,30.875908000000003,-84.24508,"Grady County","county"
-8021,8,"08","Conejos",1287.472,37.213406,-106.176445,"Conejos County","county"
-49037,49,"49","San Juan",7820.1074,37.602634,-109.79157,"San Juan County","county"
-18133,18,"18","Putnam",480.55365,39.665546,-86.85337,"Putnam County","county"
-16047,16,"16","Gooding",729.3459,42.973186,-114.82141999999999,"Gooding County","county"
-47167,47,"47","Tipton",458.42435,35.50026,-89.7668,"Tipton County","county"
-22121,22,"22","West Baton Rouge Parish",192.39876999999998,30.464052000000002,-91.30981,"West Baton Rouge Parish","county"
-29171,29,"29","Putnam",517.3342,40.478607000000004,-93.014534,"Putnam County","county"
-56039,56,"56","Teton",3996.9822,44.04866,-110.42608999999999,"Teton County","county"
-55043,55,"55","Grant",1146.9177,42.870026,-90.69423,"Grant County","county"
-38059,38,"38","Morton",1925.9531,46.71082,-101.29826,"Morton County","county"
-37041,37,"37","Chowan",172.66301,36.12898,-76.60275,"Chowan County","county"
-37021,37,"37","Buncombe",656.51917,35.60937,-82.530426,"Buncombe County","county"
-6063,6,"06","Plumas",2553.1492,39.992294,-120.82437,"Plumas County","county"
-51730,51,"51","Petersburg city",22.721062,37.20473,-77.392365,"Petersburg city","county"
-50023,50,"50","Washington",687.066,44.27499,-72.60951,"Washington County","county"
-46093,46,"46","Meade",3471.0518,44.60528,-102.71417,"Meade County","county"
-18097,18,"18","Marion",396.5827,39.782973999999996,-86.135796,"Marion County","county"
-5017,5,"05","Chicot",644.7488400000001,33.267140000000005,-91.29715999999999,"Chicot County","county"
-13021,13,"13","Bibb",249.40692,32.808846,-83.69419,"Bibb County","county"
-72059,72,"72","Guayanilla Municipio",42.272053,18.005339000000003,-66.798294,"Guayanilla Municipio","county"
-72131,72,"72","San Sebastián Municipio",70.42546,18.331423,-66.97069499999999,"San Sebastián Municipio","county"
-5115,5,"05","Pope",812.5438,35.456559999999996,-93.02682,"Pope County","county"
-51175,51,"51","Southampton",599.2161,36.720065999999996,-77.10381,"Southampton County","county"
-48183,48,"48","Gregg",273.38977,32.486397,-94.81628,"Gregg County","county"
-36087,36,"36","Rockland",173.45009,41.15463,-74.02466,"Rockland County","county"
-5089,5,"05","Marion",596.9769,36.266663,-92.67857,"Marion County","county"
-51800,51,"51","Suffolk city",399.16702000000004,36.69716,-76.63478,"Suffolk city","county"
-8041,8,"08","El Paso",2126.9216,38.827385,-104.52747,"El Paso County","county"
-29187,29,"29","St. Francois",451.90227999999996,37.810707,-90.47386999999999,"St. Francois County","county"
-48475,48,"48","Ward",835.6311,31.513070000000003,-103.10511,"Ward County","county"
-8061,8,"08","Kiowa",1767.8689,38.387665000000005,-102.75685,"Kiowa County","county"
-48487,48,"48","Wilbarger",970.9788,34.084920000000004,-99.24244,"Wilbarger County","county"
-41015,41,"41","Curry",1628.4368,42.466440000000006,-124.21093,"Curry County","county"
-8119,8,"08","Teller",557.06104,38.869976,-105.18736000000001,"Teller County","county"
-29049,29,"29","Clinton",418.9717,39.608723,-94.39580500000001,"Clinton County","county"
-49051,49,"49","Wasatch",1177.0548,40.334885,-111.16157,"Wasatch County","county"
-16029,16,"16","Caribou",1764.2538,42.78607,-111.54427,"Caribou County","county"
-37157,37,"37","Rockingham",565.6578400000001,36.381805,-79.78275,"Rockingham County","county"
-5117,5,"05","Prairie",647.89105,34.831115999999994,-91.55362,"Prairie County","county"
-5011,5,"05","Bradley",649.25757,33.46655,-92.16915999999999,"Bradley County","county"
-48193,48,"48","Hamilton",835.943,31.707341999999997,-98.111755,"Hamilton County","county"
-24011,24,"24","Caroline",319.45257999999995,38.871532,-75.831665,"Caroline County","county"
-27041,27,"27","Douglas",636.7753,45.93683,-95.46216,"Douglas County","county"
-30043,30,"30","Jefferson",1656.9192,46.124233000000004,-112.059425,"Jefferson County","county"
-51059,51,"51","Fairfax",391.02032,38.82952,-77.27325400000001,"Fairfax County","county"
-30023,30,"30","Deer Lodge",736.7077,46.094673,-113.141624,"Deer Lodge County","county"
-47001,47,"47","Anderson",337.21477999999996,36.11673,-84.19542,"Anderson County","county"
-39077,39,"39","Huron",491.5112,41.14508,-82.59464,"Huron County","county"
-13005,13,"13","Bacon",284.0946,31.550209000000002,-82.45143,"Bacon County","county"
-10001,10,"10","Kent",586.0801,39.097088,-75.50298000000001,"Kent County","county"
-39173,39,"39","Wood",617.2093,41.360184000000004,-83.62268,"Wood County","county"
-13157,13,"13","Jackson",339.68015,34.130905,-83.56255,"Jackson County","county"
-20003,20,"20","Anderson",579.6644,38.215115000000004,-95.292046,"Anderson County","county"
-17095,17,"17","Knox",716.409,40.930946,-90.21379,"Knox County","county"
-30107,30,"30","Wheatland",1422.5292,46.497046999999995,-109.85715,"Wheatland County","county"
-47015,47,"47","Cannon",265.6444,35.808395000000004,-86.0624,"Cannon County","county"
-23007,23,"23","Franklin",1697.0620000000001,44.976723,-70.41493,"Franklin County","county"
-21165,21,"21","Menifee",203.5921,37.9355,-83.58936,"Menifee County","county"
-46089,46,"46","McPherson",1136.682,45.78425,-99.21141999999999,"McPherson County","county"
-8051,8,"08","Gunnison",3239.2517,38.670497999999995,-107.05688,"Gunnison County","county"
-26029,26,"26","Charlevoix",416.34378,45.513165,-85.45039,"Charlevoix County","county"
-27151,27,"27","Swift",742.0083,45.27581,-95.690125,"Swift County","county"
-39147,39,"39","Seneca",551.0451,41.11999,-83.12755,"Seneca County","county"
-13267,13,"13","Tattnall",480.8399,32.04377,-82.05921,"Tattnall County","county"
-48429,48,"48","Stephens",896.7517,32.738052,-98.83935,"Stephens County","county"
-37117,37,"37","Martin",456.44046,35.8473,-77.1196,"Martin County","county"
-30081,30,"30","Ravalli",2391.0789999999997,46.077744,-114.1058,"Ravalli County","county"
-13317,13,"13","Wilkes",469.51675,33.77903,-82.747925,"Wilkes County","county"
-53043,53,"53","Lincoln",2310.6765,47.582745,-118.417694,"Lincoln County","county"
-6081,6,"06","San Mateo",448.64938,37.414673,-122.371544,"San Mateo County","county"
-39171,39,"39","Williams",420.6741,41.56496,-84.58431999999999,"Williams County","county"
-8009,8,"08","Baca",2555.0796,37.309779999999996,-102.54374,"Baca County","county"
-16021,16,"16","Boundary",1268.7223,48.773132000000004,-116.524666,"Boundary County","county"
-16007,16,"16","Bear Lake",975.7609,42.285892,-111.32751499999999,"Bear Lake County","county"
-39159,39,"39","Union",431.73944000000006,40.295902000000005,-83.36704,"Union County","county"
-39035,39,"39","Cuyahoga",457.1967,41.76039,-81.72421999999999,"Cuyahoga County","county"
-48285,48,"48","Lavaca",969.7422,29.382578000000002,-96.92363,"Lavaca County","county"
-40105,40,"40","Nowata",565.8367,36.789615999999995,-95.61331,"Nowata County","county"
-13125,13,"13","Glascock",143.75043,33.22749,-82.60691,"Glascock County","county"
-41059,41,"41","Umatilla",3215.5583,45.591198,-118.73388,"Umatilla County","county"
-46102,46,"46","Oglala Lakota",2093.6724,43.33358,-102.56168000000001,"Oglala Lakota County","county"
-20117,20,"20","Marshall",900.2054,39.782707,-96.52124,"Marshall County","county"
-22065,22,"22","Madison Parish",624.4258,32.346878000000004,-91.23193,"Madison Parish","county"
-30105,30,"30","Valley",4926.267,48.34985,-106.670425,"Valley County","county"
-13313,13,"13","Whitfield",290.44775,34.801727,-84.968544,"Whitfield County","county"
-20203,20,"20","Wichita",718.5907599999999,38.481922,-101.347435,"Wichita County","county"
-46023,46,"46","Charles Mix",1097.5255,43.206184,-98.595146,"Charles Mix County","county"
-31027,31,"31","Cedar",740.2679400000001,42.60456,-97.25686999999999,"Cedar County","county"
-53035,53,"53","Kitsap",395.1398,47.639595,-122.649635,"Kitsap County","county"
-17111,17,"17","McHenry",603.4159,42.3243,-88.45225,"McHenry County","county"
-30069,30,"30","Petroleum",1655.6809,47.14192,-108.22658,"Petroleum County","county"
-29033,29,"29","Carroll",694.6453,39.427376,-93.50023,"Carroll County","county"
-53075,53,"53","Whitman",2159.3347,46.905945,-117.53538999999999,"Whitman County","county"
-27147,27,"27","Steele",429.6597,44.015263,-93.22045,"Steele County","county"
-31169,31,"31","Thayer",573.8265,40.173843,-97.59626,"Thayer County","county"
-47033,47,"47","Crockett",265.53722999999997,35.818794,-89.13249,"Crockett County","county"
-19079,19,"19","Hamilton",576.773,42.39077,-93.7092,"Hamilton County","county"
-39165,39,"39","Warren",401.20285,39.42565,-84.16991,"Warren County","county"
-13255,13,"13","Spalding",195.9999,33.26235,-84.284904,"Spalding County","county"
-34019,34,"34","Hunterdon",427.84545999999995,40.565284999999996,-74.91197,"Hunterdon County","county"
-29217,29,"29","Vernon",826.4195,37.850196999999994,-94.3416,"Vernon County","county"
-18121,18,"18","Parke",444.7362,39.77425,-87.19695,"Parke County","county"
-19069,19,"19","Franklin",581.99207,42.736546000000004,-93.271416,"Franklin County","county"
-13035,13,"13","Butts",183.6962,33.290356,-83.95822,"Butts County","county"
-8039,8,"08","Elbert",1850.8993,39.31516,-104.114075,"Elbert County","county"
-44001,44,"44","Bristol",24.133114000000003,41.706833,-71.28664,"Bristol County","county"
-48035,48,"48","Bosque",983.0141,31.90082,-97.63764,"Bosque County","county"
-44005,44,"44","Newport",102.44097,41.502502,-71.28369,"Newport County","county"
-39045,39,"39","Fairfield",504.42682,39.747692,-82.62668599999999,"Fairfield County","county"
-38069,38,"38","Pierce",1018.3193,48.238884000000006,-99.9665,"Pierce County","county"
-17015,17,"17","Carroll",445.4216,42.0709,-89.92419,"Carroll County","county"
-27125,27,"27","Red Lake",432.42184000000003,47.865486,-96.08718,"Red Lake County","county"
-41031,41,"41","Jefferson",1782.2993,44.64515,-121.17863500000001,"Jefferson County","county"
-47021,47,"47","Cheatham",302.5351,36.25517,-87.10081,"Cheatham County","county"
-46127,46,"46","Union",460.77243,42.831109999999995,-96.650826,"Union County","county"
-1051,1,"01","Elmore",618.46747,32.597229999999996,-86.14274,"Elmore County","county"
-13187,13,"13","Lumpkin",282.95206,34.568142,-83.998924,"Lumpkin County","county"
-39083,39,"39","Knox",525.5233,40.403620000000004,-82.42239000000001,"Knox County","county"
-19017,19,"19","Bremer",435.49387,42.780895,-92.327354,"Bremer County","county"
-48175,48,"48","Goliad",852.0401,28.6607,-97.43041,"Goliad County","county"
-37089,37,"37","Henderson",372.95575,35.336414000000005,-82.479744,"Henderson County","county"
-12061,12,"12","Indian River",502.8008,27.70053,-80.57479000000001,"Indian River County","county"
-48393,48,"48","Roberts",924.0891,35.838596,-100.836685,"Roberts County","county"
-31049,31,"31","Deuel",439.86605999999995,41.111903999999996,-102.33261,"Deuel County","county"
-36051,36,"36","Livingston",631.783,42.727486,-77.76978000000001,"Livingston County","county"
-19141,19,"19","O'Brien",573.0546,43.083744,-95.625626,"O'Brien County","county"
-48059,48,"48","Callahan",899.4028,32.293147999999995,-99.37224599999999,"Callahan County","county"
-48379,48,"48","Rains",229.46094,32.87058,-95.79544,"Rains County","county"
-20067,20,"20","Grant",574.8276,37.547540000000005,-101.29936,"Grant County","county"
-51105,51,"51","Lee",435.39224,36.70172,-83.13011,"Lee County","county"
-35051,35,"35","Sierra",4181.3384,33.11947,-107.18816000000001,"Sierra County","county"
-5043,5,"05","Drew",828.4061,33.587241999999996,-91.72278,"Drew County","county"
-31123,31,"31","Morrill",1423.8856,41.732203999999996,-102.99059,"Morrill County","county"
-29015,29,"29","Benton",704.06665,38.301037,-93.28794,"Benton County","county"
-5109,5,"05","Pike",600.6454,34.158190000000005,-93.65866,"Pike County","county"
-8077,8,"08","Mesa",3329.0278,39.019524,-108.46056999999999,"Mesa County","county"
-29065,29,"29","Dent",752.78625,37.603072999999995,-91.489716,"Dent County","county"
-51185,51,"51","Tazewell",518.8084,37.125397,-81.56293000000001,"Tazewell County","county"
-42103,42,"42","Pike",544.97906,41.325947,-75.03152,"Pike County","county"
-42115,42,"42","Susquehanna",823.52386,41.819664,-75.80096999999999,"Susquehanna County","county"
-48343,48,"48","Morris",251.99777000000003,33.116467,-94.73125999999999,"Morris County","county"
-42125,42,"42","Washington",857.0164,40.200005,-80.25213000000001,"Washington County","county"
-50001,50,"50","Addison",766.3539999999999,44.031246,-73.14158,"Addison County","county"
-20103,20,"20","Leavenworth",463.4208,39.18951,-95.03898000000001,"Leavenworth County","county"
-26121,26,"26","Muskegon",503.9307,43.289257,-86.75189,"Muskegon County","county"
-28049,28,"28","Hinds",869.85956,32.267788,-90.46602,"Hinds County","county"
-48281,48,"48","Lampasas",712.8656,31.196732,-98.24089000000001,"Lampasas County","county"
-51107,51,"51","Loudoun",515.783,39.0812,-77.6389,"Loudoun County","county"
-29185,29,"29","St. Clair",675.00415,38.042229999999996,-93.77656,"St. Clair County","county"
-36025,36,"36","Delaware",1442.4718,42.193985,-74.96673,"Delaware County","county"
-30071,30,"30","Phillips",5140.653,48.250145,-107.928894,"Phillips County","county"
-29129,29,"29","Mercer",453.85062,40.421413,-93.567635,"Mercer County","county"
-53045,53,"53","Mason",959.58875,47.354126,-123.17385,"Mason County","county"
-37127,37,"37","Nash",540.4621,35.965946,-77.98756,"Nash County","county"
-51199,51,"51","York",104.61229,37.21908,-76.561646,"York County","county"
-29159,29,"29","Pettis",682.2478,38.727367,-93.28520999999999,"Pettis County","county"
-30063,30,"30","Missoula",2593.0972,47.027264,-113.89268999999999,"Missoula County","county"
-20019,20,"20","Chautauqua",638.9027,37.15426,-96.2454,"Chautauqua County","county"
-48459,48,"48","Upshur",582.9997,32.735347999999995,-94.941185,"Upshur County","county"
-51047,51,"51","Culpeper",379.19965,38.485929999999996,-77.956474,"Culpeper County","county"
-40061,40,"40","Haskell",576.743,35.232296000000005,-95.10956999999999,"Haskell County","county"
-54069,54,"54","Ohio",105.8338,40.098929999999996,-80.62073000000001,"Ohio County","county"
-54065,54,"54","Morgan",229.08046000000002,39.555,-78.25735,"Morgan County","county"
-51165,51,"51","Rockingham",849.818,38.507584,-78.88532,"Rockingham County","county"
-18183,18,"18","Whitley",335.5931,41.136425,-85.50189,"Whitley County","county"
-6093,6,"06","Siskiyou",6278.981,41.587986,-122.53329,"Siskiyou County","county"
-46037,46,"46","Day",1028.5295,45.35516,-97.58143000000001,"Day County","county"
-22071,22,"22","Orleans Parish",169.4393,30.053420000000003,-89.9345,"Orleans Parish","county"
-1073,1,"01","Jefferson",1111.453,33.553444,-86.89654,"Jefferson County","county"
-1127,1,"01","Walker",791.02905,33.791557,-87.30109399999999,"Walker County","county"
-29063,29,"29","DeKalb",421.37198,39.894665,-94.40719,"DeKalb County","county"
-12039,12,"12","Gadsden",516.3264,30.578685999999998,-84.61261,"Gadsden County","county"
-13083,13,"13","Dade",173.9856,34.852425,-85.5062,"Dade County","county"
-28033,28,"28","DeSoto",476.32892000000004,34.874268,-89.99324,"DeSoto County","county"
-51187,51,"51","Warren",214.5415,38.908221999999995,-78.207596,"Warren County","county"
-17047,17,"17","Edwards",222.40722999999997,38.417095,-88.04794,"Edwards County","county"
-47113,47,"47","Madison",557.1929299999999,35.606056,-88.83343,"Madison County","county"
-69110,69,"69","Saipan Municipality",45.905632000000004,15.198095,145.77719,"Saipan Municipality","county"
-1111,1,"01","Randolph",580.5691,33.296473999999996,-85.464066,"Randolph County","county"
-37009,37,"37","Ashe",425.08594000000005,36.44347,-81.49934,"Ashe County","county"
-8033,8,"08","Dolores",1067.2067,37.711723,-108.52412,"Dolores County","county"
-39089,39,"39","Licking",682.46155,40.091503,-82.48344,"Licking County","county"
-51683,51,"51","Manassas city",9.849598,38.746807000000004,-77.482635,"Manassas city","county"
-5139,5,"05","Union",1039.2896,33.168217,-92.598145,"Union County","county"
-17071,17,"17","Henderson",378.80896,40.814471999999995,-90.94124599999999,"Henderson County","county"
-1101,1,"01","Montgomery",785.36536,32.20288,-86.20446,"Montgomery County","county"
-8005,8,"08","Arapahoe",797.9869,39.644554,-104.3317,"Arapahoe County","county"
-21155,21,"21","Marion",343.04944,37.552605,-85.26895999999999,"Marion County","county"
-53057,53,"53","Skagit",1730.28,48.49329,-121.81577,"Skagit County","county"
-28067,28,"28","Jones",694.8353,31.616602,-89.16853,"Jones County","county"
-55021,55,"55","Columbia",765.5725,43.47188,-89.330475,"Columbia County","county"
-37019,37,"37","Brunswick",849.2217,34.038754,-78.22776999999999,"Brunswick County","county"
-27029,27,"27","Clearwater",998.86,47.575874,-95.37111999999999,"Clearwater County","county"
-51131,51,"51","Northampton",211.72617000000002,37.302776,-75.92402,"Northampton County","county"
-20163,20,"20","Rooks",890.55725,39.34601,-99.32449,"Rooks County","county"
-18041,18,"18","Fayette",215.02821,39.639656,-85.18503,"Fayette County","county"
-31079,31,"31","Hall",546.4096,40.866028,-98.50265999999999,"Hall County","county"
-31081,31,"31","Hamilton",541.9163,40.872818,-98.02233000000001,"Hamilton County","county"
-31115,31,"31","Loup",563.5405,41.903183,-99.50985,"Loup County","county"
-30091,30,"30","Sheridan",1675.8652,48.705524,-104.53390999999999,"Sheridan County","county"
-31063,31,"31","Frontier",974.66437,40.53095,-100.406685,"Frontier County","county"
-72089,72,"72","Luquillo Municipio",25.812345999999998,18.367995999999998,-65.7099,"Luquillo Municipio","county"
-1007,1,"01","Bibb",622.4825400000001,33.015892,-87.127144,"Bibb County","county"
-28075,28,"28","Lauderdale",703.6983,32.404,-88.660446,"Lauderdale County","county"
-27011,27,"27","Big Stone",499.19365999999997,45.419926000000004,-96.40223,"Big Stone County","county"
-27013,27,"27","Blue Earth",747.8093,44.03371,-94.06401,"Blue Earth County","county"
-51091,51,"51","Highland",415.17699999999996,38.366240000000005,-79.56447,"Highland County","county"
-51177,51,"51","Spotsylvania",401.51706,38.18243,-77.65723,"Spotsylvania County","county"
-33017,33,"33","Strafford",367.48337000000004,43.293274,-71.03559,"Strafford County","county"
-13153,13,"13","Houston",376.05612,32.458286,-83.66252,"Houston County","county"
-26041,26,"26","Delta",1171.1409,45.80523,-86.90194,"Delta County","county"
-5131,5,"05","Sebastian",531.18677,35.196979999999996,-94.27499,"Sebastian County","county"
-6087,6,"06","Santa Cruz",445.11166,37.01249,-122.0072,"Santa Cruz County","county"
-13191,13,"13","McIntosh",431.36877000000004,31.488506,-81.37229,"McIntosh County","county"
-13207,13,"13","Monroe",396.10504,33.017437,-83.922935,"Monroe County","county"
-29069,29,"29","Dunklin",541.1168,36.306903999999996,-90.06539000000001,"Dunklin County","county"
-48483,48,"48","Wheeler",914.56396,35.392593,-100.253105,"Wheeler County","county"
-13117,13,"13","Forsyth",224.55907000000002,34.225143,-84.12741,"Forsyth County","county"
-48409,48,"48","San Patricio",693.4596,28.011795000000003,-97.51716,"San Patricio County","county"
-28147,28,"28","Walthall",403.94196,31.164492,-90.10343,"Walthall County","county"
-29137,29,"29","Monroe",647.6805,39.49827,-92.006454,"Monroe County","county"
-26073,26,"26","Isabella",572.7181,43.645233000000005,-84.839424,"Isabella County","county"
-48341,48,"48","Moore",899.72864,35.835674,-101.8905,"Moore County","county"
-45017,45,"45","Calhoun",381.16492,33.67478,-80.78035,"Calhoun County","county"
-56035,56,"56","Sublette",4886.648,42.76793,-109.91617,"Sublette County","county"
-21069,21,"21","Fleming",348.55692,38.367847,-83.6992,"Fleming County","county"
-55019,55,"55","Clark",1209.7369,44.739346000000005,-90.609955,"Clark County","county"
-45091,45,"45","York",680.69604,34.97019,-81.18319,"York County","county"
-18001,18,"18","Adams",338.93800000000005,40.74573,-84.93613,"Adams County","county"
-22005,22,"22","Ascension Parish",290.07275,30.206444,-90.91250600000001,"Ascension Parish","county"
-42119,42,"42","Union",315.9672,40.962177000000004,-77.05547,"Union County","county"
-51041,51,"51","Chesterfield",423.5708,37.378433,-77.58584599999999,"Chesterfield County","county"
-22001,22,"22","Acadia Parish",655.1916,30.291496000000002,-92.41103000000001,"Acadia Parish","county"
-42039,42,"42","Crawford",1012.33594,41.687878000000005,-80.107796,"Crawford County","county"
-46123,46,"46","Tripp",1612.513,43.349728000000006,-99.87621999999999,"Tripp County","county"
-19077,19,"19","Guthrie",590.6401400000001,41.683575,-94.501274,"Guthrie County","county"
-19183,19,"19","Washington",568.8312400000001,41.329403000000006,-91.72505,"Washington County","county"
-46111,46,"46","Sanborn",569.2677,44.018944,-98.09170999999999,"Sanborn County","county"
-40051,40,"40","Grady",1100.5779,35.021057,-97.88689000000001,"Grady County","county"
-54039,54,"54","Kanawha",901.6625,38.328068,-81.52351,"Kanawha County","county"
-55109,55,"55","St. Croix",722.47864,45.028957,-92.44728,"St. Croix County","county"
-42121,42,"42","Venango",674.3074,41.400715000000005,-79.765816,"Venango County","county"
-39153,39,"39","Summit",412.80325,41.121845,-81.53493,"Summit County","county"
-13127,13,"13","Glynn",419.56528,31.212709999999998,-81.49645,"Glynn County","county"
-48479,48,"48","Webb",3361.5918,27.7608,-99.34075,"Webb County","county"
-37123,37,"37","Montgomery",491.55395999999996,35.334415,-79.9066,"Montgomery County","county"
-23003,23,"23","Aroostook",6671.3193,46.709194000000004,-68.61241,"Aroostook County","county"
-28065,28,"28","Jefferson Davis",408.4603,31.564808000000003,-89.82709,"Jefferson Davis County","county"
-18175,18,"18","Washington",513.7088,38.600613,-86.10475,"Washington County","county"
-48031,48,"48","Blanco",709.2759,30.266455,-98.39921600000001,"Blanco County","county"
-51025,51,"51","Brunswick",566.25287,36.764206,-77.86148,"Brunswick County","county"
-47045,47,"47","Dyer",512.3688,36.054195,-89.39831,"Dyer County","county"
-47053,47,"47","Gibson",602.7656,35.99163,-88.933815,"Gibson County","county"
-51149,51,"51","Prince George",265.3509,37.187325,-77.22099,"Prince George County","county"
-5075,5,"05","Lawrence",587.63416,36.0411,-91.10115,"Lawrence County","county"
-38027,38,"38","Eddy",630.26013,47.723434000000005,-98.900475,"Eddy County","county"
-53053,53,"53","Pierce",1668.1056,47.051414,-122.15324,"Pierce County","county"
-16063,16,"16","Lincoln",1201.4045,42.98618,-114.1539,"Lincoln County","county"
-42071,42,"42","Lancaster",943.9559300000001,40.041992,-76.2502,"Lancaster County","county"
-55057,55,"55","Juneau",767.1067,43.932835,-90.11398,"Juneau County","county"
-47151,47,"47","Scott",532.3186599999999,36.435234,-84.50352,"Scott County","county"
-46031,46,"46","Corson",2469.778,45.68567,-101.179665,"Corson County","county"
-46053,46,"46","Gregory",1014.98413,43.175144,-99.20659,"Gregory County","county"
-37181,37,"37","Vance",252.4088,36.365482,-78.40543000000001,"Vance County","county"
-21033,21,"21","Caldwell",344.80172999999996,37.148643,-87.87051,"Caldwell County","county"
-45011,45,"45","Barnwell",548.3976,33.26055,-81.43423,"Barnwell County","county"
-47039,47,"47","Decatur",333.88925,35.603138,-88.11029,"Decatur County","county"
-18009,18,"18","Blackford",165.08722,40.47267,-85.32373,"Blackford County","county"
-1055,1,"01","Etowah",535.1063,34.04764,-86.03426,"Etowah County","county"
-16025,16,"16","Camas",1074.2708,43.502552,-114.77213,"Camas County","county"
-20155,20,"20","Reno",1255.3503,37.948184999999995,-98.07835,"Reno County","county"
-47119,47,"47","Maury",613.1596,35.615696,-87.07777,"Maury County","county"
-56015,56,"56","Goshen",2225.6887,42.089455,-104.35354,"Goshen County","county"
-55107,55,"55","Rusk",913.58435,45.472733000000005,-91.13674,"Rusk County","county"
-55133,55,"55","Waukesha",549.73956,43.018368,-88.30424000000001,"Waukesha County","county"
-21079,21,"21","Garrard",230.1065,37.63016,-84.54585,"Garrard County","county"
-25021,25,"25","Norfolk",396.12067,42.171738,-71.18111400000001,"Norfolk County","county"
-18063,18,"18","Hendricks",406.90738,39.768963,-86.50990999999999,"Hendricks County","county"
-17077,17,"17","Jackson",583.58997,37.786095,-89.38121,"Jackson County","county"
-45043,45,"45","Georgetown",813.9215,33.41753,-79.29633000000001,"Georgetown County","county"
-38041,38,"38","Hettinger",1132.2776,46.435703000000004,-102.45424,"Hettinger County","county"
-49019,49,"49","Grand",3672.8684,38.974327,-109.57345,"Grand County","county"
-49045,49,"49","Tooele",6942.182,40.467754,-113.12398,"Tooele County","county"
-51650,51,"51","Hampton city",51.45988,37.047962,-76.29729499999999,"Hampton city","county"
-55011,55,"55","Buffalo",675.8135,44.38563,-91.76129,"Buffalo County","county"
-51069,51,"51","Frederick",413.18273999999997,39.20366,-78.26383,"Frederick County","county"
-54041,54,"54","Lewis",386.9421,38.988876,-80.495476,"Lewis County","county"
-27119,27,"27","Polk",1971.1396,47.774254,-96.400024,"Polk County","county"
-27127,27,"27","Redwood",878.6028,44.403534,-95.25424,"Redwood County","county"
-47047,47,"47","Fayette",704.79926,35.196995,-89.4138,"Fayette County","county"
-60040,60,"60","Swains Island",0.93926597,-11.054436,-171.06902,"Swains Island","county"
-22089,22,"22","St. Charles Parish",277.7603,29.905721999999997,-90.35786,"St. Charles Parish","county"
-5111,5,"05","Poinsett",758.388,35.568870000000004,-90.68111,"Poinsett County","county"
-12045,12,"12","Gulf",553.45807,29.907257,-85.25654,"Gulf County","county"
-47063,47,"47","Hamblen",161.19437,36.218395,-83.26607,"Hamblen County","county"
-1021,1,"01","Chilton",692.87506,32.85405,-86.72661,"Chilton County","county"
-48351,48,"48","Newton",933.70886,30.786718,-93.73925,"Newton County","county"
-48219,48,"48","Hockley",908.4226699999999,33.60593,-102.3434,"Hockley County","county"
-13009,13,"13","Baldwin",258.7079,33.059490000000004,-83.255455,"Baldwin County","county"
-37175,37,"37","Transylvania",378.36612,35.210102,-82.816666,"Transylvania County","county"
-37171,37,"37","Surry",533.7604,36.415417,-80.68646,"Surry County","county"
-1031,1,"01","Coffee",679.0092,31.402258000000003,-85.9896,"Coffee County","county"
-39149,39,"39","Shelby",407.70956,40.33668,-84.20414,"Shelby County","county"
-16027,16,"16","Canyon",587.06714,43.625797,-116.70906000000001,"Canyon County","county"
-30019,30,"30","Daniels",1426.0648,48.79443,-105.54173999999999,"Daniels County","county"
-12073,12,"12","Leon",666.9127,30.45931,-84.2778,"Leon County","county"
-40119,40,"40","Payne",684.9244,36.079223999999996,-96.97525999999999,"Payne County","county"
-1039,1,"01","Covington",1030.5935,31.243988,-86.44872,"Covington County","county"
-18093,18,"18","Lawrence",449.19385,38.839813,-86.48782,"Lawrence County","county"
-20069,20,"20","Gray",868.8969,37.744514,-100.45170999999999,"Gray County","county"
-21045,21,"21","Casey",444.2536,37.32196,-84.92822,"Casey County","county"
-21169,21,"21","Metcalfe",289.6506,36.99243,-85.63345,"Metcalfe County","county"
-21207,21,"21","Russell",253.7011,36.990584999999996,-85.05495,"Russell County","county"
-22011,22,"22","Beauregard Parish",1157.4019,30.645018,-93.34025600000001,"Beauregard Parish","county"
-23025,23,"23","Somerset",3924.4163,45.503646999999994,-69.95611,"Somerset County","county"
-40025,40,"40","Cimarron",1834.8707,36.74839,-102.5177,"Cimarron County","county"
-21163,21,"21","Meade",305.45337,37.967476,-86.20085999999999,"Meade County","county"
-21179,21,"21","Nelson",417.53213999999997,37.80312,-85.465935,"Nelson County","county"
-21187,21,"21","Owen",351.11984,38.499393,-84.84159,"Owen County","county"
-29155,29,"29","Pemiscot",492.63297,36.209915,-89.78594,"Pemiscot County","county"
-31125,31,"31","Nance",441.61287999999996,41.402386,-97.99141,"Nance County","county"
-55078,55,"55","Menominee",357.62677,44.991302000000005,-88.66925,"Menominee County","county"
-48365,48,"48","Panola",811.38306,32.16398,-94.30515,"Panola County","county"
-21011,21,"21","Bath",278.80667,38.15225,-83.73764,"Bath County","county"
-48001,48,"48","Anderson",1062.667,31.84126,-95.66173,"Anderson County","county"
-51033,51,"51","Caroline",527.6276,38.03032,-77.35235,"Caroline County","county"
-19167,19,"19","Sioux",767.9402,43.082645,-96.17801,"Sioux County","county"
-6021,6,"06","Glenn",1314.0122,39.602546999999994,-122.4017,"Glenn County","county"
-29510,29,"29","St. Louis city",61.745674,38.6357,-90.24458,"St. Louis city","county"
-13111,13,"13","Fannin",387.11813,34.866543,-84.31733,"Fannin County","county"
-46051,46,"46","Grant",681.46924,45.172638,-96.77226,"Grant County","county"
-46091,46,"46","Marshall",838.1498,45.737045,-97.58086999999999,"Marshall County","county"
-53067,53,"53","Thurston",722.5144,46.93582,-122.83015400000001,"Thurston County","county"
-31107,31,"31","Knox",1108.4808,42.634403000000006,-97.89135,"Knox County","county"
-35061,35,"35","Valencia",1066.7803,34.716840000000005,-106.80658000000001,"Valencia County","county"
-30079,30,"30","Prairie",1736.6617,46.812386,-105.50398999999999,"Prairie County","county"
-19005,19,"19","Allamakee",639.0655,43.274963,-91.38275,"Allamakee County","county"
-48061,48,"48","Cameron",891.6719,26.102922,-97.47896,"Cameron County","county"
-48339,48,"48","Montgomery",1042.3248,30.298801,-95.50295,"Montgomery County","county"
-8071,8,"08","Las Animas",4773.1006,37.318832,-104.04411,"Las Animas County","county"
-48299,48,"48","Llano",934.0846,30.707584000000004,-98.68469,"Llano County","county"
-48319,48,"48","Mason",928.86755,30.703916999999997,-99.237305,"Mason County","county"
-37043,37,"37","Clay",214.99074,35.052997999999995,-83.752266,"Clay County","county"
-36071,36,"36","Orange",812.3428299999999,41.402409999999996,-74.30625,"Orange County","county"
-36093,36,"36","Schenectady",204.58806,42.81755,-74.04356,"Schenectady County","county"
-54059,54,"54","Mingo",423.15402,37.72116,-82.15899,"Mingo County","county"
-20197,20,"20","Wabaunsee",794.3630400000001,38.955154,-96.20125999999999,"Wabaunsee County","county"
-27055,27,"27","Houston",552.0622599999999,43.666990000000006,-91.50156,"Houston County","county"
-21181,21,"21","Nicholas",195.16805,38.338029999999996,-84.02622,"Nicholas County","county"
-25023,25,"25","Plymouth",658.60315,41.987194,-70.74194,"Plymouth County","county"
-36005,36,"36","Bronx",42.05165,40.848713000000004,-73.852936,"Bronx County","county"
-37055,37,"37","Dare",383.2418,35.60627,-75.76754,"Dare County","county"
-39103,39,"39","Medina",421.47144000000003,41.116172999999996,-81.899765,"Medina County","county"
-42005,42,"42","Armstrong",653.21313,40.81238,-79.46413000000001,"Armstrong County","county"
-34001,34,"34","Atlantic",555.5337,39.469357,-74.63376,"Atlantic County","county"
-55071,55,"55","Manitowoc",589.3245,44.156136,-87.577354,"Manitowoc County","county"
-55029,55,"55","Door",481.97900000000004,45.09342,-87.04868,"Door County","county"
-37047,37,"37","Columbus",938.15295,34.2616,-78.63930500000001,"Columbus County","county"
-39053,39,"39","Gallia",466.54654000000005,38.817046999999995,-82.30174,"Gallia County","county"
-48441,48,"48","Taylor",915.5675,32.297127,-99.89043000000001,"Taylor County","county"
-51570,51,"51","Colonial Heights city",7.519685000000001,37.261684,-77.396805,"Colonial Heights city","county"
-39031,39,"39","Coshocton",563.9784,40.29671,-81.93011,"Coshocton County","county"
-31135,31,"31","Perkins",883.3654,40.857647,-101.627464,"Perkins County","county"
-48205,48,"48","Hartley",1462.0006,35.840244,-102.61005,"Hartley County","county"
-8049,8,"08","Grand",1846.509,40.113064,-106.11084,"Grand County","county"
-48249,48,"48","Jim Wells",865.19916,27.733515,-98.09081,"Jim Wells County","county"
-19189,19,"19","Winnebago",400.50272,43.378124,-93.743484,"Winnebago County","county"
-6079,6,"06","San Luis Obispo",3300.7290000000003,35.385222999999996,-120.44755,"San Luis Obispo County","county"
-1067,1,"01","Henry",561.7694,31.516977,-85.239975,"Henry County","county"
-39175,39,"39","Wyandot",406.89304,40.839783000000004,-83.31368,"Wyandot County","county"
-48505,48,"48","Zapata",998.44635,26.996979999999997,-99.1826,"Zapata County","county"
-13177,13,"13","Lee",355.89444,31.818419,-84.14668,"Lee County","county"
-21019,21,"21","Boyd",159.87265,38.360003999999996,-82.681404,"Boyd County","county"
-27019,27,"27","Carver",354.20853,44.82132,-93.800095,"Carver County","county"
-31037,31,"31","Colfax",411.66083,41.57496,-97.08894000000001,"Colfax County","county"
-45025,45,"45","Chesterfield",799.0128,34.637015999999996,-80.159225,"Chesterfield County","county"
-47101,47,"47","Lewis",282.10152999999997,35.523243,-87.49699,"Lewis County","county"
-41067,41,"41","Washington",724.2980299999999,45.553543,-123.09761999999999,"Washington County","county"
-51810,51,"51","Virginia Beach city",244.7309,36.779984000000006,-76.02521,"Virginia Beach city","county"
-30057,30,"30","Madison",3588.2793,45.32529,-111.91378999999999,"Madison County","county"
-51103,51,"51","Lancaster",133.30202,37.704840000000004,-76.41266999999999,"Lancaster County","county"
-29013,29,"29","Bates",836.7231400000001,38.257217,-94.33925,"Bates County","county"
-33001,33,"33","Belknap",401.8578,43.519108,-71.42537,"Belknap County","county"
-51159,51,"51","Richmond",191.48439,37.942894,-76.73056,"Richmond County","county"
-2230,2,"02","Skagway Municipality",433.9477,59.56038,-135.33827,"Skagway Municipality","county"
-2105,2,"02","Hoonah-Angoon Census Area",6556.696,58.25346,-136.32072,"Hoonah-Angoon Census Area","county"
-53021,53,"53","Franklin",1241.6381,46.53458,-118.906944,"Franklin County","county"
-19093,19,"19","Ida",431.5224,42.39186,-95.50742,"Ida County","county"
-20173,20,"20","Sedgwick",996.96204,37.681046,-97.46105,"Sedgwick County","county"
-48453,48,"48","Travis",992.2665,30.239513,-97.69126999999999,"Travis County","county"
-12057,12,"12","Hillsborough",1021.95917,27.906607,-82.34971999999999,"Hillsborough County","county"
-34021,34,"34","Mercer",224.44795,40.2825,-74.70373000000001,"Mercer County","county"
-31023,31,"31","Butler",584.9209,41.226074,-97.13204,"Butler County","county"
-42129,42,"42","Westmoreland",1028.0756,40.31107,-79.46669,"Westmoreland County","county"
-12015,12,"12","Charlotte",681.13,26.868975,-81.94128,"Charlotte County","county"
-19029,19,"19","Cass",564.2776,41.333824,-94.933304,"Cass County","county"
-39107,39,"39","Mercer",462.45932,40.53533,-84.63206,"Mercer County","county"
-60030,60,"60","Rose Island",0.031697363,-14.536529999999999,-168.15129,"Rose Island","county"
-21115,21,"21","Johnson",261.97345,37.847755,-82.830124,"Johnson County","county"
-44003,44,"44","Kent",168.57086,41.674244,-71.580925,"Kent County","county"
-50025,50,"50","Windham",785.5353,42.995335,-72.721954,"Windham County","county"
-50019,50,"50","Orleans",693.59705,44.82844,-72.25163,"Orleans County","county"
-20085,20,"20","Jackson",656.2417,39.411144,-95.79449,"Jackson County","county"
-22041,22,"22","Franklin Parish",624.61426,32.139076,-91.67237,"Franklin Parish","county"
-28155,28,"28","Webster",421.1592,33.61206,-89.28396,"Webster County","county"
-25011,25,"25","Franklin",699.2225,42.584503000000005,-72.59179,"Franklin County","county"
-31031,31,"31","Cherry",5960.411,42.571323,-101.04765,"Cherry County","county"
-30001,30,"30","Beaverhead",5542.875,45.13386,-112.89287,"Beaverhead County","county"
-29143,29,"29","New Madrid",674.8807400000001,36.59426,-89.65594499999999,"New Madrid County","county"
-5057,5,"05","Hempstead",727.5459,33.735954,-93.66435,"Hempstead County","county"
-29029,29,"29","Camden",656.0653,38.026527,-92.76533,"Camden County","county"
-51117,51,"51","Mecklenburg",625.3309,36.687256,-78.36896,"Mecklenburg County","county"
-21233,21,"21","Webster",332.11017000000004,37.519459999999995,-87.68479,"Webster County","county"
-40047,40,"40","Garfield",1058.5433,36.378056,-97.78845,"Garfield County","county"
-53059,53,"53","Skamania",1658.3384,46.024784000000004,-121.95323,"Skamania County","county"
-26091,26,"26","Lenawee",749.6445,41.896023,-84.07435600000001,"Lenawee County","county"
-13123,13,"13","Gilmer",426.2276,34.690506,-84.45463000000001,"Gilmer County","county"
-27135,27,"27","Roseau",1671.6753,48.761066,-95.8215,"Roseau County","county"
-28089,28,"28","Madison",714.546,32.634370000000004,-90.03416,"Madison County","county"
-48227,48,"48","Howard",900.8221,32.30343,-101.43871999999999,"Howard County","county"
-54099,54,"54","Wayne",506.02367999999996,38.143642,-82.42267,"Wayne County","county"
+id,location,state_fips,state,name,area,latitude,longitude,fullname,location_type
+iso1:us#iso2:us-wv,54,54,54,West Virginia,24041.943,38.647285,-80.618324,West Virginia,state
+iso1:us#iso2:us-fl,12,12,12,Florida,53649.703,28.45743,-82.40915,Florida,state
+iso1:us#iso2:us-il,17,17,17,Illinois,55515.605,40.102875,-89.15261,Illinois,state
+iso1:us#iso2:us-mn,27,27,27,Minnesota,79628.586,46.315956,-94.19960999999999,Minnesota,state
+iso1:us#iso2:us-md,24,24,24,Maryland,9711.466,38.946659999999994,-76.67449,Maryland,state
+iso1:us#iso2:us-ri,44,44,44,Rhode Island,1033.9346,41.59742,-71.527275,Rhode Island,state
+iso1:us#iso2:us-id,16,16,16,Idaho,82647.94,44.348423,-114.55885,Idaho,state
+iso1:us#iso2:us-nh,33,33,33,New Hampshire,8953.704,43.67269,-71.58431,New Hampshire,state
+iso1:us#iso2:us-nc,37,37,37,North Carolina,48621.926,35.53971,-79.13087,North Carolina,state
+iso1:us#iso2:us-vt,50,50,50,Vermont,9218.193000000001,44.068577000000005,-72.66918000000001,Vermont,state
+iso1:us#iso2:us-ct,9,9,9,Connecticut,4842.85,41.579865000000005,-72.74665999999999,Connecticut,state
+iso1:us#iso2:us-de,10,10,10,Delaware,1948.5771,38.998566,-75.44164,Delaware,state
+iso1:us#iso2:us-nm,35,35,35,New Mexico,121316.37,34.434684999999995,-106.131615,New Mexico,state
+iso1:us#iso2:us-ca,6,6,6,California,155859.33,37.155178,-119.54342,California,state
+iso1:us#iso2:us-nj,34,34,34,New Jersey,7355.052,40.107273,-74.6652,New Jersey,state
+iso1:us#iso2:us-wi,55,55,55,Wisconsin,54169.28,44.63091,-89.70939,Wisconsin,state
+iso1:us#iso2:us-or,41,41,41,Oregon,95991.266,43.971714,-120.622955,Oregon,state
+iso1:us#iso2:us-ne,31,31,31,Nebraska,76819.11,41.543304,-99.81187,Nebraska,state
+iso1:us#iso2:us-pa,42,42,42,Pennsylvania,44743.22,40.904602000000004,-77.82753000000001,Pennsylvania,state
+iso1:us#iso2:us-wa,53,53,53,Washington,66457.375,47.407322,-120.5758,Washington,state
+iso1:us#iso2:us-la,22,22,22,Louisiana,43205.957,30.863438000000002,-91.79871,Louisiana,state
+iso1:us#iso2:us-ga,13,13,13,Georgia,57718.293,32.629578,-83.42351,Georgia,state
+iso1:us#iso2:us-al,1,1,1,Alabama,50648.363,32.73963,-86.84346,Alabama,state
+iso1:us#iso2:us-ut,49,49,49,Utah,82379.68,39.334990000000005,-111.65633400000002,Utah,state
+iso1:us#iso2:us-oh,39,39,39,Ohio,40860.15,40.41493,-82.712,Ohio,state
+iso1:us#iso2:us-tx,48,48,48,Texas,261271.94,31.434703999999996,-99.28182,Texas,state
+iso1:us#iso2:us-co,8,8,8,Colorado,103641.016,38.993846999999995,-105.508316,Colorado,state
+iso1:us#iso2:us-sc,45,45,45,South Carolina,30064.736,33.874176,-80.85426,South Carolina,state
+iso1:us#iso2:us-ok,40,40,40,Oklahoma,68598.27,35.59005,-97.48682,Oklahoma,state
+iso1:us#iso2:us-tn,47,47,47,Tennessee,41239.367,35.8608,-86.34999,Tennessee,state
+iso1:us#iso2:us-wy,56,56,56,Wyoming,97092.0,42.98966,-107.544395,Wyoming,state
+iso1:us#iso2:us-hi,15,15,15,Hawaii,6422.644,19.597765,-155.50243999999998,Hawaii,state
+iso1:us#iso2:us-nd,38,38,38,North Dakota,68997.12,47.442173,-100.46082,North Dakota,state
+iso1:us#iso2:us-ky,21,21,21,Kentucky,39492.73,37.533684,-85.29298,Kentucky,state
+iso1:us#iso2:us-vi,78,78,78,United States Virgin Islands,134.37657,18.326748000000002,-64.97125,United States Virgin Islands,state
+iso1:us#iso2:us-mp,69,69,69,Commonwealth of the Northern Mariana Islands,182.35938000000002,14.936784,145.60103,Commonwealth of the Northern Mariana Islands,state
+iso1:us#iso2:us-gu,66,66,66,Guam,209.87523,13.441745000000001,144.7719,Guam,state
+iso1:us#iso2:us-me,23,23,23,Maine,30845.847999999998,45.409283,-68.66662,Maine,state
+iso1:us#iso2:us-ny,36,36,36,New York,47125.37,42.9134,-75.596275,New York,state
+iso1:us#iso2:us-nv,32,32,32,Nevada,109864.11,39.331093,-116.61515,Nevada,state
+iso1:us#iso2:us-ak,2,2,2,Alaska,571036.4,63.34735500000001,-152.83973999999998,Alaska,state
+iso1:us#iso2:us-as,60,60,60,American Samoa,76.3578,-14.267159,-170.66827,American Samoa,state
+iso1:us#iso2:us-mi,26,26,26,Michigan,56607.855,44.844177,-85.66049,Michigan,state
+iso1:us#iso2:us-ar,5,5,5,Arkansas,52039.3,34.895527,-92.444626,Arkansas,state
+iso1:us#iso2:us-ms,28,28,28,Mississippi,46927.133,32.68647,-89.656136,Mississippi,state
+iso1:us#iso2:us-mo,29,29,29,Missouri,68747.8,38.35075,-92.45678000000001,Missouri,state
+iso1:us#iso2:us-mt,30,30,30,Montana,145552.66,47.051178,-109.63481999999999,Montana,state
+iso1:us#iso2:us-ks,20,20,20,Kansas,81761.26,38.498546999999995,-98.38343,Kansas,state
+iso1:us#iso2:us-in,18,18,18,Indiana,35827.656,39.901314,-86.291916,Indiana,state
+iso1:us#iso2:us-pr,72,72,72,Puerto Rico,3424.3416,18.217648,-66.4108,Puerto Rico,state
+iso1:us#iso2:us-sd,46,46,46,South Dakota,75812.266,44.446796,-100.238174,South Dakota,state
+iso1:us#iso2:us-ma,25,25,25,Massachusetts,7801.223000000001,42.15652,-71.48959,Massachusetts,state
+iso1:us#iso2:us-va,51,51,51,Virginia,39483.496,37.52225,-78.66819,Virginia,state
+iso1:us#iso2:us-dc,11,11,11,District of Columbia,61.137646,38.904247,-77.01652,District of Columbia,state
+iso1:us#iso2:us-ia,19,19,19,Iowa,55855.617,42.070023,-93.49335,Iowa,state
+iso1:us#iso2:us-az,4,4,4,Arizona,113657.01,34.203934000000004,-111.60635,Arizona,state
+iso1:us#iso2:us-ne#fips:31039,31039,31,31,Cuming,570.5441,41.915867,-96.78851,Cuming County,county
+iso1:us#iso2:us-wa#fips:53069,53069,53,53,Wahkiakum,262.93018,46.29464,-123.42446000000001,Wahkiakum County,county
+iso1:us#iso2:us-nm#fips:35011,35011,35,35,De Baca,2323.186,34.359272,-104.3687,De Baca County,county
+iso1:us#iso2:us-ne#fips:31109,31109,31,31,Lancaster,837.5885599999999,40.783546,-96.68866,Lancaster County,county
+iso1:us#iso2:us-ne#fips:31129,31129,31,31,Nuckolls,575.1748,40.17649,-98.046844,Nuckolls County,county
+iso1:us#iso2:us-pr#fips:72085,72085,72,72,Las Piedras Municipio,33.880984999999995,18.18715,-65.871185,Las Piedras Municipio,county
+iso1:us#iso2:us-sd#fips:46099,46099,46,46,Minnehaha,806.86194,43.667473,-96.79571999999999,Minnehaha County,county
+iso1:us#iso2:us-tx#fips:48327,48327,48,48,Menard,902.0572,30.885267,-99.858864,Menard County,county
+iso1:us#iso2:us-ca#fips:06091,6091,6,6,Sierra,953.20074,39.576923,-120.521996,Sierra County,county
+iso1:us#iso2:us-ky#fips:21053,21053,21,21,Clinton,197.25694,36.727257,-85.1361,Clinton County,county
+iso1:us#iso2:us-oh#fips:39063,39063,39,39,Hancock,531.3431400000001,41.00047,-83.66603,Hancock County,county
+iso1:us#iso2:us-tx#fips:48189,48189,48,48,Hale,1004.71423,34.068436,-101.82289,Hale County,county
+iso1:us#iso2:us-al#fips:01027,1027,1,1,Clay,603.98157,33.2704,-85.863525,Clay County,county
+iso1:us#iso2:us-tx#fips:48011,48011,48,48,Armstrong,909.14,34.96418,-101.356636,Armstrong County,county
+iso1:us#iso2:us-oh#fips:39003,39003,39,39,Allen,402.51743,40.771626,-84.1061,Allen County,county
+iso1:us#iso2:us-ga#fips:13189,13189,13,13,McDuffie,257.4805,33.479620000000004,-82.47874,McDuffie County,county
+iso1:us#iso2:us-wi#fips:55111,55111,55,55,Sauk,831.5711,43.428000000000004,-89.94332,Sauk County,county
+iso1:us#iso2:us-ar#fips:05137,5137,5,5,Stone,606.49243,35.857002,-92.14048000000001,Stone County,county
+iso1:us#iso2:us-or#fips:41063,41063,41,41,Wallowa,3146.0040000000004,45.593754,-117.18558,Wallowa County,county
+iso1:us#iso2:us-pa#fips:42007,42007,42,42,Beaver,434.72775,40.68414,-80.35072,Beaver County,county
+iso1:us#iso2:us-ms#fips:28061,28061,28,28,Jasper,676.2634,32.01699,-89.11943000000001,Jasper County,county
+iso1:us#iso2:us-mo#fips:29083,29083,29,29,Henry,696.9683,38.38649,-93.792625,Henry County,county
+iso1:us#iso2:us-co#fips:08109,8109,8,8,Saguache,3168.6736,38.03165,-106.23466499999999,Saguache County,county
+iso1:us#iso2:us-nc#fips:37037,37037,37,37,Chatham,681.7438400000001,35.704994,-79.25146,Chatham County,county
+iso1:us#iso2:us-ut#fips:49033,49033,49,49,Rich,1028.8818,41.627598,-111.24023000000001,Rich County,county
+iso1:us#iso2:us-ok#fips:40001,40001,40,40,Adair,573.87463,35.898045,-94.65102399999999,Adair County,county
+iso1:us#iso2:us-oh#fips:39085,39085,39,39,Lake,229.27805,41.924118,-81.39264,Lake County,county
+iso1:us#iso2:us-va#fips:51775,51775,51,51,Salem city,14.518981,37.28533,-80.05524399999999,Salem city,county
+iso1:us#iso2:us-va#fips:51121,51121,51,51,Montgomery,386.85724,37.175533,-80.387794,Montgomery County,county
+iso1:us#iso2:us-tn#fips:47065,47065,47,47,Hamilton,542.3849,35.163470000000004,-85.20184,Hamilton County,county
+iso1:us#iso2:us-nm#fips:35035,35035,35,35,Otero,6612.786999999999,32.6156,-105.751305,Otero County,county
+iso1:us#iso2:us-nm#fips:35003,35003,35,35,Catron,6924.422,33.90162,-108.39193,Catron County,county
+iso1:us#iso2:us-al#fips:01091,1091,1,1,Marengo,976.92584,32.247593,-87.79109,Marengo County,county
+iso1:us#iso2:us-wy#fips:56023,56023,56,56,Lincoln,4075.4753,42.229991999999996,-110.68296000000001,Lincoln County,county
+iso1:us#iso2:us-mo#fips:29011,29011,29,29,Barton,592.0503,37.500797,-94.344086,Barton County,county
+iso1:us#iso2:us-tx#fips:48057,48057,48,48,Calhoun,506.85625999999996,28.44172,-96.579575,Calhoun County,county
+iso1:us#iso2:us-va#fips:51735,51735,51,51,Poquoson city,15.381905,37.12836,-76.303535,Poquoson city,county
+iso1:us#iso2:us-wv#fips:54075,54075,54,54,Pocahontas,940.2705699999999,38.332607,-80.010124,Pocahontas County,county
+iso1:us#iso2:us-tx#fips:48077,48077,48,48,Clay,1088.795,33.785903999999995,-98.21292,Clay County,county
+iso1:us#iso2:us-va#fips:51095,51095,51,51,James City,142.37006,37.324837,-76.777885,James City County,county
+iso1:us#iso2:us-ne#fips:31101,31101,31,31,Keith,1061.6364,41.194244,-101.64445,Keith County,county
+iso1:us#iso2:us-ne#fips:31137,31137,31,31,Phelps,539.8079,40.516365,-99.40655500000001,Phelps County,county
+iso1:us#iso2:us-la#fips:22019,22019,22,22,Calcasieu Parish,1064.1895,30.229559000000002,-93.35802,Calcasieu Parish,county
+iso1:us#iso2:us-la#fips:22111,22111,22,22,Union Parish,876.96875,32.82935,-92.37565,Union Parish,county
+iso1:us#iso2:us-ok#fips:40135,40135,40,40,Sequoyah,673.49677,35.502434,-94.750755,Sequoyah County,county
+iso1:us#iso2:us-al#fips:01049,1049,1,1,DeKalb,777.1252,34.46093,-85.80399,DeKalb County,county
+iso1:us#iso2:us-ny#fips:36101,36101,36,36,Steuben,1390.602,42.266723999999996,-77.38553,Steuben County,county
+iso1:us#iso2:us-pa#fips:42053,42053,42,42,Forest,427.28442,41.513306,-79.2497,Forest County,county
+iso1:us#iso2:us-la#fips:22105,22105,22,22,Tangipahoa Parish,791.3367,30.62153,-90.40663,Tangipahoa Parish,county
+iso1:us#iso2:us-va#fips:51179,51179,51,51,Stafford,269.21396,38.41326,-77.45133,Stafford County,county
+iso1:us#iso2:us-mi#fips:26109,26109,26,26,Menominee,1044.0763,45.536204999999995,-87.50180999999999,Menominee County,county
+iso1:us#iso2:us-in#fips:18073,18073,18,18,Jasper,559.6987,41.01769,-87.11881,Jasper County,county
+iso1:us#iso2:us-ga#fips:13025,13025,13,13,Brantley,443.24075,31.197334,-81.98298,Brantley County,county
+iso1:us#iso2:us-ga#fips:13171,13171,13,13,Lamar,183.50687,33.07444,-84.14669,Lamar County,county
+iso1:us#iso2:us-in#fips:18151,18151,18,18,Steuben,308.78772000000004,41.643467,-85.0024,Steuben County,county
+iso1:us#iso2:us-tx#fips:48361,48361,48,48,Orange,333.7971,30.122321999999997,-93.8941,Orange County,county
+iso1:us#iso2:us-oh#fips:39047,39047,39,39,Fayette,406.37473,39.555244,-83.46189,Fayette County,county
+iso1:us#iso2:us-ma#fips:25015,25015,25,25,Hampshire,527.25366,42.339459999999995,-72.6637,Hampshire County,county
+iso1:us#iso2:us-ky#fips:21003,21003,21,21,Allen,344.3526,36.75077,-86.19246,Allen County,county
+iso1:us#iso2:us-nc#fips:37001,37001,37,37,Alamance,423.45963,36.043953,-79.40057,Alamance County,county
+iso1:us#iso2:us-ks#fips:20073,20073,20,20,Greenwood,1143.3429,37.87935,-96.24173,Greenwood County,county
+iso1:us#iso2:us-ma#fips:25025,25025,25,25,Suffolk,58.250533999999995,42.33855,-71.01825,Suffolk County,county
+iso1:us#iso2:us-id#fips:16051,16051,16,16,Jefferson,1093.7168,43.796966999999995,-112.31858999999999,Jefferson County,county
+iso1:us#iso2:us-tx#fips:48177,48177,48,48,Gonzales,1066.7227,29.461911999999998,-97.49192,Gonzales County,county
+iso1:us#iso2:us-tn#fips:47115,47115,47,47,Marion,498.27127,35.133423,-85.6184,Marion County,county
+iso1:us#iso2:us-mi#fips:26007,26007,26,26,Alpena,571.88605,44.894954999999996,-83.426575,Alpena County,county
+iso1:us#iso2:us-ky#fips:21231,21231,21,21,Wayne,458.19943,36.80077,-84.82659,Wayne County,county
+iso1:us#iso2:us-tn#fips:47185,47185,47,47,White,376.69104,35.927048,-85.45579000000001,White County,county
+iso1:us#iso2:us-tx#fips:48147,48147,48,48,Fannin,890.8649,33.591159999999995,-96.10499,Fannin County,county
+iso1:us#iso2:us-ks#fips:20043,20043,20,20,Doniphan,393.49228,39.7885,-95.147224,Doniphan County,county
+iso1:us#iso2:us-tx#fips:48265,48265,48,48,Kerr,1103.3644,30.059953999999998,-99.35334,Kerr County,county
+iso1:us#iso2:us-fl#fips:12053,12053,12,12,Hernando,472.97665,28.573041999999997,-82.466225,Hernando County,county
+iso1:us#iso2:us-fl#fips:12129,12129,12,12,Wakulla,606.4388,30.139433,-84.37485,Wakulla County,county
+iso1:us#iso2:us-fl#fips:12131,12131,12,12,Walton,1037.7776,30.63121,-86.17661,Walton County,county
+iso1:us#iso2:us-ms#fips:28017,28017,28,28,Chickasaw,501.79868,33.933277000000004,-88.947556,Chickasaw County,county
+iso1:us#iso2:us-ak#fips:02130,2130,2,2,Ketchikan Gateway Borough,4857.0903,55.449936,-131.10669,Ketchikan Gateway Borough,county
+iso1:us#iso2:us-mi#fips:26035,26035,26,26,Clare,564.3848,43.99114,-84.838326,Clare County,county
+iso1:us#iso2:us-ks#fips:20157,20157,20,20,Republic,717.4016,39.828907,-97.65089,Republic County,county
+iso1:us#iso2:us-fl#fips:12127,12127,12,12,Volusia,1101.2797,29.05777,-81.16179,Volusia County,county
+iso1:us#iso2:us-ok#fips:40017,40017,40,40,Canadian,896.6103,35.543354,-97.97989,Canadian County,county
+iso1:us#iso2:us-pr#fips:72115,72115,72,72,Quebradillas Municipio,22.683378,18.466356,-66.927605,Quebradillas Municipio,county
+iso1:us#iso2:us-vi#fips:78030,78030,78,78,St. Thomas Island,31.317203999999997,18.326748000000002,-64.97125,St. Thomas Island,county
+iso1:us#iso2:us-ga#fips:13115,13115,13,13,Floyd,509.83994,34.263690000000004,-85.213684,Floyd County,county
+iso1:us#iso2:us-nv#fips:32001,32001,32,32,Churchill,4950.6875,39.53771,-118.26417,Churchill County,county
+iso1:us#iso2:us-ne#fips:31181,31181,31,31,Webster,574.9326,40.180645,-98.49859000000001,Webster County,county
+iso1:us#iso2:us-il#fips:17067,17067,17,17,Hancock,793.7753,40.401317999999996,-91.1688,Hancock County,county
+iso1:us#iso2:us-sd#fips:46067,46067,46,46,Hutchinson,813.0409,43.33671,-97.74938,Hutchinson County,county
+iso1:us#iso2:us-or#fips:41013,41013,41,41,Crook,2979.0305,44.163055,-120.37158000000001,Crook County,county
+iso1:us#iso2:us-vt#fips:50011,50011,50,50,Franklin,634.1441,44.858963,-72.9094,Franklin County,county
+iso1:us#iso2:us-mi#fips:26103,26103,26,26,Marquette,1809.1069,46.656597,-87.58403,Marquette County,county
+iso1:us#iso2:us-ct#fips:09007,9007,9,9,Middlesex,369.31686,41.433002,-72.52278000000001,Middlesex County,county
+iso1:us#iso2:us-nc#fips:37057,37057,37,37,Davidson,553.19794,35.79513,-80.20711,Davidson County,county
+iso1:us#iso2:us-il#fips:17025,17025,17,17,Clay,468.2867,38.74682,-88.48232,Clay County,county
+iso1:us#iso2:us-mo#fips:29103,29103,29,29,Knox,504.02588,40.136856,-92.146835,Knox County,county
+iso1:us#iso2:us-mo#fips:29117,29117,29,29,Livingston,532.32074,39.778587,-93.5482,Livingston County,county
+iso1:us#iso2:us-pa#fips:42117,42117,42,42,Tioga,1133.8116,41.76686,-77.257286,Tioga County,county
+iso1:us#iso2:us-ne#fips:31043,31043,31,31,Dakota,264.28165,42.391644,-96.561356,Dakota County,county
+iso1:us#iso2:us-mi#fips:26089,26089,26,26,Leelanau,347.21106000000003,45.146183,-86.051575,Leelanau County,county
+iso1:us#iso2:us-va#fips:51181,51181,51,51,Surry,278.95892000000003,37.119762,-76.88016999999999,Surry County,county
+iso1:us#iso2:us-tx#fips:48391,48391,48,48,Refugio,770.5107,28.322115000000004,-97.162476,Refugio County,county
+iso1:us#iso2:us-oh#fips:39017,39017,39,39,Butler,466.54456,39.439747,-84.565735,Butler County,county
+iso1:us#iso2:us-ga#fips:13273,13273,13,13,Terrell,335.7503,31.777191,-84.43944499999999,Terrell County,county
+iso1:us#iso2:us-ga#fips:13063,13063,13,13,Clayton,141.68373,33.542685999999996,-84.355576,Clayton County,county
+iso1:us#iso2:us-wy#fips:56013,56013,56,56,Fremont,9183.902,43.054832,-108.60893,Fremont County,county
+iso1:us#iso2:us-in#fips:18115,18115,18,18,Ohio,86.15268,38.940529999999995,-84.9643,Ohio County,county
+iso1:us#iso2:us-ga#fips:13073,13073,13,13,Columbia,290.0858,33.54763,-82.2523,Columbia County,county
+iso1:us#iso2:us-co#fips:08115,8115,8,8,Sedgwick,548.0594,40.871567,-102.355354,Sedgwick County,county
+iso1:us#iso2:us-mt#fips:30065,30065,30,30,Musselshell,1869.0211,46.50528,-108.43976599999999,Musselshell County,county
+iso1:us#iso2:us-pa#fips:42043,42043,42,42,Dauphin,524.9068599999999,40.412563,-76.79263,Dauphin County,county
+iso1:us#iso2:us-sd#fips:46101,46101,46,46,Moody,519.4010599999999,44.01243,-96.676056,Moody County,county
+iso1:us#iso2:us-wv#fips:54079,54079,54,54,Putnam,345.69006,38.510513,-81.90611,Putnam County,county
+iso1:us#iso2:us-nj#fips:34037,34037,34,34,Sussex,518.77094,41.137463000000004,-74.69192,Sussex County,county
+iso1:us#iso2:us-ks#fips:20039,20039,20,20,Decatur,893.5477,39.783543,-100.45971,Decatur County,county
+iso1:us#iso2:us-in#fips:18123,18123,18,18,Perry,381.7531,38.081436,-86.62654,Perry County,county
+iso1:us#iso2:us-ms#fips:28145,28145,28,28,Union,415.6214,34.489532000000004,-89.00234,Union County,county
+iso1:us#iso2:us-ne#fips:31015,31015,31,31,Boyd,539.953,42.894447,-98.773026,Boyd County,county
+iso1:us#iso2:us-mn#fips:27095,27095,27,27,Mille Lacs,572.3831,45.929043,-93.63299599999999,Mille Lacs County,county
+iso1:us#iso2:us-nd#fips:38099,38099,38,38,Walsh,1281.6504,48.376979999999996,-97.72223000000001,Walsh County,county
+iso1:us#iso2:us-oh#fips:39115,39115,39,39,Morgan,416.44012000000004,39.624947,-81.861694,Morgan County,county
+iso1:us#iso2:us-oh#fips:39133,39133,39,39,Portage,487.42037999999997,41.168972,-81.19696,Portage County,county
+iso1:us#iso2:us-wy#fips:56041,56041,56,56,Uinta,2081.7915,41.284725,-110.558945,Uinta County,county
+iso1:us#iso2:us-nv#fips:32013,32013,32,32,Humboldt,9641.119,41.407913,-118.12759399999999,Humboldt County,county
+iso1:us#iso2:us-tx#fips:48247,48247,48,48,Jim Hogg,1136.2117,27.05323,-98.747574,Jim Hogg County,county
+iso1:us#iso2:us-co#fips:08017,8017,8,8,Cheyenne,1778.3365,38.835644,-102.60179000000001,Cheyenne County,county
+iso1:us#iso2:us-or#fips:41005,41005,41,41,Clackamas,1870.7423,45.160492,-122.19513,Clackamas County,county
+iso1:us#iso2:us-ar#fips:05113,5113,5,5,Polk,857.5093,34.490913,-94.23088,Polk County,county
+iso1:us#iso2:us-ga#fips:13193,13193,13,13,Macon,400.6757,32.362686,-84.05123,Macon County,county
+iso1:us#iso2:us-in#fips:18007,18007,18,18,Benton,406.4313,40.60094,-87.31479,Benton County,county
+iso1:us#iso2:us-tn#fips:47129,47129,47,47,Morgan,522.19763,36.1387,-84.63926,Morgan County,county
+iso1:us#iso2:us-sd#fips:46043,46043,46,46,Douglas,431.81543,43.391506,-98.35844,Douglas County,county
+iso1:us#iso2:us-md#fips:24047,24047,24,24,Worcester,468.41772000000003,38.222134000000004,-75.30993000000001,Worcester County,county
+iso1:us#iso2:us-il#fips:17185,17185,17,17,Wabash,223.33062999999999,38.44582,-87.83916500000001,Wabash County,county
+iso1:us#iso2:us-in#fips:18069,18069,18,18,Huntington,382.66213999999997,40.826392999999996,-85.4786,Huntington County,county
+iso1:us#iso2:us-ky#fips:21209,21209,21,21,Scott,281.77707000000004,38.285709999999995,-84.57834,Scott County,county
+iso1:us#iso2:us-ia#fips:19053,19053,19,19,Decatur,531.8998,40.736378,-93.78458,Decatur County,county
+iso1:us#iso2:us-in#fips:18169,18169,18,18,Wabash,412.55188,40.843746,-85.79519,Wabash County,county
+iso1:us#iso2:us-in#fips:18003,18003,18,18,Allen,657.3426,41.091908000000004,-85.07179000000001,Allen County,county
+iso1:us#iso2:us-in#fips:18099,18099,18,18,Marshall,443.6349,41.325005,-86.269035,Marshall County,county
+iso1:us#iso2:us-ne#fips:31171,31171,31,31,Thomas,712.9247,41.85573,-100.524704,Thomas County,county
+iso1:us#iso2:us-nd#fips:38085,38085,38,38,Sioux,1094.0887,46.110620000000004,-101.06129,Sioux County,county
+iso1:us#iso2:us-tx#fips:48127,48127,48,48,Dimmit,1328.9298,28.423588,-99.76586999999999,Dimmit County,county
+iso1:us#iso2:us-mn#fips:27045,27045,27,27,Fillmore,861.3254400000001,43.679188,-92.09393,Fillmore County,county
+iso1:us#iso2:us-sc#fips:45023,45023,45,45,Chester,580.681,34.689341999999996,-81.16125,Chester County,county
+iso1:us#iso2:us-mn#fips:27073,27073,27,27,Lac qui Parle,765.04675,44.999855,-96.176834,Lac qui Parle County,county
+iso1:us#iso2:us-ut#fips:49005,49005,49,49,Cache,1164.7704,41.734116,-111.7454,Cache County,county
+iso1:us#iso2:us-wi#fips:55093,55093,55,55,Pierce,574.0378,44.725338,-92.42628,Pierce County,county
+iso1:us#iso2:us-ga#fips:13049,13049,13,13,Charlton,780.1134,30.779903000000004,-82.13964,Charlton County,county
+iso1:us#iso2:us-ga#fips:13233,13233,13,13,Polk,310.3435,33.996014,-85.18834,Polk County,county
+iso1:us#iso2:us-il#fips:17113,17113,17,17,McLean,1183.2893,40.49456,-88.844536,McLean County,county
+iso1:us#iso2:us-me#fips:23001,23001,23,23,Androscoggin,467.96808,44.167683000000004,-70.207436,Androscoggin County,county
+iso1:us#iso2:us-id#fips:16055,16055,16,16,Kootenai,1237.8215,47.675964,-116.69592,Kootenai County,county
+iso1:us#iso2:us-nv#fips:32003,32003,32,32,Clark,7891.9175,36.214256,-115.01381,Clark County,county
+iso1:us#iso2:us-ks#fips:20147,20147,20,20,Phillips,885.90125,39.784504,-99.34215,Phillips County,county
+iso1:us#iso2:us-ne#fips:31089,31089,31,31,Holt,2412.4788,42.459286,-98.78477,Holt County,county
+iso1:us#iso2:us-mo#fips:29101,29101,29,29,Johnson,829.28827,38.741528,-93.81187,Johnson County,county
+iso1:us#iso2:us-wi#fips:55063,55063,55,55,La Crosse,451.7845,43.908221999999995,-91.111755,La Crosse County,county
+iso1:us#iso2:us-la#fips:22021,22021,22,22,Caldwell Parish,529.5077,32.10122,-92.11423,Caldwell Parish,county
+iso1:us#iso2:us-ky#fips:21061,21061,21,21,Edmonson,302.89522999999997,37.227512,-86.21802,Edmonson County,county
+iso1:us#iso2:us-il#fips:17005,17005,17,17,Bond,380.35187,38.885925,-89.43659,Bond County,county
+iso1:us#iso2:us-il#fips:17009,17009,17,17,Brown,305.73715,39.962070000000004,-90.75031,Brown County,county
+iso1:us#iso2:us-mn#fips:27085,27085,27,27,McLeod,491.50284000000005,44.821655,-94.27232,McLeod County,county
+iso1:us#iso2:us-wi#fips:55033,55033,55,55,Dunn,850.18933,44.94775,-91.897644,Dunn County,county
+iso1:us#iso2:us-co#fips:08027,8027,8,8,Custer,738.6509,38.101997,-105.37351000000001,Custer County,county
+iso1:us#iso2:us-mo#fips:29123,29123,29,29,Madison,494.40445,37.47448,-90.343414,Madison County,county
+iso1:us#iso2:us-tx#fips:48353,48353,48,48,Nolan,912.02814,32.31234,-100.41810600000001,Nolan County,county
+iso1:us#iso2:us-pa#fips:42127,42127,42,42,Wayne,725.6251,41.646603000000006,-75.292496,Wayne County,county
+iso1:us#iso2:us-ny#fips:36091,36091,36,36,Saratoga,810.0232,43.106136,-73.855385,Saratoga County,county
+iso1:us#iso2:us-tx#fips:48041,48041,48,48,Brazos,586.15814,30.656713,-96.30239,Brazos County,county
+iso1:us#iso2:us-ok#fips:40095,40095,40,40,Marshall,371.61404,34.027008,-96.77053000000001,Marshall County,county
+iso1:us#iso2:us-md#fips:24001,24001,24,24,Allegany,422.20242,39.612312,-78.7031,Allegany County,county
+iso1:us#iso2:us-wv#fips:54103,54103,54,54,Wetzel,358.07912999999996,39.59818,-80.6354,Wetzel County,county
+iso1:us#iso2:us-wi#fips:55053,55053,55,55,Jackson,987.9485,44.32459,-90.79951,Jackson County,county
+iso1:us#iso2:us-or#fips:41007,41007,41,41,Clatsop,828.16797,46.02451,-123.70504,Clatsop County,county
+iso1:us#iso2:us-wa#fips:53041,53041,53,53,Lewis,2402.8647,46.58007,-122.37743999999999,Lewis County,county
+iso1:us#iso2:us-ny#fips:36003,36003,36,36,Allegany,1029.3948,42.247852,-78.02615,Allegany County,county
+iso1:us#iso2:us-ia#fips:19031,19031,19,19,Cedar,579.4813,41.77236,-91.132614,Cedar County,county
+iso1:us#iso2:us-in#fips:18117,18117,18,18,Orange,398.39162999999996,38.547382,-86.48926,Orange County,county
+iso1:us#iso2:us-ga#fips:13089,13089,13,13,DeKalb,267.74036,33.77066,-84.22634000000001,DeKalb County,county
+iso1:us#iso2:us-ga#fips:13227,13227,13,13,Pickens,232.06727999999998,34.456745,-84.49035,Pickens County,county
+iso1:us#iso2:us-mt#fips:30015,30015,30,30,Chouteau,3972.6726,47.886833,-110.4362,Chouteau County,county
+iso1:us#iso2:us-ne#fips:31017,31017,31,31,Brown,1221.3971,42.359562,-99.92392,Brown County,county
+iso1:us#iso2:us-tn#fips:47013,47013,47,47,Campbell,480.2059,36.401592,-84.15925,Campbell County,county
+iso1:us#iso2:us-nc#fips:37069,37069,37,37,Franklin,491.8171,36.08824,-78.28309,Franklin County,county
+iso1:us#iso2:us-md#fips:24510,24510,24,24,Baltimore city,80.94945,39.300034000000004,-76.61046999999999,Baltimore city,county
+iso1:us#iso2:us-ks#fips:20111,20111,20,20,Lyon,847.5147,38.455402,-96.161644,Lyon County,county
+iso1:us#iso2:us-ia#fips:19027,19027,19,19,Carroll,569.45636,42.039494,-94.867645,Carroll County,county
+iso1:us#iso2:us-la#fips:22107,22107,22,22,Tensas Parish,602.80493,32.001488,-91.342575,Tensas Parish,county
+iso1:us#iso2:us-tn#fips:47123,47123,47,47,Monroe,635.7995,35.44782,-84.2497,Monroe County,county
+iso1:us#iso2:us-ks#fips:20075,20075,20,20,Hamilton,996.5475,37.995243,-101.793686,Hamilton County,county
+iso1:us#iso2:us-ia#fips:19151,19151,19,19,Pocahontas,577.2605599999999,42.73403,-94.678276,Pocahontas County,county
+iso1:us#iso2:us-id#fips:16045,16045,16,16,Gem,559.78845,44.061474,-116.39878,Gem County,county
+iso1:us#iso2:us-ar#fips:05063,5063,5,5,Independence,764.0507,35.7375,-91.55994399999999,Independence County,county
+iso1:us#iso2:us-ar#fips:05085,5085,5,5,Lonoke,771.39996,34.755115999999994,-91.89413499999999,Lonoke County,county
+iso1:us#iso2:us-in#fips:18111,18111,18,18,Newton,401.76833999999997,40.9624,-87.40217,Newton County,county
+iso1:us#iso2:us-ga#fips:13119,13119,13,13,Franklin,261.57043,34.375267,-83.22753,Franklin County,county
+iso1:us#iso2:us-fl#fips:12051,12051,12,12,Hendry,1156.2683,26.539966999999997,-81.15211500000001,Hendry County,county
+iso1:us#iso2:us-ga#fips:13265,13265,13,13,Taliaferro,194.61409,33.55932,-82.875275,Taliaferro County,county
+iso1:us#iso2:us-tx#fips:48245,48245,48,48,Jefferson,876.4018,29.854,-94.14933,Jefferson County,county
+iso1:us#iso2:us-mt#fips:30059,30059,30,30,Meagher,2391.9495,46.5857,-110.92173999999999,Meagher County,county
+iso1:us#iso2:us-co#fips:08067,8067,8,8,La Plata,1689.739,37.28737,-107.83971399999999,La Plata County,county
+iso1:us#iso2:us-tx#fips:48027,48027,48,48,Bell,1051.4247,31.042747,-97.48127,Bell County,county
+iso1:us#iso2:us-ms#fips:28069,28069,28,28,Kemper,766.20844,32.750137,-88.62563,Kemper County,county
+iso1:us#iso2:us-ar#fips:05019,5019,5,5,Clark,866.10693,34.053318,-93.17621,Clark County,county
+iso1:us#iso2:us-or#fips:41035,41035,41,41,Klamath,5942.9478,42.68376,-121.64617,Klamath County,county
+iso1:us#iso2:us-ny#fips:36075,36075,36,36,Oswego,951.6782,43.461445,-76.20926,Oswego County,county
+iso1:us#iso2:us-pr#fips:72105,72105,72,72,Naranjito Municipio,27.402287,18.289920000000002,-66.25344,Naranjito Municipio,county
+iso1:us#iso2:us-al#fips:01019,1019,1,1,Cherokee,553.5439,34.069515,-85.65424,Cherokee County,county
+iso1:us#iso2:us-tx#fips:48019,48019,48,48,Bandera,791.0216,29.756390000000003,-99.24828000000001,Bandera County,county
+iso1:us#iso2:us-mt#fips:30087,30087,30,30,Rosebud,5008.305,46.173233,-106.66675,Rosebud County,county
+iso1:us#iso2:us-nm#fips:35059,35059,35,35,Union,3825.1926,36.488087,-103.47572,Union County,county
+iso1:us#iso2:us-mi#fips:26153,26153,26,26,Schoolcraft,1171.9161,46.021122,-86.19703,Schoolcraft County,county
+iso1:us#iso2:us-ny#fips:36111,36111,36,36,Ulster,1124.2743,41.947212,-74.26546,Ulster County,county
+iso1:us#iso2:us-nj#fips:34007,34007,34,34,Camden,221.35754,39.802406,-74.96125,Camden County,county
+iso1:us#iso2:us-il#fips:17083,17083,17,17,Jersey,369.67264,39.080196,-90.36138000000001,Jersey County,county
+iso1:us#iso2:us-va#fips:51085,51085,51,51,Hanover,467.90157999999997,37.760216,-77.49132,Hanover County,county
+iso1:us#iso2:us-ks#fips:20199,20199,20,20,Wallace,913.6833,38.926624,-101.7711,Wallace County,county
+iso1:us#iso2:us-mi#fips:26003,26003,26,26,Alger,915.06445,47.08008,-86.56411,Alger County,county
+iso1:us#iso2:us-ar#fips:05049,5049,5,5,Fulton,618.2091,36.383617,-91.819664,Fulton County,county
+iso1:us#iso2:us-tx#fips:48215,48215,48,48,Hidalgo,1570.8699,26.396383,-98.18099000000001,Hidalgo County,county
+iso1:us#iso2:us-nc#fips:37155,37155,37,37,Robeson,947.309,34.63921,-79.10088,Robeson County,county
+iso1:us#iso2:us-mi#fips:26123,26123,26,26,Newaygo,838.91516,43.562709999999996,-85.791374,Newaygo County,county
+iso1:us#iso2:us-or#fips:41049,41049,41,41,Morrow,2030.5983,45.425495,-119.60231,Morrow County,county
+iso1:us#iso2:us-mn#fips:27153,27153,27,27,Todd,945.11786,46.06657,-94.90057,Todd County,county
+iso1:us#iso2:us-ar#fips:05083,5083,5,5,Logan,708.2959599999999,35.218655,-93.72091,Logan County,county
+iso1:us#iso2:us-nc#fips:37109,37109,37,37,Lincoln,295.8535,35.488490000000006,-81.22689,Lincoln County,county
+iso1:us#iso2:us-ar#fips:05091,5091,5,5,Miller,625.753,33.305504,-93.901505,Miller County,county
+iso1:us#iso2:us-fl#fips:12095,12095,12,12,Orange,901.8962,28.514390000000002,-81.32328000000001,Orange County,county
+iso1:us#iso2:us-co#fips:08111,8111,8,8,San Juan,387.52875,37.781048,-107.67026000000001,San Juan County,county
+iso1:us#iso2:us-id#fips:16041,16041,16,16,Franklin,663.0415,42.17361,-111.82297,Franklin County,county
+iso1:us#iso2:us-ga#fips:13045,13045,13,13,Carroll,499.0447,33.582237,-85.08053000000001,Carroll County,county
+iso1:us#iso2:us-ks#fips:20161,20161,20,20,Riley,609.72107,39.29121,-96.727486,Riley County,county
+iso1:us#iso2:us-tx#fips:48413,48413,48,48,Schleicher,1310.6862,30.896233000000002,-100.527214,Schleicher County,county
+iso1:us#iso2:us-va#fips:51167,51167,51,51,Russell,473.53964,36.93342,-82.09593000000001,Russell County,county
+iso1:us#iso2:us-nc#fips:37027,37027,37,37,Caldwell,471.90722999999997,35.966396,-81.51254,Caldwell County,county
+iso1:us#iso2:us-id#fips:16065,16065,16,16,Madison,469.2831,43.788612,-111.65699,Madison County,county
+iso1:us#iso2:us-in#fips:18173,18173,18,18,Warrick,384.82748,38.09773,-87.27205,Warrick County,county
+iso1:us#iso2:us-ky#fips:21001,21001,21,21,Adair,405.3018,37.10556,-85.28138,Adair County,county
+iso1:us#iso2:us-ky#fips:21077,21077,21,21,Gallatin,98.3439,38.7601,-84.86215,Gallatin County,county
+iso1:us#iso2:us-ky#fips:21097,21097,21,21,Harrison,306.42258,38.444576,-84.33413,Harrison County,county
+iso1:us#iso2:us-me#fips:23023,23023,23,23,Sagadahoc,253.97975,43.916843,-69.84423000000001,Sagadahoc County,county
+iso1:us#iso2:us-mt#fips:30097,30097,30,30,Sweet Grass,1855.5679,45.81129,-109.94479,Sweet Grass County,county
+iso1:us#iso2:us-tx#fips:48181,48181,48,48,Grayson,932.8647,33.624522999999996,-96.67569,Grayson County,county
+iso1:us#iso2:us-pa#fips:42059,42059,42,42,Greene,575.9519700000001,39.847706,-80.225655,Greene County,county
+iso1:us#iso2:us-ak#fips:02188,2188,2,2,Northwest Arctic Borough,35665.17,67.005066,-160.02109,Northwest Arctic Borough,county
+iso1:us#iso2:us-ks#fips:20051,20051,20,20,Ellis,899.943,38.914597,-99.317314,Ellis County,county
+iso1:us#iso2:us-al#fips:01065,1065,1,1,Hale,644.00854,32.752796000000004,-87.62306,Hale County,county
+iso1:us#iso2:us-al#fips:01105,1105,1,1,Perry,719.6805400000001,32.639004,-87.29382,Perry County,county
+iso1:us#iso2:us-al#fips:01033,1033,1,1,Colbert,592.7651,34.703114,-87.80145999999999,Colbert County,county
+iso1:us#iso2:us-ks#fips:20151,20151,20,20,Pratt,735.0635,37.647594,-98.74011999999999,Pratt County,county
+iso1:us#iso2:us-ky#fips:21017,21017,21,21,Bourbon,289.7561,38.20256,-84.20985999999999,Bourbon County,county
+iso1:us#iso2:us-tn#fips:47149,47149,47,47,Rutherford,619.28754,35.84337,-86.41721,Rutherford County,county
+iso1:us#iso2:us-ga#fips:13075,13075,13,13,Cook,228.42836,31.152515,-83.42944,Cook County,county
+iso1:us#iso2:us-ks#fips:20101,20101,20,20,Lane,717.43317,38.481285,-100.46619,Lane County,county
+iso1:us#iso2:us-ok#fips:40059,40059,40,40,Harper,1038.619,36.80035,-99.6628,Harper County,county
+iso1:us#iso2:us-il#fips:17147,17147,17,17,Piatt,439.2031,40.009033,-88.592354,Piatt County,county
+iso1:us#iso2:us-tx#fips:48107,48107,48,48,Crosby,900.2291,33.609142,-101.29871,Crosby County,county
+iso1:us#iso2:us-pr#fips:72053,72053,72,72,Fajardo Municipio,29.904108,18.386377,-65.58845500000001,Fajardo Municipio,county
+iso1:us#iso2:us-al#fips:01063,1063,1,1,Greene,647.0451,32.844498,-87.9642,Greene County,county
+iso1:us#iso2:us-id#fips:16033,16033,16,16,Clark,1763.205,44.29022,-112.35461399999998,Clark County,county
+iso1:us#iso2:us-ia#fips:19109,19109,19,19,Kossuth,972.7641,43.21248,-94.21398,Kossuth County,county
+iso1:us#iso2:us-pr#fips:72151,72151,72,72,Yabucoa Municipio,55.216488,18.059858,-65.85987,Yabucoa Municipio,county
+iso1:us#iso2:us-nd#fips:38013,38013,38,38,Burke,1103.5867,48.786453,-102.52009,Burke County,county
+iso1:us#iso2:us-nc#fips:37063,37063,37,37,Durham,286.49536,36.03383,-78.87813,Durham County,county
+iso1:us#iso2:us-ia#fips:19085,19085,19,19,Harrison,696.8666,41.688583,-95.82715,Harrison County,county
+iso1:us#iso2:us-ne#fips:31103,31103,31,31,Keya Paha,773.1023,42.875479999999996,-99.71835,Keya Paha County,county
+iso1:us#iso2:us-ia#fips:19187,19187,19,19,Webster,715.73303,42.43358,-94.17583499999999,Webster County,county
+iso1:us#iso2:us-il#fips:17151,17151,17,17,Pope,368.86624,37.417168,-88.54236999999999,Pope County,county
+iso1:us#iso2:us-tn#fips:47159,47159,47,47,Smith,314.3058,36.256645,-85.94192,Smith County,county
+iso1:us#iso2:us-va#fips:51089,51089,51,51,Henry,382.36404,36.78148,-79.75923,Henry County,county
+iso1:us#iso2:us-va#fips:51510,51510,51,51,Alexandria city,14.934701,38.819252,-77.08367,Alexandria city,county
+iso1:us#iso2:us-ia#fips:19101,19101,19,19,Jefferson,435.53795999999994,41.005886,-91.96664,Jefferson County,county
+iso1:us#iso2:us-mt#fips:30049,30049,30,30,Lewis and Clark,3458.4983,47.13201,-112.37337,Lewis and Clark County,county
+iso1:us#iso2:us-ut#fips:49013,49013,49,49,Duchesne,3235.454,40.289394,-110.42958,Duchesne County,county
+iso1:us#iso2:us-ok#fips:40003,40003,40,40,Alfalfa,866.5943599999999,36.729702,-98.32345,Alfalfa County,county
+iso1:us#iso2:us-tx#fips:48119,48119,48,48,Delta,256.84085,33.385933,-95.67335,Delta County,county
+iso1:us#iso2:us-tn#fips:47169,47169,47,47,Trousdale,114.34556599999999,36.393029999999996,-86.15669,Trousdale County,county
+iso1:us#iso2:us-ky#fips:21193,21193,21,21,Perry,339.71155,37.241283,-83.21777,Perry County,county
+iso1:us#iso2:us-sd#fips:46039,46039,46,46,Deuel,622.7598,44.75629,-96.69024,Deuel County,county
+iso1:us#iso2:us-or#fips:41029,41029,41,41,Jackson,2783.3499,42.41162,-122.67561,Jackson County,county
+iso1:us#iso2:us-pr#fips:72067,72067,72,72,Hormigueros Municipio,11.345957,18.134695,-67.116196,Hormigueros Municipio,county
+iso1:us#iso2:us-tx#fips:48507,48507,48,48,Zavala,1297.4512,28.864653000000004,-99.75983000000001,Zavala County,county
+iso1:us#iso2:us-ne#fips:31007,31007,31,31,Banner,746.2360000000001,41.53975,-103.726265,Banner County,county
+iso1:us#iso2:us-ia#fips:19121,19121,19,19,Madison,561.0252,41.33062,-94.01518,Madison County,county
+iso1:us#iso2:us-fl#fips:12011,12011,12,12,Broward,1202.8607,26.193535,-80.476685,Broward County,county
+iso1:us#iso2:us-ga#fips:13279,13279,13,13,Toombs,364.02127,32.117813,-82.33063,Toombs County,county
+iso1:us#iso2:us-mi#fips:26151,26151,26,26,Sanilac,962.6036,43.449154,-82.642815,Sanilac County,county
+iso1:us#iso2:us-tx#fips:48397,48397,48,48,Rockwall,127.118454,32.898678000000004,-96.4044,Rockwall County,county
+iso1:us#iso2:us-mi#fips:26163,26163,26,26,Wayne,611.8002,42.284664,-83.261955,Wayne County,county
+iso1:us#iso2:us-mn#fips:27105,27105,27,27,Nobles,715.11694,43.677685,-95.76313,Nobles County,county
+iso1:us#iso2:us-mn#fips:27001,27001,27,27,Aitkin,1821.8594,46.602447999999995,-93.41976,Aitkin County,county
+iso1:us#iso2:us-nd#fips:38071,38071,38,38,Ramsey,1185.4205,48.266163,-98.73903,Ramsey County,county
+iso1:us#iso2:us-nc#fips:37145,37145,37,37,Person,392.34726,36.38635,-78.96562,Person County,county
+iso1:us#iso2:us-ks#fips:20195,20195,20,20,Trego,889.5043300000001,38.921303,-99.865425,Trego County,county
+iso1:us#iso2:us-ms#fips:28151,28151,28,28,Washington,725.6668,33.273174,-90.94444,Washington County,county
+iso1:us#iso2:us-tx#fips:48133,48133,48,48,Eastland,926.53955,32.324646,-98.83655999999999,Eastland County,county
+iso1:us#iso2:us-ms#fips:28055,28055,28,28,Issaquena,413.05953999999997,32.75554,-91.00353,Issaquena County,county
+iso1:us#iso2:us-tx#fips:48123,48123,48,48,DeWitt,909.00726,29.082346,-97.36166,DeWitt County,county
+iso1:us#iso2:us-tx#fips:48005,48005,48,48,Angelina,797.81635,31.251896000000002,-94.61114,Angelina County,county
+iso1:us#iso2:us-sc#fips:45081,45081,45,45,Saluda,452.9661,34.00528,-81.727905,Saluda County,county
+iso1:us#iso2:us-mo#fips:29125,29125,29,29,Maries,526.9961,38.162617,-91.9236,Maries County,county
+iso1:us#iso2:us-ar#fips:05001,5001,5,5,Arkansas,988.8463,34.28957,-91.37655,Arkansas County,county
+iso1:us#iso2:us-mo#fips:29109,29109,29,29,Lawrence,611.7585,37.106590000000004,-93.83055,Lawrence County,county
+iso1:us#iso2:us-va#fips:51540,51540,51,51,Charlottesville city,10.245017,38.037659999999995,-78.48538,Charlottesville city,county
+iso1:us#iso2:us-il#fips:17011,17011,17,17,Bureau,869.1206,41.401306,-89.52837,Bureau County,county
+iso1:us#iso2:us-oh#fips:39145,39145,39,39,Scioto,610.2508,38.814888,-82.99866999999999,Scioto County,county
+iso1:us#iso2:us-nc#fips:37115,37115,37,37,Madison,449.63037,35.86421,-82.71263,Madison County,county
+iso1:us#iso2:us-id#fips:16053,16053,16,16,Jerome,597.49176,42.691395,-114.26208500000001,Jerome County,county
+iso1:us#iso2:us-oh#fips:39163,39163,39,39,Vinton,412.37,39.25204,-82.48595999999999,Vinton County,county
+iso1:us#iso2:us-tx#fips:48309,48309,48,48,McLennan,1037.1843,31.549595,-97.20151,McLennan County,county
+iso1:us#iso2:us-id#fips:16037,16037,16,16,Custer,4922.344,44.27335,-114.25226599999999,Custer County,county
+iso1:us#iso2:us-ia#fips:19089,19089,19,19,Howard,473.2626,43.36531,-92.32191,Howard County,county
+iso1:us#iso2:us-fl#fips:12099,12099,12,12,Palm Beach,1964.3495,26.649126000000003,-80.44836,Palm Beach County,county
+iso1:us#iso2:us-ga#fips:13181,13181,13,13,Lincoln,210.38835,33.792152,-82.448296,Lincoln County,county
+iso1:us#iso2:us-al#fips:01013,1013,1,1,Butler,776.8649,31.751666999999998,-86.68196999999999,Butler County,county
+iso1:us#iso2:us-tn#fips:47165,47165,47,47,Sumner,529.4754,36.473442,-86.4598,Sumner County,county
+iso1:us#iso2:us-va#fips:51097,51097,51,51,King and Queen,315.17368,37.717773,-76.90558,King and Queen County,county
+iso1:us#iso2:us-ar#fips:05015,5015,5,5,Carroll,630.0721,36.33737,-93.54097,Carroll County,county
+iso1:us#iso2:us-va#fips:51820,51820,51,51,Waynesboro city,14.970304999999998,38.067158,-78.90142,Waynesboro city,county
+iso1:us#iso2:us-ak#fips:02220,2220,2,2,Sitka City and Borough,2870.1128,57.193203000000004,-135.3674,Sitka City and Borough,county
+iso1:us#iso2:us-or#fips:41051,41051,41,41,Multnomah,431.121,45.547709999999995,-122.41736599999999,Multnomah County,county
+iso1:us#iso2:us-tn#fips:47061,47061,47,47,Grundy,360.45633,35.393387,-85.71038,Grundy County,county
+iso1:us#iso2:us-mn#fips:27057,27057,27,27,Hubbard,926.03796,47.09555,-94.91329,Hubbard County,county
+iso1:us#iso2:us-nd#fips:38081,38081,38,38,Sargent,858.5125,46.108204,-97.63005,Sargent County,county
+iso1:us#iso2:us-ny#fips:36089,36089,36,36,St. Lawrence,2679.5928,44.488113,-75.07431,St. Lawrence County,county
+iso1:us#iso2:us-mo#fips:29179,29179,29,29,Reynolds,808.5047,37.366463,-90.97228,Reynolds County,county
+iso1:us#iso2:us-ca#fips:06067,6067,6,6,Sacramento,965.28204,38.450016,-121.34043999999999,Sacramento County,county
+iso1:us#iso2:us-oh#fips:39125,39125,39,39,Paulding,416.44897000000003,41.11895,-84.58211999999999,Paulding County,county
+iso1:us#iso2:us-in#fips:18179,18179,18,18,Wells,368.09963999999997,40.73527,-85.212975,Wells County,county
+iso1:us#iso2:us-va#fips:51063,51063,51,51,Floyd,380.9358,36.931435,-80.350266,Floyd County,county
+iso1:us#iso2:us-ca#fips:06083,6083,6,6,Santa Barbara,2735.2651,34.537056,-120.03997,Santa Barbara County,county
+iso1:us#iso2:us-wv#fips:54005,54005,54,54,Boone,501.55118,38.022816,-81.71354000000001,Boone County,county
+iso1:us#iso2:us-ms#fips:28009,28009,28,28,Benton,406.63016,34.810520000000004,-89.20029,Benton County,county
+iso1:us#iso2:us-ky#fips:21055,21055,21,21,Crittenden,359.97546,37.35815,-88.10501,Crittenden County,county
+iso1:us#iso2:us-ia#fips:19147,19147,19,19,Palo Alto,563.883,43.075336,-94.66905,Palo Alto County,county
+iso1:us#iso2:us-ia#fips:19159,19159,19,19,Ringgold,535.5158,40.735332,-94.24425500000001,Ringgold County,county
+iso1:us#iso2:us-nc#fips:37151,37151,37,37,Randolph,782.3584,35.709915,-79.80621,Randolph County,county
+iso1:us#iso2:us-md#fips:24015,24015,24,24,Cecil,346.31067,39.562355,-75.94158,Cecil County,county
+iso1:us#iso2:us-in#fips:18171,18171,18,18,Warren,364.70285,40.352657,-87.37585,Warren County,county
+iso1:us#iso2:us-ne#fips:31077,31077,31,31,Greeley,569.83057,41.56757,-98.53056,Greeley County,county
+iso1:us#iso2:us-ne#fips:31095,31095,31,31,Jefferson,570.1904,40.175734999999996,-97.143105,Jefferson County,county
+iso1:us#iso2:us-ne#fips:31151,31151,31,31,Saline,574.081,40.516804,-97.13175,Saline County,county
+iso1:us#iso2:us-ky#fips:21119,21119,21,21,Knott,351.53002999999995,37.35437,-82.952545,Knott County,county
+iso1:us#iso2:us-ia#fips:19045,19045,19,19,Clinton,694.9375,41.898075,-90.53424,Clinton County,county
+iso1:us#iso2:us-mn#fips:27063,27063,27,27,Jackson,702.99603,43.671112,-95.149734,Jackson County,county
+iso1:us#iso2:us-mn#fips:27039,27039,27,27,Dodge,439.29297,44.020706,-92.869354,Dodge County,county
+iso1:us#iso2:us-mn#fips:27047,27047,27,27,Freeborn,707.26917,43.674202,-93.35029,Freeborn County,county
+iso1:us#iso2:us-ca#fips:06009,6009,6,6,Calaveras,1020.0335699999999,38.1839,-120.56143999999999,Calaveras County,county
+iso1:us#iso2:us-ma#fips:25001,25001,25,25,Barnstable,394.23107999999996,41.799015000000004,-70.21188000000001,Barnstable County,county
+iso1:us#iso2:us-va#fips:51119,51119,51,51,Middlesex,130.33482,37.606976,-76.52808,Middlesex County,county
+iso1:us#iso2:us-pa#fips:42065,42065,42,42,Jefferson,652.4575,41.138027,-79.01241999999999,Jefferson County,county
+iso1:us#iso2:us-in#fips:18089,18089,18,18,Lake,498.80605999999995,41.472248,-87.37434,Lake County,county
+iso1:us#iso2:us-tn#fips:47003,47003,47,47,Bedford,473.65527000000003,35.513659999999994,-86.45829,Bedford County,county
+iso1:us#iso2:us-tn#fips:47027,47027,47,47,Clay,236.5446,36.54575,-85.545715,Clay County,county
+iso1:us#iso2:us-il#fips:17029,17029,17,17,Coles,508.30037999999996,39.51368,-88.22078,Coles County,county
+iso1:us#iso2:us-tn#fips:47097,47097,47,47,Lauderdale,471.98315,35.76295,-89.62773,Lauderdale County,county
+iso1:us#iso2:us-or#fips:41001,41001,41,41,Baker,3068.0708,44.703426,-117.69193,Baker County,county
+iso1:us#iso2:us-ny#fips:36097,36097,36,36,Schuyler,328.35452000000004,42.419777,-76.93861,Schuyler County,county
+iso1:us#iso2:us-mi#fips:26159,26159,26,26,Van Buren,607.8481,42.28215,-86.306076,Van Buren County,county
+iso1:us#iso2:us-il#fips:17131,17131,17,17,Mercer,561.25885,41.205605,-90.74176999999999,Mercer County,county
+iso1:us#iso2:us-ky#fips:21127,21127,21,21,Lawrence,415.6098,38.07445,-82.73829,Lawrence County,county
+iso1:us#iso2:us-ky#fips:21175,21175,21,21,Morgan,381.1399,37.922940000000004,-83.25894,Morgan County,county
+iso1:us#iso2:us-ky#fips:21177,21177,21,21,Muhlenberg,467.37384000000003,37.213817999999996,-87.13409399999999,Muhlenberg County,county
+iso1:us#iso2:us-il#fips:17049,17049,17,17,Effingham,478.7859,39.047943,-88.59285,Effingham County,county
+iso1:us#iso2:us-tn#fips:47105,47105,47,47,Loudon,229.27965,35.735085,-84.31409000000001,Loudon County,county
+iso1:us#iso2:us-sd#fips:46025,46025,46,46,Clark,957.6361699999999,44.85521,-97.724915,Clark County,county
+iso1:us#iso2:us-hi#fips:15003,15003,15,15,Honolulu,600.5916,21.580023,-158.12341,Honolulu County,county
+iso1:us#iso2:us-fl#fips:12041,12041,12,12,Gilchrist,349.7068,29.723454999999998,-82.7958,Gilchrist County,county
+iso1:us#iso2:us-in#fips:18157,18157,18,18,Tippecanoe,498.92407000000003,40.389133,-86.893555,Tippecanoe County,county
+iso1:us#iso2:us-pa#fips:42109,42109,42,42,Snyder,328.79437,40.755404999999996,-77.07293,Snyder County,county
+iso1:us#iso2:us-tx#fips:48277,48277,48,48,Lamar,907.22687,33.667263,-95.57035,Lamar County,county
+iso1:us#iso2:us-fl#fips:12086,12086,12,12,Miami-Dade,1899.9056,25.61058,-80.4971,Miami-Dade County,county
+iso1:us#iso2:us-ne#fips:31057,31057,31,31,Dundy,919.7097,40.180164000000005,-101.68113000000001,Dundy County,county
+iso1:us#iso2:us-tx#fips:48289,48289,48,48,Leon,1073.1927,31.300493,-95.99562,Leon County,county
+iso1:us#iso2:us-co#fips:08097,8097,8,8,Pitkin,970.7344,39.217537,-106.91616,Pitkin County,county
+iso1:us#iso2:us-nd#fips:38035,38035,38,38,Grand Forks,1436.2742,47.926003,-97.45085,Grand Forks County,county
+iso1:us#iso2:us-in#fips:18091,18091,18,18,LaPorte,598.2905,41.549009999999996,-86.744736,LaPorte County,county
+iso1:us#iso2:us-in#fips:18057,18057,18,18,Hamilton,394.36078,40.053509999999996,-86.02171,Hamilton County,county
+iso1:us#iso2:us-va#fips:51595,51595,51,51,Emporia city,6.904155,36.696182,-77.53596999999999,Emporia city,county
+iso1:us#iso2:us-ok#fips:40081,40081,40,40,Lincoln,952.4038,35.703117,-96.88139,Lincoln County,county
+iso1:us#iso2:us-ks#fips:20071,20071,20,20,Greeley,778.4308,38.480404,-101.80597,Greeley County,county
+iso1:us#iso2:us-ga#fips:13145,13145,13,13,Harris,463.84055,32.73155,-84.91243,Harris County,county
+iso1:us#iso2:us-ga#fips:13251,13251,13,13,Screven,645.7934,32.74475,-81.617584,Screven County,county
+iso1:us#iso2:us-pr#fips:72127,72127,72,72,San Juan Municipio,47.88984,18.422249,-66.069084,San Juan Municipio,county
+iso1:us#iso2:us-tx#fips:48433,48433,48,48,Stonewall,916.34375,33.17958,-100.25381,Stonewall County,county
+iso1:us#iso2:us-oh#fips:39069,39069,39,39,Henry,416.02435,41.331585,-84.0689,Henry County,county
+iso1:us#iso2:us-nh#fips:33009,33009,33,33,Grafton,1708.6584,43.926437,-71.84241999999999,Grafton County,county
+iso1:us#iso2:us-mo#fips:29145,29145,29,29,Newton,624.77563,36.90837,-94.33504,Newton County,county
+iso1:us#iso2:us-in#fips:18129,18129,18,18,Posey,409.38245,38.027615000000004,-87.86865,Posey County,county
+iso1:us#iso2:us-tx#fips:48311,48311,48,48,McMullen,1139.8378,28.384921999999996,-98.57885,McMullen County,county
+iso1:us#iso2:us-il#fips:17035,17035,17,17,Cumberland,345.95544,39.27312,-88.240616,Cumberland County,county
+iso1:us#iso2:us-ga#fips:13297,13297,13,13,Walton,326.82614,33.783885999999995,-83.73183,Walton County,county
+iso1:us#iso2:us-mn#fips:27121,27121,27,27,Pope,669.5531599999999,45.589622,-95.44671,Pope County,county
+iso1:us#iso2:us-va#fips:51157,51157,51,51,Rappahannock,266.3813,38.68452,-78.16882,Rappahannock County,county
+iso1:us#iso2:us-va#fips:51009,51009,51,51,Amherst,473.97763,37.629303,-79.15467,Amherst County,county
+iso1:us#iso2:us-ca#fips:06111,6111,6,6,Ventura,1842.5375,34.358740000000004,-119.13314,Ventura County,county
+iso1:us#iso2:us-il#fips:17033,17033,17,17,Crawford,443.65854,39.002784999999996,-87.76061999999999,Crawford County,county
+iso1:us#iso2:us-co#fips:08093,8093,8,8,Park,2193.9775,39.118916,-105.71765,Park County,county
+iso1:us#iso2:us-ca#fips:06037,6037,6,6,Los Angeles,4058.7905,34.1964,-118.26186000000001,Los Angeles County,county
+iso1:us#iso2:us-az#fips:04027,4027,4,4,Yuma,5514.026999999999,32.77394,-113.910904,Yuma County,county
+iso1:us#iso2:us-ga#fips:13129,13129,13,13,Gordon,356.4548,34.509665999999996,-84.87386,Gordon County,county
+iso1:us#iso2:us-ia#fips:19025,19025,19,19,Calhoun,569.8655,42.38617,-94.643684,Calhoun County,county
+iso1:us#iso2:us-fl#fips:12055,12055,12,12,Highlands,1017.67847,27.341079999999998,-81.342354,Highlands County,county
+iso1:us#iso2:us-va#fips:51580,51580,51,51,Covington city,5.468876,37.78106,-79.985435,Covington city,county
+iso1:us#iso2:us-vt#fips:50017,50017,50,50,Orange,687.0518,44.00339,-72.36969,Orange County,county
+iso1:us#iso2:us-ks#fips:20113,20113,20,20,McPherson,898.31555,38.395813000000004,-97.64749,McPherson County,county
+iso1:us#iso2:us-az#fips:04021,4021,4,4,Pinal,5366.2295,32.91852,-111.36634,Pinal County,county
+iso1:us#iso2:us-oh#fips:39051,39051,39,39,Fulton,405.4609,41.597263,-84.12427,Fulton County,county
+iso1:us#iso2:us-co#fips:08003,8003,8,8,Alamosa,722.6016,37.568443,-105.78804,Alamosa County,county
+iso1:us#iso2:us-fl#fips:12017,12017,12,12,Citrus,581.93066,28.84364,-82.52481,Citrus County,county
+iso1:us#iso2:us-pr#fips:72049,72049,72,72,Culebra Municipio,11.627883,18.3266,-65.30771999999999,Culebra Municipio,county
+iso1:us#iso2:us-pr#fips:72051,72051,72,72,Dorado Municipio,23.116757999999997,18.474375,-66.26196999999999,Dorado Municipio,county
+iso1:us#iso2:us-tn#fips:47041,47041,47,47,DeKalb,304.42526000000004,35.98222,-85.83359499999999,DeKalb County,county
+iso1:us#iso2:us-pa#fips:42031,42031,42,42,Clarion,600.8558,41.198159999999994,-79.42036999999999,Clarion County,county
+iso1:us#iso2:us-sd#fips:46097,46097,46,46,Miner,570.18964,44.02154,-97.60812,Miner County,county
+iso1:us#iso2:us-sd#fips:46073,46073,46,46,Jerauld,526.1505,44.06341,-98.62317,Jerauld County,county
+iso1:us#iso2:us-in#fips:18031,18031,18,18,Decatur,372.58044,39.30598,-85.49983,Decatur County,county
+iso1:us#iso2:us-in#fips:18037,18037,18,18,Dubois,427.27975,38.373344,-86.87338000000001,Dubois County,county
+iso1:us#iso2:us-va#fips:51057,51057,51,51,Essex,257.09692,37.939479999999996,-76.94187,Essex County,county
+iso1:us#iso2:us-sc#fips:45089,45089,45,45,Williamsburg,934.1972699999999,33.626459999999994,-79.71648,Williamsburg County,county
+iso1:us#iso2:us-ny#fips:36031,36031,36,36,Essex,1794.1791,44.1096,-73.77843,Essex County,county
+iso1:us#iso2:us-ia#fips:19195,19195,19,19,Worth,400.13705,43.373490000000004,-93.248535,Worth County,county
+iso1:us#iso2:us-ok#fips:40063,40063,40,40,Hughes,804.51245,35.052933,-96.25118,Hughes County,county
+iso1:us#iso2:us-va#fips:51027,51027,51,51,Buchanan,502.8715,37.26812,-82.038155,Buchanan County,county
+iso1:us#iso2:us-va#fips:51005,51005,51,51,Alleghany,446.58435,37.787907000000004,-80.00867,Alleghany County,county
+iso1:us#iso2:us-ms#fips:28087,28087,28,28,Lowndes,505.46063,33.471424,-88.43972,Lowndes County,county
+iso1:us#iso2:us-in#fips:18143,18143,18,18,Scott,190.40756000000002,38.679432,-85.7519,Scott County,county
+iso1:us#iso2:us-co#fips:08099,8099,8,8,Prowers,1638.453,37.958183,-102.39216,Prowers County,county
+iso1:us#iso2:us-tx#fips:48435,48435,48,48,Sutton,1453.9846,30.522184000000003,-100.51335999999999,Sutton County,county
+iso1:us#iso2:us-pr#fips:72121,72121,72,72,Sabana Grande Municipio,36.314240000000005,18.084484,-66.94761,Sabana Grande Municipio,county
+iso1:us#iso2:us-ok#fips:40101,40101,40,40,Muskogee,810.65137,35.61755,-95.38391,Muskogee County,county
+iso1:us#iso2:us-mo#fips:29043,29043,29,29,Christian,562.6669,36.969738,-93.187614,Christian County,county
+iso1:us#iso2:us-pr#fips:72039,72039,72,72,Ciales Municipio,66.5316,18.295912,-66.51559,Ciales Municipio,county
+iso1:us#iso2:us-ms#fips:28073,28073,28,28,Lamar,496.6915,31.197585999999998,-89.50636999999999,Lamar County,county
+iso1:us#iso2:us-in#fips:18137,18137,18,18,Ripley,446.4385,39.100227000000004,-85.26049,Ripley County,county
+iso1:us#iso2:us-nd#fips:38057,38057,38,38,Mercer,1042.8163,47.307148,-101.83333,Mercer County,county
+iso1:us#iso2:us-ga#fips:13147,13147,13,13,Hart,232.43005,34.348732,-82.96329,Hart County,county
+iso1:us#iso2:us-la#fips:22049,22049,22,22,Jackson Parish,569.2048,32.30429,-92.5617,Jackson Parish,county
+iso1:us#iso2:us-va#fips:51133,51133,51,51,Northumberland,191.4468,37.856970000000004,-76.379684,Northumberland County,county
+iso1:us#iso2:us-tx#fips:48157,48157,48,48,Fort Bend,861.7923599999999,29.526602,-95.77101,Fort Bend County,county
+iso1:us#iso2:us-wi#fips:55047,55047,55,55,Green Lake,349.55588,43.780246999999996,-88.97038,Green Lake County,county
+iso1:us#iso2:us-mt#fips:30073,30073,30,30,Pondera,1624.622,48.228603,-112.22076399999999,Pondera County,county
+iso1:us#iso2:us-wi#fips:55127,55127,55,55,Walworth,555.43805,42.66811,-88.54173,Walworth County,county
+iso1:us#iso2:us-nv#fips:32021,32021,32,32,Mineral,3752.9692,38.516647,-118.41628,Mineral County,county
+iso1:us#iso2:us-il#fips:17057,17057,17,17,Fulton,865.7226,40.46524,-90.20227,Fulton County,county
+iso1:us#iso2:us-ny#fips:36103,36103,36,36,Suffolk,911.8377,40.943554,-72.692215,Suffolk County,county
+iso1:us#iso2:us-in#fips:18161,18161,18,18,Union,161.19566,39.62311,-84.925156,Union County,county
+iso1:us#iso2:us-mo#fips:29119,29119,29,29,McDonald,539.4985,36.63022,-94.343956,McDonald County,county
+iso1:us#iso2:us-ne#fips:31157,31157,31,31,Scotts Bluff,739.4414,41.85033,-103.701546,Scotts Bluff County,county
+iso1:us#iso2:us-nm#fips:35047,35047,35,35,San Miguel,4721.6753,35.476859999999995,-104.80351999999999,San Miguel County,county
+iso1:us#iso2:us-al#fips:01081,1081,1,1,Lee,607.5581,32.604065000000006,-85.35305,Lee County,county
+iso1:us#iso2:us-tx#fips:48367,48367,48,48,Parker,903.7507300000001,32.777096,-97.80591,Parker County,county
+iso1:us#iso2:us-nd#fips:38021,38021,38,38,Dickey,1131.5319,46.107758000000004,-98.49651999999999,Dickey County,county
+iso1:us#iso2:us-nd#fips:38003,38003,38,38,Barnes,1491.609,46.94255,-98.0702,Barnes County,county
+iso1:us#iso2:us-mn#fips:27143,27143,27,27,Sibley,588.8544,44.575733,-94.230125,Sibley County,county
+iso1:us#iso2:us-ga#fips:13293,13293,13,13,Upson,323.4777,32.881836,-84.29228,Upson County,county
+iso1:us#iso2:us-ca#fips:06097,6097,6,6,Sonoma,1575.6454,38.52518,-122.92611000000001,Sonoma County,county
+iso1:us#iso2:us-mi#fips:26033,26033,26,26,Chippewa,1558.5604,46.32182,-84.52063000000001,Chippewa County,county
+iso1:us#iso2:us-id#fips:16019,16019,16,16,Bonneville,1866.0458,43.395171999999995,-111.62188,Bonneville County,county
+iso1:us#iso2:us-ga#fips:13013,13013,13,13,Barrow,161.04183999999998,33.99201,-83.7123,Barrow County,county
+iso1:us#iso2:us-ga#fips:13183,13183,13,13,Long,400.40677,31.749563000000002,-81.74287,Long County,county
+iso1:us#iso2:us-tx#fips:48271,48271,48,48,Kinney,1360.1011,29.347085999999997,-100.4177,Kinney County,county
+iso1:us#iso2:us-ok#fips:40115,40115,40,40,Ottawa,470.83272999999997,36.835762,-94.80268000000001,Ottawa County,county
+iso1:us#iso2:us-pa#fips:42033,42033,42,42,Clearfield,1144.7216,41.000248,-78.47375,Clearfield County,county
+iso1:us#iso2:us-mi#fips:26037,26037,26,26,Clinton,566.43787,42.950455,-84.5917,Clinton County,county
+iso1:us#iso2:us-pr#fips:72133,72133,72,72,Santa Isabel Municipio,34.036106,17.952920000000002,-66.38759,Santa Isabel Municipio,county
+iso1:us#iso2:us-il#fips:17135,17135,17,17,Montgomery,703.7826,39.22807,-89.47814,Montgomery County,county
+iso1:us#iso2:us-ms#fips:28003,28003,28,28,Alcorn,400.05807000000004,34.88657,-88.58111,Alcorn County,county
+iso1:us#iso2:us-ms#fips:28071,28071,28,28,Lafayette,631.7157599999999,34.353077,-89.48538,Lafayette County,county
+iso1:us#iso2:us-la#fips:22043,22043,22,22,Grant Parish,643.0479,31.597788,-92.561714,Grant Parish,county
+iso1:us#iso2:us-mo#fips:29005,29005,29,29,Atchison,547.304,40.431847,-95.43755,Atchison County,county
+iso1:us#iso2:us-il#fips:17115,17115,17,17,Macon,580.59546,39.860237,-88.96153000000001,Macon County,county
+iso1:us#iso2:us-mi#fips:26149,26149,26,26,St. Joseph,500.61252,41.911488,-85.52287,St. Joseph County,county
+iso1:us#iso2:us-il#fips:17055,17055,17,17,Franklin,408.93532999999996,37.99185,-88.92631999999999,Franklin County,county
+iso1:us#iso2:us-mt#fips:30033,30033,30,30,Garfield,4676.7188,47.267185,-106.995995,Garfield County,county
+iso1:us#iso2:us-ne#fips:31001,31001,31,31,Adams,563.2931,40.520634,-98.500046,Adams County,county
+iso1:us#iso2:us-mn#fips:27109,27109,27,27,Olmsted,653.6394,43.9995,-92.410095,Olmsted County,county
+iso1:us#iso2:us-nj#fips:34039,34039,34,34,Union,102.769806,40.65987,-74.30869,Union County,county
+iso1:us#iso2:us-pr#fips:72139,72139,72,72,Trujillo Alto Municipio,20.76765,18.335386,-66.003784,Trujillo Alto Municipio,county
+iso1:us#iso2:us-al#fips:01097,1097,1,1,Mobile,1229.4523,30.684571999999996,-88.19657,Mobile County,county
+iso1:us#iso2:us-sd#fips:46087,46087,46,46,McCook,574.22485,43.680415999999994,-97.35805,McCook County,county
+iso1:us#iso2:us-al#fips:01057,1057,1,1,Fayette,627.705,33.716156,-87.76429,Fayette County,county
+iso1:us#iso2:us-al#fips:01017,1017,1,1,Chambers,596.5812,32.915504,-85.394035,Chambers County,county
+iso1:us#iso2:us-nc#fips:37131,37131,37,37,Northampton,536.6957,36.421772,-77.39835,Northampton County,county
+iso1:us#iso2:us-co#fips:08081,8081,8,8,Moffat,4743.405,40.610863,-108.217155,Moffat County,county
+iso1:us#iso2:us-ky#fips:21087,21087,21,21,Green,286.05875,37.275383000000005,-85.57848,Green County,county
+iso1:us#iso2:us-in#fips:18047,18047,18,18,Franklin,384.4389,39.409763,-85.06696,Franklin County,county
+iso1:us#iso2:us-nc#fips:37013,37013,37,37,Beaufort,832.1208,35.48231,-76.84201999999999,Beaufort County,county
+iso1:us#iso2:us-pr#fips:72073,72073,72,72,Jayuya Municipio,44.534748,18.211153,-66.58686999999999,Jayuya Municipio,county
+iso1:us#iso2:us-nd#fips:38015,38015,38,38,Burleigh,1632.75,46.97883,-100.469536,Burleigh County,county
+iso1:us#iso2:us-nc#fips:37159,37159,37,37,Rowan,511.49744000000004,35.641354,-80.52172,Rowan County,county
+iso1:us#iso2:us-mi#fips:26071,26071,26,26,Iron,1166.037,46.170254,-88.54053,Iron County,county
+iso1:us#iso2:us-mn#fips:27067,27067,27,27,Kandiyohi,797.4093,45.152714,-95.00498,Kandiyohi County,county
+iso1:us#iso2:us-ky#fips:21237,21237,21,21,Wolfe,222.17812999999998,37.743893,-83.49511,Wolfe County,county
+iso1:us#iso2:us-tx#fips:48149,48149,48,48,Fayette,949.966,29.877886,-96.921234,Fayette County,county
+iso1:us#iso2:us-sd#fips:46081,46081,46,46,Lawrence,800.0801,44.348766,-103.80495,Lawrence County,county
+iso1:us#iso2:us-me#fips:23029,23029,23,23,Washington,2562.8137,44.967009999999995,-67.60935,Washington County,county
+iso1:us#iso2:us-tx#fips:48045,48045,48,48,Briscoe,900.0313,34.525172999999995,-101.205894,Briscoe County,county
+iso1:us#iso2:us-mi#fips:26131,26131,26,26,Ontonagon,1311.0221,47.216602,-89.500465,Ontonagon County,county
+iso1:us#iso2:us-ms#fips:28015,28015,28,28,Carroll,628.3113400000001,33.440796,-89.91888399999999,Carroll County,county
+iso1:us#iso2:us-or#fips:41003,41003,41,41,Benton,675.20465,44.49388,-123.42466999999999,Benton County,county
+iso1:us#iso2:us-mn#fips:27133,27133,27,27,Rock,482.47452000000004,43.669585999999995,-96.26324,Rock County,county
+iso1:us#iso2:us-pa#fips:42063,42063,42,42,Indiana,827.3409,40.651432,-79.08755,Indiana County,county
+iso1:us#iso2:us-la#fips:22061,22061,22,22,Lincoln Parish,471.75802999999996,32.601820000000004,-92.6623,Lincoln Parish,county
+iso1:us#iso2:us-pa#fips:42099,42099,42,42,Perry,551.46704,40.39778,-77.26633000000001,Perry County,county
+iso1:us#iso2:us-sd#fips:46137,46137,46,46,Ziebach,1961.307,44.989765000000006,-101.66083,Ziebach County,county
+iso1:us#iso2:us-tx#fips:48203,48203,48,48,Harrison,900.0884,32.547993,-94.37443499999999,Harrison County,county
+iso1:us#iso2:us-mi#fips:26013,26013,26,26,Baraga,898.4572,46.695858,-88.36180999999999,Baraga County,county
+iso1:us#iso2:us-ok#fips:40131,40131,40,40,Rogers,675.6568599999999,36.377792,-95.60139000000001,Rogers County,county
+iso1:us#iso2:us-mo#fips:29019,29019,29,29,Boone,685.5742,38.98986,-92.3102,Boone County,county
+iso1:us#iso2:us-pr#fips:72097,72097,72,72,Mayagüez Municipio,77.67653,18.164125,-67.89333,Mayagüez Municipio,county
+iso1:us#iso2:us-ok#fips:40015,40015,40,40,Caddo,1277.797,35.16792,-98.38104,Caddo County,county
+iso1:us#iso2:us-co#fips:08059,8059,8,8,Jefferson,764.36285,39.57951,-105.24546000000001,Jefferson County,county
+iso1:us#iso2:us-wv#fips:54011,54011,54,54,Cabell,281.02914,38.419579999999996,-82.24339,Cabell County,county
+iso1:us#iso2:us-tx#fips:48383,48383,48,48,Reagan,1175.3539,31.375190000000003,-101.5144,Reagan County,county
+iso1:us#iso2:us-ar#fips:05141,5141,5,5,Van Buren,709.7743,35.582954,-92.515976,Van Buren County,county
+iso1:us#iso2:us-co#fips:08117,8117,8,8,Summit,608.3596,39.62102,-106.13756000000001,Summit County,county
+iso1:us#iso2:us-ks#fips:20035,20035,20,20,Cowley,1125.7764,37.23451,-96.83725,Cowley County,county
+iso1:us#iso2:us-ar#fips:05071,5071,5,5,Johnson,659.8636,35.57336,-93.466324,Johnson County,county
+iso1:us#iso2:us-ny#fips:36041,36041,36,36,Hamilton,1717.4368,43.65788,-74.50246,Hamilton County,county
+iso1:us#iso2:us-va#fips:51045,51045,51,51,Craig,328.10938,37.473602,-80.23105,Craig County,county
+iso1:us#iso2:us-tx#fips:48083,48083,48,48,Coleman,1262.9574,31.914206,-99.34662,Coleman County,county
+iso1:us#iso2:us-ak#fips:02290,2290,2,2,Yukon-Koyukuk Census Area,145580.47,65.375725,-151.57785,Yukon-Koyukuk Census Area,county
+iso1:us#iso2:us-az#fips:04017,4017,4,4,Navajo,9950.392,35.390785,-110.32101999999999,Navajo County,county
+iso1:us#iso2:us-ms#fips:28085,28085,28,28,Lincoln,586.2272,31.535215,-90.45357,Lincoln County,county
+iso1:us#iso2:us-tx#fips:48357,48357,48,48,Ochiltree,917.7157599999999,36.278744,-100.815865,Ochiltree County,county
+iso1:us#iso2:us-tx#fips:48103,48103,48,48,Crane,785.0958,31.422796,-102.48778,Crane County,county
+iso1:us#iso2:us-wy#fips:56003,56003,56,56,Big Horn,3137.0640000000003,44.525116,-107.99485,Big Horn County,county
+iso1:us#iso2:us-tn#fips:47081,47081,47,47,Hickman,612.5042,35.802326,-87.46712,Hickman County,county
+iso1:us#iso2:us-ms#fips:28143,28143,28,28,Tunica,454.69372999999996,34.652203,-90.37177,Tunica County,county
+iso1:us#iso2:us-mo#fips:29081,29081,29,29,Harrison,722.5414,40.345620000000004,-93.992584,Harrison County,county
+iso1:us#iso2:us-pr#fips:72029,72029,72,72,Canóvanas Municipio,32.869137,18.329872,-65.88514,Canóvanas Municipio,county
+iso1:us#iso2:us-in#fips:18005,18005,18,18,Bartholomew,406.96924,39.205845000000004,-85.897995,Bartholomew County,county
+iso1:us#iso2:us-ga#fips:13223,13223,13,13,Paulding,312.33966000000004,33.92103,-84.86717,Paulding County,county
+iso1:us#iso2:us-oh#fips:39015,39015,39,39,Brown,490.0338,38.931377000000005,-83.866776,Brown County,county
+iso1:us#iso2:us-tn#fips:47141,47141,47,47,Putnam,401.11996,36.14094,-85.49618000000001,Putnam County,county
+iso1:us#iso2:us-nd#fips:38101,38101,38,38,Ward,2012.9983,48.216685999999996,-101.54053499999999,Ward County,county
+iso1:us#iso2:us-ma#fips:25027,25027,25,25,Worcester,1510.6973,42.311695,-71.940285,Worcester County,county
+iso1:us#iso2:us-oh#fips:39091,39091,39,39,Logan,458.52524000000005,40.387553999999994,-83.76634,Logan County,county
+iso1:us#iso2:us-ca#fips:06031,6031,6,6,Kings,1390.3563,36.07248,-119.81553000000001,Kings County,county
+iso1:us#iso2:us-ca#fips:06073,6073,6,6,San Diego,4210.345,33.023604999999996,-116.77611499999999,San Diego County,county
+iso1:us#iso2:us-pr#fips:72123,72123,72,72,Salinas Municipio,69.39692,17.971485,-66.26225,Salinas Municipio,county
+iso1:us#iso2:us-ga#fips:13079,13079,13,13,Crawford,324.9245,32.709427000000005,-83.97919,Crawford County,county
+iso1:us#iso2:us-pr#fips:72103,72103,72,72,Naguabo Municipio,51.66212,18.21107,-65.73575,Naguabo Municipio,county
+iso1:us#iso2:us-mo#fips:29037,29037,29,29,Cass,696.6382,38.646473,-94.354546,Cass County,county
+iso1:us#iso2:us-ny#fips:36027,36027,36,36,Dutchess,795.67584,41.75477,-73.74004000000001,Dutchess County,county
+iso1:us#iso2:us-tx#fips:48477,48477,48,48,Washington,604.2144,30.215075,-96.41027,Washington County,county
+iso1:us#iso2:us-co#fips:08101,8101,8,8,Pueblo,2386.179,38.17066,-104.48989,Pueblo County,county
+iso1:us#iso2:us-mo#fips:29067,29067,29,29,Douglas,813.65076,36.946518,-92.51589,Douglas County,county
+iso1:us#iso2:us-nd#fips:38009,38009,38,38,Bottineau,1668.4335,48.79441,-100.83126,Bottineau County,county
+iso1:us#iso2:us-nc#fips:37051,37051,37,37,Cumberland,652.5849599999999,35.050194,-78.82871999999999,Cumberland County,county
+iso1:us#iso2:us-wy#fips:56017,56017,56,56,Hot Springs,2004.4972,43.720209999999994,-108.435074,Hot Springs County,county
+iso1:us#iso2:us-mi#fips:26001,26001,26,26,Alcona,674.6783,44.682533,-82.834076,Alcona County,county
+iso1:us#iso2:us-ca#fips:06061,6061,6,6,Placer,1407.1224,39.06203,-120.72272,Placer County,county
+iso1:us#iso2:us-ar#fips:05129,5129,5,5,Searcy,666.0318599999999,35.896384999999995,-92.695885,Searcy County,county
+iso1:us#iso2:us-tx#fips:48305,48305,48,48,Lynn,891.89734,33.178413,-101.8185,Lynn County,county
+iso1:us#iso2:us-ny#fips:36077,36077,36,36,Otsego,1001.7712,42.629776,-75.02884,Otsego County,county
+iso1:us#iso2:us-nc#fips:37153,37153,37,37,Richmond,473.70538,35.004635,-79.75569,Richmond County,county
+iso1:us#iso2:us-nc#fips:37093,37093,37,37,Hoke,390.13727,35.01723,-79.24197,Hoke County,county
+iso1:us#iso2:us-ne#fips:31131,31131,31,31,Otoe,615.68463,40.637993,-96.13103000000001,Otoe County,county
+iso1:us#iso2:us-pa#fips:42023,42023,42,42,Cameron,396.2444,41.43829,-78.198326,Cameron County,county
+iso1:us#iso2:us-sc#fips:45035,45035,45,45,Dorchester,568.6133,33.082188,-80.40469,Dorchester County,county
+iso1:us#iso2:us-mn#fips:27161,27161,27,27,Waseca,423.37737999999996,44.01846,-93.58984,Waseca County,county
+iso1:us#iso2:us-sd#fips:46015,46015,46,46,Brule,817.2686,43.729874,-99.09291,Brule County,county
+iso1:us#iso2:us-tn#fips:47177,47177,47,47,Warren,432.6882,35.67825,-85.77734,Warren County,county
+iso1:us#iso2:us-il#fips:17023,17023,17,17,Clark,501.3919,39.332333,-87.79169,Clark County,county
+iso1:us#iso2:us-ky#fips:21201,21201,21,21,Robertson,99.9247,38.513474,-84.06423000000001,Robertson County,county
+iso1:us#iso2:us-tn#fips:47095,47095,47,47,Lake,165.79066,36.333904,-89.485535,Lake County,county
+iso1:us#iso2:us-sc#fips:45015,45015,45,45,Berkeley,1103.7072,33.2077,-79.95366,Berkeley County,county
+iso1:us#iso2:us-ar#fips:05051,5051,5,5,Garland,677.6422,34.578854,-93.146935,Garland County,county
+iso1:us#iso2:us-ks#fips:20139,20139,20,20,Osage,705.53046,38.650215,-95.70825,Osage County,county
+iso1:us#iso2:us-oh#fips:39155,39155,39,39,Trumbull,618.1079,41.306374,-80.7704,Trumbull County,county
+iso1:us#iso2:us-tx#fips:48333,48333,48,48,Mills,748.2401,31.494888,-98.59461999999999,Mills County,county
+iso1:us#iso2:us-tx#fips:48359,48359,48,48,Oldham,1500.5742,35.401920000000004,-102.59761999999999,Oldham County,county
+iso1:us#iso2:us-pa#fips:42019,42019,42,42,Butler,789.58527,40.913845,-79.918976,Butler County,county
+iso1:us#iso2:us-id#fips:16049,16049,16,16,Idaho,8477.787,45.849644,-115.46734,Idaho County,county
+iso1:us#iso2:us-ks#fips:20115,20115,20,20,Marion,944.3309300000001,38.359646000000005,-97.10276999999999,Marion County,county
+iso1:us#iso2:us-va#fips:51029,51029,51,51,Buckingham,579.6422,37.57393,-78.52917,Buckingham County,county
+iso1:us#iso2:us-nc#fips:37025,37025,37,37,Cabarrus,361.26883,35.388344000000004,-80.55273000000001,Cabarrus County,county
+iso1:us#iso2:us-mo#fips:29225,29225,29,29,Webster,592.5833,37.280803999999996,-92.876076,Webster County,county
+iso1:us#iso2:us-ut#fips:49011,49011,49,49,Davis,299.07482999999996,41.03756,-112.20194,Davis County,county
+iso1:us#iso2:us-mn#fips:27033,27033,27,27,Cottonwood,639.9947,44.01064,-95.18315,Cottonwood County,county
+iso1:us#iso2:us-fl#fips:12093,12093,12,12,Okeechobee,769.1833,27.385592,-80.88739,Okeechobee County,county
+iso1:us#iso2:us-ga#fips:13291,13291,13,13,Union,322.09634,34.833332,-83.98926,Union County,county
+iso1:us#iso2:us-ia#fips:19013,19013,19,19,Black Hawk,565.7868,42.47113,-92.3076,Black Hawk County,county
+iso1:us#iso2:us-tx#fips:48403,48403,48,48,Sabine,491.72687,31.3433,-93.85191,Sabine County,county
+iso1:us#iso2:us-oh#fips:39131,39131,39,39,Pike,440.29672,39.071342,-83.05291,Pike County,county
+iso1:us#iso2:us-al#fips:01125,1125,1,1,Tuscaloosa,1320.9043,33.29022,-87.52278000000001,Tuscaloosa County,county
+iso1:us#iso2:us-al#fips:01131,1131,1,1,Wilcox,888.4803,31.990082,-87.30493,Wilcox County,county
+iso1:us#iso2:us-ms#fips:28097,28097,28,28,Montgomery,406.99442,33.500713,-89.639626,Montgomery County,county
+iso1:us#iso2:us-ne#fips:31099,31099,31,31,Kearney,516.2607,40.50912,-98.9476,Kearney County,county
+iso1:us#iso2:us-ne#fips:31087,31087,31,31,Hitchcock,709.9667,40.176895,-101.04422,Hitchcock County,county
+iso1:us#iso2:us-de#fips:10003,10003,10,10,New Castle,426.33227999999997,39.575916,-75.64413499999999,New Castle County,county
+iso1:us#iso2:us-id#fips:16081,16081,16,16,Teton,449.10614000000004,43.760994000000004,-111.21177,Teton County,county
+iso1:us#iso2:us-il#fips:17161,17161,17,17,Rock Island,427.46747,41.468422,-90.57213,Rock Island County,county
+iso1:us#iso2:us-va#fips:51073,51073,51,51,Gloucester,217.81717999999998,37.40354,-76.52350600000001,Gloucester County,county
+iso1:us#iso2:us-ar#fips:05133,5133,5,5,Sevier,565.3238,33.994877,-94.24328,Sevier County,county
+iso1:us#iso2:us-in#fips:18017,18017,18,18,Cass,412.16913,40.7538,-86.35517,Cass County,county
+iso1:us#iso2:us-id#fips:16077,16077,16,16,Power,1403.8737,42.694126000000004,-112.844406,Power County,county
+iso1:us#iso2:us-in#fips:18015,18015,18,18,Carroll,372.2373,40.58498,-86.56514,Carroll County,county
+iso1:us#iso2:us-pa#fips:42101,42101,42,42,Philadelphia,134.28388999999999,40.009377,-75.13335,Philadelphia County,county
+iso1:us#iso2:us-wy#fips:56043,56043,56,56,Washakie,2238.75,43.87883,-107.66905,Washakie County,county
+iso1:us#iso2:us-nc#fips:37029,37029,37,37,Camden,240.33696,36.342341999999995,-76.16249,Camden County,county
+iso1:us#iso2:us-ny#fips:36109,36109,36,36,Tompkins,474.65732,42.453007,-76.47348000000001,Tompkins County,county
+iso1:us#iso2:us-ar#fips:05069,5069,5,5,Jefferson,870.08185,34.27724,-91.92967,Jefferson County,county
+iso1:us#iso2:us-ar#fips:05079,5079,5,5,Lincoln,561.55975,33.957676,-91.72762,Lincoln County,county
+iso1:us#iso2:us-wi#fips:55123,55123,55,55,Vernon,791.58875,43.599365,-90.82198000000001,Vernon County,county
+iso1:us#iso2:us-mo#fips:29093,29093,29,29,Iron,550.28314,37.594364,-90.98468000000001,Iron County,county
+iso1:us#iso2:us-tx#fips:48223,48223,48,48,Hopkins,767.4540400000001,33.148967999999996,-95.56544,Hopkins County,county
+iso1:us#iso2:us-ny#fips:36001,36001,36,36,Albany,522.8467400000001,42.58824,-73.97400999999999,Albany County,county
+iso1:us#iso2:us-tx#fips:48225,48225,48,48,Houston,1231.0432,31.323036,-95.4216,Houston County,county
+iso1:us#iso2:us-oh#fips:39111,39111,39,39,Monroe,455.73874000000006,39.726254,-81.09098,Monroe County,county
+iso1:us#iso2:us-ks#fips:20165,20165,20,20,Rush,717.7874,38.523598,-99.30918,Rush County,county
+iso1:us#iso2:us-in#fips:18107,18107,18,18,Montgomery,504.66437,40.040295,-86.892715,Montgomery County,county
+iso1:us#iso2:us-ks#fips:20187,20187,20,20,Stanton,680.37506,37.565933,-101.78938000000001,Stanton County,county
+iso1:us#iso2:us-ky#fips:21129,21129,21,21,Lee,208.86603,37.608115999999995,-83.719246,Lee County,county
+iso1:us#iso2:us-mn#fips:27071,27071,27,27,Koochiching,3104.8372,48.245373,-93.7829,Koochiching County,county
+iso1:us#iso2:us-tx#fips:48029,48029,48,48,Bexar,1240.3489,29.448671,-98.52015,Bexar County,county
+iso1:us#iso2:us-co#fips:08013,8013,8,8,Boulder,726.40234,40.09497,-105.39769,Boulder County,county
+iso1:us#iso2:us-tn#fips:47089,47089,47,47,Jefferson,275.08206,36.048336,-83.44114,Jefferson County,county
+iso1:us#iso2:us-ok#fips:40097,40097,40,40,Mayes,655.3995,36.303802000000005,-95.23564,Mayes County,county
+iso1:us#iso2:us-mn#fips:27165,27165,27,27,Watonwan,434.96905999999996,43.978107,-94.6138,Watonwan County,county
+iso1:us#iso2:us-id#fips:16013,16013,16,16,Blaine,2637.8271,43.39419,-113.95537,Blaine County,county
+iso1:us#iso2:us-la#fips:22053,22053,22,22,Jefferson Davis Parish,651.3863,30.26953,-92.81622,Jefferson Davis Parish,county
+iso1:us#iso2:us-sd#fips:46119,46119,46,46,Sully,1006.7569,44.722324,-100.1314,Sully County,county
+iso1:us#iso2:us-co#fips:08031,8031,8,8,Denver,153.29733000000002,39.76185,-104.8811,Denver County,county
+iso1:us#iso2:us-ok#fips:40029,40029,40,40,Coal,516.78723,34.582863,-96.28804000000001,Coal County,county
+iso1:us#iso2:us-mt#fips:30011,30011,30,30,Carter,3340.5908,45.516822999999995,-104.51533,Carter County,county
+iso1:us#iso2:us-tx#fips:48461,48461,48,48,Upton,1241.3647,31.353817,-102.04155,Upton County,county
+iso1:us#iso2:us-in#fips:18051,18051,18,18,Gibson,487.4385,38.317398,-87.58051999999999,Gibson County,county
+iso1:us#iso2:us-ne#fips:31105,31105,31,31,Kimball,951.8781,41.199272,-103.703156,Kimball County,county
+iso1:us#iso2:us-il#fips:17093,17093,17,17,Kendall,320.24896,41.58814,-88.430626,Kendall County,county
+iso1:us#iso2:us-dc#fips:11001,11001,11,11,District of Columbia,61.137646,38.904247,-77.01652,District of Columbia,county
+iso1:us#iso2:us-co#fips:08085,8085,8,8,Montrose,2241.0222,38.407505,-108.26628000000001,Montrose County,county
+iso1:us#iso2:us-mn#fips:27171,27171,27,27,Wright,661.1412,45.175090000000004,-93.9664,Wright County,county
+iso1:us#iso2:us-wi#fips:55059,55059,55,55,Kenosha,271.85422,42.579704,-87.425,Kenosha County,county
+iso1:us#iso2:us-co#fips:08037,8037,8,8,Eagle,1684.5275,39.62699,-106.69516999999999,Eagle County,county
+iso1:us#iso2:us-ca#fips:06075,6075,6,6,San Francisco,46.904415,37.727238,-123.03223,San Francisco County,county
+iso1:us#iso2:us-co#fips:08113,8113,8,8,San Miguel,1286.7701,38.00932,-108.42726,San Miguel County,county
+iso1:us#iso2:us-ak#fips:02020,2020,2,2,Anchorage Municipality,1706.8579,61.17425,-149.28433,Anchorage Municipality,county
+iso1:us#iso2:us-fl#fips:12109,12109,12,12,St. Johns,600.5854,29.890488,-81.40004,St. Johns County,county
+iso1:us#iso2:us-ms#fips:28019,28019,28,28,Choctaw,418.2102,33.345963,-89.251335,Choctaw County,county
+iso1:us#iso2:us-mo#fips:29079,29079,29,29,Grundy,435.3069,40.11254,-93.56505600000001,Grundy County,county
+iso1:us#iso2:us-mi#fips:26085,26085,26,26,Lake,567.6106,43.995186,-85.8114,Lake County,county
+iso1:us#iso2:us-mi#fips:26139,26139,26,26,Ottawa,563.5306,42.94246,-86.654945,Ottawa County,county
+iso1:us#iso2:us-il#fips:17031,17031,17,17,Cook,944.96234,41.894295,-87.645454,Cook County,county
+iso1:us#iso2:us-il#fips:17059,17059,17,17,Gallatin,323.00116,37.768677000000004,-88.22797,Gallatin County,county
+iso1:us#iso2:us-sc#fips:45047,45047,45,45,Greenwood,454.73868,34.155796,-82.12788,Greenwood County,county
+iso1:us#iso2:us-ks#fips:20059,20059,20,20,Franklin,571.79126,38.558018,-95.27896,Franklin County,county
+iso1:us#iso2:us-mn#fips:27027,27027,27,27,Clay,1045.2338,46.898376,-96.4949,Clay County,county
+iso1:us#iso2:us-tn#fips:47075,47075,47,47,Haywood,533.1254,35.586678000000006,-89.28269,Haywood County,county
+iso1:us#iso2:us-ut#fips:49003,49003,49,49,Box Elder,5745.7880000000005,41.276061999999996,-113.12623,Box Elder County,county
+iso1:us#iso2:us-ms#fips:28139,28139,28,28,Tippah,457.83797999999996,34.76362,-88.918816,Tippah County,county
+iso1:us#iso2:us-wv#fips:54051,54051,54,54,Marshall,305.4417,39.854427,-80.67179,Marshall County,county
+iso1:us#iso2:us-wv#fips:54035,54035,54,54,Jackson,464.3751,38.834232,-81.67772,Jackson County,county
+iso1:us#iso2:us-id#fips:16039,16039,16,16,Elmore,3075.1833,43.3947,-115.47121000000001,Elmore County,county
+iso1:us#iso2:us-md#fips:24005,24005,24,24,Baltimore,598.3803,39.443165,-76.61657,Baltimore County,county
+iso1:us#iso2:us-nd#fips:38005,38005,38,38,Benson,1388.6023,48.071743,-99.35115,Benson County,county
+iso1:us#iso2:us-mo#fips:29163,29163,29,29,Pike,670.4616,39.33996,-91.17161,Pike County,county
+iso1:us#iso2:us-oh#fips:39087,39087,39,39,Lawrence,453.3861,38.603867,-82.51719,Lawrence County,county
+iso1:us#iso2:us-mo#fips:29201,29201,29,29,Scott,420.00574000000006,37.047794,-89.5681,Scott County,county
+iso1:us#iso2:us-oh#fips:39001,39001,39,39,Adams,583.887,38.83447,-83.47808,Adams County,county
+iso1:us#iso2:us-tx#fips:48143,48143,48,48,Erath,1083.2146,32.23666,-98.220505,Erath County,county
+iso1:us#iso2:us-ga#fips:13137,13137,13,13,Habersham,276.83704,34.63439,-83.52587,Habersham County,county
+iso1:us#iso2:us-ga#fips:13319,13319,13,13,Wilkinson,449.22964,32.804268,-83.175514,Wilkinson County,county
+iso1:us#iso2:us-wv#fips:54061,54061,54,54,Monongalia,360.1032,39.633644,-80.059074,Monongalia County,county
+iso1:us#iso2:us-oh#fips:39033,39033,39,39,Crawford,401.79916000000003,40.848526,-82.92478,Crawford County,county
+iso1:us#iso2:us-fl#fips:12027,12027,12,12,DeSoto,636.7148,27.190579999999997,-81.80625,DeSoto County,county
+iso1:us#iso2:us-ct#fips:09011,9011,9,9,New London,665.1651,41.472652000000004,-72.10863499999999,New London County,county
+iso1:us#iso2:us-oh#fips:39059,39059,39,39,Guernsey,522.2716,40.056664000000005,-81.49786999999999,Guernsey County,county
+iso1:us#iso2:us-mi#fips:26015,26015,26,26,Barry,553.1134,42.582809999999995,-85.31455,Barry County,county
+iso1:us#iso2:us-mo#fips:29209,29209,29,29,Stone,463.8969,36.751003000000004,-93.4737,Stone County,county
+iso1:us#iso2:us-va#fips:51760,51760,51,51,Richmond city,59.925087,37.5314,-77.47600600000001,Richmond city,county
+iso1:us#iso2:us-nc#fips:37169,37169,37,37,Stokes,449.0295,36.393505,-80.26621,Stokes County,county
+iso1:us#iso2:us-ia#fips:19039,19039,19,19,Clarke,431.18118,41.02919,-93.78409599999999,Clarke County,county
+iso1:us#iso2:us-ia#fips:19065,19065,19,19,Fayette,730.8548599999999,42.86412,-91.84038000000001,Fayette County,county
+iso1:us#iso2:us-ca#fips:06041,6041,6,6,Marin,520.4642,38.051815000000005,-122.74597,Marin County,county
+iso1:us#iso2:us-tx#fips:48381,48381,48,48,Randall,911.9643599999999,34.96253,-101.895546,Randall County,county
+iso1:us#iso2:us-tx#fips:48401,48401,48,48,Rusk,924.0683,32.109425,-94.75638599999999,Rusk County,county
+iso1:us#iso2:us-ia#fips:19181,19181,19,19,Warren,569.8572,41.332446999999995,-93.56875,Warren County,county
+iso1:us#iso2:us-oh#fips:39161,39161,39,39,Van Wert,409.1672,40.855522,-84.58578,Van Wert County,county
+iso1:us#iso2:us-fl#fips:12043,12043,12,12,Glades,806.5956,26.954811,-81.19082,Glades County,county
+iso1:us#iso2:us-ga#fips:13199,13199,13,13,Meriwether,501.24042000000003,33.029266,-84.66705999999999,Meriwether County,county
+iso1:us#iso2:us-co#fips:08023,8023,8,8,Costilla,1227.6351,37.277546,-105.42894,Costilla County,county
+iso1:us#iso2:us-tx#fips:48099,48099,48,48,Coryell,1052.2344,31.391178000000004,-97.79802,Coryell County,county
+iso1:us#iso2:us-ia#fips:19001,19001,19,19,Adair,569.29,41.32853,-94.478165,Adair County,county
+iso1:us#iso2:us-ga#fips:13053,13053,13,13,Chattahoochee,248.7456,32.347446000000005,-84.78801999999999,Chattahoochee County,county
+iso1:us#iso2:us-ca#fips:06043,6043,6,6,Mariposa,1448.8868,37.570029999999996,-119.912865,Mariposa County,county
+iso1:us#iso2:us-mo#fips:29089,29089,29,29,Howard,463.81604000000004,39.143364,-92.69592,Howard County,county
+iso1:us#iso2:us-or#fips:41047,41047,41,41,Marion,1180.5992,44.900898,-122.57626,Marion County,county
+iso1:us#iso2:us-wi#fips:55079,55079,55,55,Milwaukee,241.49011000000002,43.01766,-87.48155,Milwaukee County,county
+iso1:us#iso2:us-mn#fips:27139,27139,27,27,Scott,356.2658,44.651806,-93.53373,Scott County,county
+iso1:us#iso2:us-oh#fips:39129,39129,39,39,Pickaway,501.2453,39.64895,-83.052826,Pickaway County,county
+iso1:us#iso2:us-va#fips:51145,51145,51,51,Powhatan,260.21378,37.549403999999996,-77.91286,Powhatan County,county
+iso1:us#iso2:us-co#fips:08014,8014,8,8,Broomfield,33.004658,39.953594,-105.05078999999999,Broomfield County,county
+iso1:us#iso2:us-tn#fips:47099,47099,47,47,Lawrence,617.1509,35.220478,-87.39654499999999,Lawrence County,county
+iso1:us#iso2:us-mi#fips:26009,26009,26,26,Antrim,475.69507000000004,45.005455,-85.17564,Antrim County,county
+iso1:us#iso2:us-sc#fips:45069,45069,45,45,Marlboro,479.89005,34.60167,-79.679436,Marlboro County,county
+iso1:us#iso2:us-id#fips:16009,16009,16,16,Benewah,776.95776,47.218452,-116.633545,Benewah County,county
+iso1:us#iso2:us-il#fips:17103,17103,17,17,Lee,724.8114,41.747448,-89.29936,Lee County,county
+iso1:us#iso2:us-ne#fips:31127,31127,31,31,Nemaha,407.39047,40.38739,-95.85271999999999,Nemaha County,county
+iso1:us#iso2:us-nc#fips:37031,37031,37,37,Carteret,507.6199,34.858340000000005,-76.53586,Carteret County,county
+iso1:us#iso2:us-ks#fips:20149,20149,20,20,Pottawatomie,840.7688,39.382187,-96.33711,Pottawatomie County,county
+iso1:us#iso2:us-mi#fips:26075,26075,26,26,Jackson,701.90497,42.248474,-84.42087,Jackson County,county
+iso1:us#iso2:us-tx#fips:48091,48091,48,48,Comal,559.54364,29.805490000000002,-98.260544,Comal County,county
+iso1:us#iso2:us-ma#fips:25019,25019,25,25,Nantucket,46.16652,41.305878,-70.14191,Nantucket County,county
+iso1:us#iso2:us-sc#fips:45009,45009,45,45,Bamberg,393.3801,33.203022,-81.05315999999999,Bamberg County,county
+iso1:us#iso2:us-tx#fips:48007,48007,48,48,Aransas,252.07799,28.122621999999996,-96.9675,Aransas County,county
+iso1:us#iso2:us-ga#fips:13019,13019,13,13,Berrien,453.3911,31.288652000000003,-83.22787,Berrien County,county
+iso1:us#iso2:us-in#fips:18165,18165,18,18,Vermillion,256.873,39.854046000000004,-87.462074,Vermillion County,county
+iso1:us#iso2:us-mi#fips:26143,26143,26,26,Roscommon,519.91437,44.339515999999996,-84.611275,Roscommon County,county
+iso1:us#iso2:us-nc#fips:37005,37005,37,37,Alleghany,234.42593,36.489357,-81.1323,Alleghany County,county
+iso1:us#iso2:us-ca#fips:06035,6035,6,6,Lassen,4541.34,40.721084999999995,-120.62995,Lassen County,county
+iso1:us#iso2:us-va#fips:51610,51610,51,51,Falls Church city,2.0465120999999997,38.884724,-77.175606,Falls Church city,county
+iso1:us#iso2:us-fl#fips:12081,12081,12,12,Manatee,743.65607,27.481682,-82.36877,Manatee County,county
+iso1:us#iso2:us-oh#fips:39119,39119,39,39,Muskingum,664.5685,39.966045,-81.943504,Muskingum County,county
+iso1:us#iso2:us-co#fips:08015,8015,8,8,Chaffee,1013.4429,38.738224,-106.31668,Chaffee County,county
+iso1:us#iso2:us-co#fips:08025,8025,8,8,Crowley,787.4543,38.30618,-103.772736,Crowley County,county
+iso1:us#iso2:us-co#fips:08043,8043,8,8,Fremont,1533.1343,38.45517,-105.42496000000001,Fremont County,county
+iso1:us#iso2:us-ms#fips:28109,28109,28,28,Pearl River,811.3314,30.774794,-89.58691,Pearl River County,county
+iso1:us#iso2:us-ms#fips:28111,28111,28,28,Perry,647.2295,31.169308,-88.988754,Perry County,county
+iso1:us#iso2:us-ne#fips:31041,31041,31,31,Custer,2575.6814,41.393894,-99.72686999999999,Custer County,county
+iso1:us#iso2:us-fl#fips:12013,12013,12,12,Calhoun,567.3557,30.388802000000002,-85.197914,Calhoun County,county
+iso1:us#iso2:us-ky#fips:21117,21117,21,21,Kenton,160.29568,38.930504,-84.53344,Kenton County,county
+iso1:us#iso2:us-ia#fips:19037,19037,19,19,Chickasaw,504.34094000000005,43.059742,-92.31721,Chickasaw County,county
+iso1:us#iso2:us-il#fips:17037,17037,17,17,DeKalb,631.35803,41.89461,-88.76899,DeKalb County,county
+iso1:us#iso2:us-ia#fips:19081,19081,19,19,Hancock,571.024,43.07541,-93.7437,Hancock County,county
+iso1:us#iso2:us-nd#fips:38089,38089,38,38,Stark,1334.9585,46.817029999999995,-102.662025,Stark County,county
+iso1:us#iso2:us-mi#fips:26095,26095,26,26,Luce,899.1056,46.9406,-85.58237,Luce County,county
+iso1:us#iso2:us-ok#fips:40019,40019,40,40,Carter,822.22955,34.25185,-97.287926,Carter County,county
+iso1:us#iso2:us-nc#fips:37139,37139,37,37,Pasquotank,226.8877,36.265198,-76.26069,Pasquotank County,county
+iso1:us#iso2:us-nm#fips:35055,35055,35,35,Taos,2202.4478,36.57653,-105.63798500000001,Taos County,county
+iso1:us#iso2:us-ms#fips:28011,28011,28,28,Bolivar,876.6908,33.79914,-90.88412,Bolivar County,county
+iso1:us#iso2:us-nv#fips:32023,32023,32,32,Nye,18182.531000000003,37.965862,-116.45901,Nye County,county
+iso1:us#iso2:us-tn#fips:47073,47073,47,47,Hawkins,487.07097999999996,36.452087,-82.93149,Hawkins County,county
+iso1:us#iso2:us-nd#fips:38011,38011,38,38,Bowman,1161.8481,46.110146,-103.50594,Bowman County,county
+iso1:us#iso2:us-pa#fips:42057,42057,42,42,Fulton,437.56622000000004,39.91075,-78.12262,Fulton County,county
+iso1:us#iso2:us-la#fips:22055,22055,22,22,Lafayette Parish,268.77045,30.206507000000002,-92.06416999999999,Lafayette Parish,county
+iso1:us#iso2:us-tx#fips:48237,48237,48,48,Jack,910.971,33.232162,-98.17116999999999,Jack County,county
+iso1:us#iso2:us-il#fips:17175,17175,17,17,Stark,288.1023,41.09691,-89.79741,Stark County,county
+iso1:us#iso2:us-ok#fips:40055,40055,40,40,Greer,639.3036,34.933853000000006,-99.55297,Greer County,county
+iso1:us#iso2:us-tx#fips:48211,48211,48,48,Hemphill,906.3168300000001,35.815956,-100.27920999999999,Hemphill County,county
+iso1:us#iso2:us-id#fips:16069,16069,16,16,Nez Perce,848.3493,46.33379,-116.76091000000001,Nez Perce County,county
+iso1:us#iso2:us-sd#fips:46129,46129,46,46,Walworth,708.6661,45.427605,-100.027855,Walworth County,county
+iso1:us#iso2:us-ca#fips:06055,6055,6,6,Napa,748.2863,38.5071,-122.325905,Napa County,county
+iso1:us#iso2:us-ok#fips:40033,40033,40,40,Cotton,632.6549,34.290676,-98.373436,Cotton County,county
+iso1:us#iso2:us-mo#fips:29221,29221,29,29,Washington,759.89185,37.942609999999995,-90.89702,Washington County,county
+iso1:us#iso2:us-ny#fips:36011,36011,36,36,Cayuga,691.6061,43.008545,-76.574585,Cayuga County,county
+iso1:us#iso2:us-tx#fips:48417,48417,48,48,Shackelford,914.3169,32.74382,-99.34701,Shackelford County,county
+iso1:us#iso2:us-tx#fips:48407,48407,48,48,San Jacinto,569.2622,30.574389,-95.16314,San Jacinto County,county
+iso1:us#iso2:us-ia#fips:19061,19061,19,19,Dubuque,608.32,42.46348,-90.87876999999999,Dubuque County,county
+iso1:us#iso2:us-va#fips:51075,51075,51,51,Goochland,280.6402,37.718815,-77.917625,Goochland County,county
+iso1:us#iso2:us-ks#fips:20181,20181,20,20,Sherman,1056.1,39.351353,-101.71986,Sherman County,county
+iso1:us#iso2:us-oh#fips:39139,39139,39,39,Richland,495.2137,40.774159999999995,-82.54278000000001,Richland County,county
+iso1:us#iso2:us-il#fips:17001,17001,17,17,Adams,855.16986,39.986053000000005,-91.19496,Adams County,county
+iso1:us#iso2:us-oh#fips:39021,39021,39,39,Champaign,429.0089,40.132774,-83.7676,Champaign County,county
+iso1:us#iso2:us-nh#fips:33019,33019,33,33,Sullivan,537.56195,43.361187,-72.222084,Sullivan County,county
+iso1:us#iso2:us-il#fips:17075,17075,17,17,Iroquois,1117.433,40.748867,-87.8336,Iroquois County,county
+iso1:us#iso2:us-ia#fips:19157,19157,19,19,Poweshiek,584.9435,41.684525,-92.52288,Poweshiek County,county
+iso1:us#iso2:us-oh#fips:39169,39169,39,39,Wayne,554.8243,40.829662,-81.88719,Wayne County,county
+iso1:us#iso2:us-ga#fips:13113,13113,13,13,Fayette,194.38464,33.412715999999996,-84.49394000000001,Fayette County,county
+iso1:us#iso2:us-ga#fips:13141,13141,13,13,Hancock,471.08307,33.269220000000004,-83.000465,Hancock County,county
+iso1:us#iso2:us-tx#fips:48259,48259,48,48,Kendall,662.4764,29.943525,-98.70926999999999,Kendall County,county
+iso1:us#iso2:us-ny#fips:36039,36039,36,36,Greene,647.1835,42.27982,-74.14203,Greene County,county
+iso1:us#iso2:us-va#fips:51137,51137,51,51,Orange,341.12335,38.250195,-78.00962,Orange County,county
+iso1:us#iso2:us-ok#fips:40089,40089,40,40,McCurtain,1850.9272,34.117073,-94.76608,McCurtain County,county
+iso1:us#iso2:us-ga#fips:13277,13277,13,13,Tift,260.89797999999996,31.457003000000004,-83.52593,Tift County,county
+iso1:us#iso2:us-ne#fips:31025,31025,31,31,Cass,557.3717,40.909878000000006,-96.14061,Cass County,county
+iso1:us#iso2:us-sd#fips:46077,46077,46,46,Kingsbury,832.2652,44.362970000000004,-97.49931,Kingsbury County,county
+iso1:us#iso2:us-wy#fips:56009,56009,56,56,Converse,4255.108,42.984623,-105.52475,Converse County,county
+iso1:us#iso2:us-ny#fips:36043,36043,36,36,Herkimer,1411.5886,43.40749,-75.01168,Herkimer County,county
+iso1:us#iso2:us-nd#fips:38047,38047,38,38,Logan,992.6325699999999,46.469276,-99.50458499999999,Logan County,county
+iso1:us#iso2:us-mi#fips:26053,26053,26,26,Gogebic,1102.173,46.461514,-89.80686,Gogebic County,county
+iso1:us#iso2:us-mn#fips:27005,27005,27,27,Becker,1315.1289,46.93763,-95.74176,Becker County,county
+iso1:us#iso2:us-al#fips:01095,1095,1,1,Marshall,565.86426,34.309563,-86.32167,Marshall County,county
+iso1:us#iso2:us-tn#fips:47173,47173,47,47,Union,223.58577999999997,36.28414,-83.83609,Union County,county
+iso1:us#iso2:us-wv#fips:54057,54057,54,54,Mineral,327.87854,39.40478,-78.95669000000001,Mineral County,county
+iso1:us#iso2:us-wi#fips:55003,55003,55,55,Ashland,1045.0118,46.544426,-90.67969000000001,Ashland County,county
+iso1:us#iso2:us-il#fips:17053,17053,17,17,Ford,485.6134,40.596540000000005,-88.22459,Ford County,county
+iso1:us#iso2:us-nd#fips:38029,38029,38,38,Emmons,1510.0541,46.284256,-100.23784,Emmons County,county
+iso1:us#iso2:us-ca#fips:06089,6089,6,6,Shasta,3775.5928,40.760513,-122.04356000000001,Shasta County,county
+iso1:us#iso2:us-la#fips:22113,22113,22,22,Vermilion Parish,1173.2518,29.789721999999998,-92.291565,Vermilion Parish,county
+iso1:us#iso2:us-ar#fips:05121,5121,5,5,Randolph,652.2458,36.341297,-91.02844,Randolph County,county
+iso1:us#iso2:us-wi#fips:55085,55085,55,55,Oneida,1113.9801,45.716175,-89.53453,Oneida County,county
+iso1:us#iso2:us-la#fips:22035,22035,22,22,East Carroll Parish,420.72222999999997,32.73017,-91.23414,East Carroll Parish,county
+iso1:us#iso2:us-la#fips:22037,22037,22,22,East Feliciana Parish,453.418,30.839785,-91.04343399999999,East Feliciana Parish,county
+iso1:us#iso2:us-la#fips:22087,22087,22,22,St. Bernard Parish,377.5247,29.91811,-89.2635,St. Bernard Parish,county
+iso1:us#iso2:us-tx#fips:48481,48481,48,48,Wharton,1086.1876,29.27848,-96.229675,Wharton County,county
+iso1:us#iso2:us-ak#fips:02198,2198,2,2,Prince of Wales-Hyder Census Area,5263.9473,55.682774,-133.16238,Prince of Wales-Hyder Census Area,county
+iso1:us#iso2:us-ak#fips:02195,2195,2,2,Petersburg Borough,2900.7524,57.11245699999999,-133.00859,Petersburg Borough,county
+iso1:us#iso2:us-tx#fips:48153,48153,48,48,Floyd,992.1763,34.07373,-101.303276,Floyd County,county
+iso1:us#iso2:us-ak#fips:02275,2275,2,2,Wrangell City and Borough,2556.0820000000003,56.317417000000006,-132.34398000000002,Wrangell City and Borough,county
+iso1:us#iso2:us-ky#fips:21151,21151,21,21,Madison,437.36782999999997,37.72551,-84.27835999999999,Madison County,county
+iso1:us#iso2:us-tn#fips:47009,47009,47,47,Blount,558.8387,35.688187,-83.92296999999999,Blount County,county
+iso1:us#iso2:us-mt#fips:30031,30031,30,30,Gallatin,2605.1038,45.518055,-111.163925,Gallatin County,county
+iso1:us#iso2:us-sc#fips:45031,45031,45,45,Darlington,560.6199,34.332184000000005,-79.96211,Darlington County,county
+iso1:us#iso2:us-al#fips:01053,1053,1,1,Escambia,945.2547,31.122286,-87.16841,Escambia County,county
+iso1:us#iso2:us-ga#fips:13143,13143,13,13,Haralson,282.17484,33.795165999999995,-85.22006,Haralson County,county
+iso1:us#iso2:us-ks#fips:20001,20001,20,20,Allen,500.3144,37.884228,-95.30094,Allen County,county
+iso1:us#iso2:us-il#fips:17041,17041,17,17,Douglas,416.66095,39.76608,-88.22286,Douglas County,county
+iso1:us#iso2:us-va#fips:51079,51079,51,51,Greene,155.93849,38.297979999999995,-78.47015999999999,Greene County,county
+iso1:us#iso2:us-gu:#fips:66010,66010,66,66,Guam,209.87523,13.441745000000001,144.7719,Guam,county
+iso1:us#iso2:us-wi#fips:55137,55137,55,55,Waushara,626.183,44.112823,-89.239784,Waushara County,county
+iso1:us#iso2:us-ar#fips:05065,5065,5,5,Izard,580.6151,36.094879999999996,-91.91363,Izard County,county
+iso1:us#iso2:us-ca#fips:06053,6053,6,6,Monterey,3281.8320000000003,36.240109999999994,-121.315575,Monterey County,county
+iso1:us#iso2:us-nm#fips:35017,35017,35,35,Grant,3961.3403,32.732085999999995,-108.38151,Grant County,county
+iso1:us#iso2:us-mo#fips:29131,29131,29,29,Miller,592.622,38.21668,-92.42988000000001,Miller County,county
+iso1:us#iso2:us-nc#fips:37193,37193,37,37,Wilkes,754.56573,36.208884999999995,-81.16609,Wilkes County,county
+iso1:us#iso2:us-ak#fips:02110,2110,2,2,Juneau City and Borough,2704.0676,58.37291,-134.17845,Juneau City and Borough,county
+iso1:us#iso2:us-mo#fips:29165,29165,29,29,Platte,419.80023,39.378696000000005,-94.761475,Platte County,county
+iso1:us#iso2:us-mo#fips:29021,29021,29,29,Buchanan,408.25818,39.66037,-94.808174,Buchanan County,county
+iso1:us#iso2:us-al#fips:01083,1083,1,1,Limestone,559.9745,34.810238,-86.9814,Limestone County,county
+iso1:us#iso2:us-in#fips:18065,18065,18,18,Henry,391.89307,39.929592,-85.39735999999999,Henry County,county
+iso1:us#iso2:us-ne#fips:31143,31143,31,31,Polk,438.3605,41.187923,-97.57066,Polk County,county
+iso1:us#iso2:us-oh#fips:39123,39123,39,39,Ottawa,254.72237,41.545494,-83.01261,Ottawa County,county
+iso1:us#iso2:us-mn#fips:27107,27107,27,27,Norman,872.81854,47.329453,-96.463776,Norman County,county
+iso1:us#iso2:us-ia#fips:19165,19165,19,19,Shelby,590.7991,41.679016,-95.308914,Shelby County,county
+iso1:us#iso2:us-md#fips:24013,24013,24,24,Carroll,447.6439,39.56333,-77.01533,Carroll County,county
+iso1:us#iso2:us-ia#fips:19011,19011,19,19,Benton,716.1266,42.09255,-92.05763,Benton County,county
+iso1:us#iso2:us-ky#fips:21159,21159,21,21,Martin,229.62616,37.796776,-82.50662,Martin County,county
+iso1:us#iso2:us-mn#fips:27025,27025,27,27,Chisago,414.91373,45.505444,-92.90385,Chisago County,county
+iso1:us#iso2:us-ky#fips:21189,21189,21,21,Owsley,197.41644,37.423621999999995,-83.69163499999999,Owsley County,county
+iso1:us#iso2:us-pa#fips:42015,42015,42,42,Bradford,1147.4524,41.791503999999996,-76.50211999999999,Bradford County,county
+iso1:us#iso2:us-wv#fips:54029,54029,54,54,Hancock,82.61211,40.51696,-80.57016999999999,Hancock County,county
+iso1:us#iso2:us-mo#fips:29051,29051,29,29,Cole,391.5611,38.503235,-92.28003000000001,Cole County,county
+iso1:us#iso2:us-mi#fips:26021,26021,26,26,Berrien,567.79944,41.79138,-86.74254599999999,Berrien County,county
+iso1:us#iso2:us-pa#fips:42061,42061,42,42,Huntingdon,874.6814,40.422309999999996,-77.9686,Huntingdon County,county
+iso1:us#iso2:us-ne#fips:31045,31045,31,31,Dawes,1396.531,42.711216,-103.13486999999999,Dawes County,county
+iso1:us#iso2:us-va#fips:51141,51141,51,51,Patrick,482.97083,36.667137,-80.286415,Patrick County,county
+iso1:us#iso2:us-mi#fips:26119,26119,26,26,Montmorency,546.6933,45.024136,-84.130104,Montmorency County,county
+iso1:us#iso2:us-mi#fips:26135,26135,26,26,Oscoda,565.6929299999999,44.687256,-84.12691,Oscoda County,county
+iso1:us#iso2:us-nm#fips:35007,35007,35,35,Colfax,3758.1028,36.612965,-104.640114,Colfax County,county
+iso1:us#iso2:us-il#fips:17163,17163,17,17,St. Clair,657.72546,38.470196,-89.92854,St. Clair County,county
+iso1:us#iso2:us-il#fips:17189,17189,17,17,Washington,562.6061,38.35314,-89.41719,Washington County,county
+iso1:us#iso2:us-pa#fips:42009,42009,42,42,Bedford,1012.337,39.998634,-78.49474000000001,Bedford County,county
+iso1:us#iso2:us-ar#fips:05127,5127,5,5,Scott,892.3963,34.858868,-94.063644,Scott County,county
+iso1:us#iso2:us-ks#fips:20099,20099,20,20,Labette,645.41516,37.191466999999996,-95.29746999999999,Labette County,county
+iso1:us#iso2:us-pa#fips:42073,42073,42,42,Lawrence,357.23828,40.992737,-80.33444,Lawrence County,county
+iso1:us#iso2:us-oh#fips:39067,39067,39,39,Harrison,402.34472999999997,40.292316,-81.09156999999999,Harrison County,county
+iso1:us#iso2:us-nc#fips:37003,37003,37,37,Alexander,259.9939,35.92095,-81.17747,Alexander County,county
+iso1:us#iso2:us-nj#fips:34009,34009,34,34,Cape May,251.4919,39.085842,-74.84635,Cape May County,county
+iso1:us#iso2:us-nh#fips:33005,33005,33,33,Cheshire,706.7328,42.92546,-72.248184,Cheshire County,county
+iso1:us#iso2:us-mn#fips:27089,27089,27,27,Marshall,1775.1205,48.36273,-96.35776,Marshall County,county
+iso1:us#iso2:us-va#fips:51101,51101,51,51,King William,273.93692000000004,37.708259999999996,-77.09106,King William County,county
+iso1:us#iso2:us-co#fips:08055,8055,8,8,Huerfano,1591.0870000000002,37.687816999999995,-104.95993,Huerfano County,county
+iso1:us#iso2:us-tx#fips:48255,48255,48,48,Karnes,747.5224,28.908996999999996,-97.8522,Karnes County,county
+iso1:us#iso2:us-tn#fips:47023,47023,47,47,Chester,285.74597,35.420254,-88.61135,Chester County,county
+iso1:us#iso2:us-il#fips:17171,17171,17,17,Scott,250.79811,39.637,-90.47776999999999,Scott County,county
+iso1:us#iso2:us-ut#fips:49027,49027,49,49,Millard,6785.7305,38.956745,-113.133095,Millard County,county
+iso1:us#iso2:us-ut#fips:49029,49029,49,49,Morgan,609.1893299999999,41.091026,-111.57788000000001,Morgan County,county
+iso1:us#iso2:us-tx#fips:48257,48257,48,48,Kaufman,780.71625,32.598946000000005,-96.288376,Kaufman County,county
+iso1:us#iso2:us-az#fips:04011,4011,4,4,Greenlee,1842.2039,33.238873,-109.242325,Greenlee County,county
+iso1:us#iso2:us-az#fips:04013,4013,4,4,Maricopa,9200.981,33.345177,-112.49893,Maricopa County,county
+iso1:us#iso2:us-mi#fips:26129,26129,26,26,Ogemaw,563.5224,44.33328,-84.128075,Ogemaw County,county
+iso1:us#iso2:us-tn#fips:47087,47087,47,47,Jackson,308.63797,36.354248,-85.674126,Jackson County,county
+iso1:us#iso2:us-il#fips:17159,17159,17,17,Richland,360.04636,38.71219,-88.08545,Richland County,county
+iso1:us#iso2:us-al#fips:01009,1009,1,1,Blount,644.85266,33.977356,-86.56644,Blount County,county
+iso1:us#iso2:us-mt#fips:30051,30051,30,30,Liberty,1430.0317,48.559653999999995,-111.03693,Liberty County,county
+iso1:us#iso2:us-tx#fips:48131,48131,48,48,Duval,1793.5382,27.681124,-98.49739,Duval County,county
+iso1:us#iso2:us-mo#fips:29173,29173,29,29,Ralls,469.80273,39.553455,-91.52479,Ralls County,county
+iso1:us#iso2:us-tx#fips:48251,48251,48,48,Johnson,725.0466299999999,32.37982,-97.36496,Johnson County,county
+iso1:us#iso2:us-ga#fips:13061,13061,13,13,Clay,195.41058,31.619831,-84.992584,Clay County,county
+iso1:us#iso2:us-or#fips:41023,41023,41,41,Grant,4527.9453,44.496326,-119.01406000000001,Grant County,county
+iso1:us#iso2:us-or#fips:41011,41011,41,41,Coos,1596.1249,43.18591,-124.09413,Coos County,county
+iso1:us#iso2:us-tx#fips:48159,48159,48,48,Franklin,284.40106000000003,33.175846,-95.21906,Franklin County,county
+iso1:us#iso2:us-ny#fips:36113,36113,36,36,Warren,867.24677,43.555107,-73.83814,Warren County,county
+iso1:us#iso2:us-va#fips:51113,51113,51,51,Madison,320.64856000000003,38.41206,-78.27696,Madison County,county
+iso1:us#iso2:us-ok#fips:40005,40005,40,40,Atoka,975.4794,34.392466999999996,-96.03656,Atoka County,county
+iso1:us#iso2:us-il#fips:17129,17129,17,17,Menard,314.40186,40.022568,-89.794136,Menard County,county
+iso1:us#iso2:us-ga#fips:13015,13015,13,13,Bartow,458.92462,34.240916999999996,-84.83819,Bartow County,county
+iso1:us#iso2:us-fl#fips:12069,12069,12,12,Lake,950.7899,28.764112,-81.71228,Lake County,county
+iso1:us#iso2:us-ok#fips:40111,40111,40,40,Okmulgee,697.4684,35.6435,-95.96595,Okmulgee County,county
+iso1:us#iso2:us-nd#fips:38083,38083,38,38,Sheridan,972.2589,47.58136,-100.330986,Sheridan County,county
+iso1:us#iso2:us-in#fips:18049,18049,18,18,Fulton,368.4055,41.050385,-86.26501,Fulton County,county
+iso1:us#iso2:us-ks#fips:20091,20091,20,20,Johnson,473.635,38.883907,-94.82233000000001,Johnson County,county
+iso1:us#iso2:us-md#fips:24009,24009,24,24,Calvert,213.19824,38.52272,-76.52976,Calvert County,county
+iso1:us#iso2:us-wi#fips:55129,55129,55,55,Washburn,797.1412,45.89249,-91.796425,Washburn County,county
+iso1:us#iso2:us-wa#fips:53031,53031,53,53,Jefferson,1803.7855,47.805706,-123.527054,Jefferson County,county
+iso1:us#iso2:us-pr#fips:72003,72003,72,72,Aguada Municipio,30.859737,18.37568,-67.18370999999999,Aguada Municipio,county
+iso1:us#iso2:us-mn#fips:27169,27169,27,27,Winona,626.1393400000001,43.98227,-91.77671,Winona County,county
+iso1:us#iso2:us-ms#fips:28149,28149,28,28,Warren,588.55035,32.356094,-90.85239,Warren County,county
+iso1:us#iso2:us-mo#fips:29003,29003,29,29,Andrew,432.64597000000003,39.988859999999995,-94.80355,Andrew County,county
+iso1:us#iso2:us-mo#fips:29139,29139,29,29,Montgomery,535.0652,38.935184,-91.46542,Montgomery County,county
+iso1:us#iso2:us-ks#fips:20021,20021,20,20,Cherokee,587.5868,37.16939,-94.84569499999999,Cherokee County,county
+iso1:us#iso2:us-nc#fips:37083,37083,37,37,Halifax,723.7627,36.25144,-77.64484399999999,Halifax County,county
+iso1:us#iso2:us-nm#fips:35043,35043,35,35,Sandoval,3710.2366,35.685093,-106.88311999999999,Sandoval County,county
+iso1:us#iso2:us-ky#fips:21051,21051,21,21,Clay,469.3125,37.164272,-83.71548,Clay County,county
+iso1:us#iso2:us-pa#fips:42035,42035,42,42,Clinton,888.0143400000001,41.262623,-77.69636,Clinton County,county
+iso1:us#iso2:us-or#fips:41043,41043,41,41,Linn,2287.3225,44.4889,-122.53721000000002,Linn County,county
+iso1:us#iso2:us-wi#fips:55065,55065,55,55,Lafayette,633.60956,42.65558,-90.13029499999999,Lafayette County,county
+iso1:us#iso2:us-ok#fips:40147,40147,40,40,Washington,415.53787,36.70438,-95.90615,Washington County,county
+iso1:us#iso2:us-wv#fips:54077,54077,54,54,Preston,648.8357,39.46903,-79.66886,Preston County,county
+iso1:us#iso2:us-mp:#fips:69100,69100,69,69,Rota Municipality,32.857174,14.1524935,145.2129,Rota Municipality,county
+iso1:us#iso2:us-wi#fips:55135,55135,55,55,Waupaca,747.71906,44.478004,-88.96700000000001,Waupaca County,county
+iso1:us#iso2:us-tx#fips:48137,48137,48,48,Edwards,2117.9426,29.985878000000003,-100.30736999999999,Edwards County,county
+iso1:us#iso2:us-or#fips:41037,41037,41,41,Lake,8138.8765,42.788403,-120.38978999999999,Lake County,county
+iso1:us#iso2:us-mo#fips:29153,29153,29,29,Ozark,744.9968,36.64959,-92.45855,Ozark County,county
+iso1:us#iso2:us-tx#fips:48473,48473,48,48,Waller,513.2746599999999,30.01359,-95.98215,Waller County,county
+iso1:us#iso2:us-al#fips:01099,1099,1,1,Monroe,1025.7036,31.580332000000002,-87.38325999999999,Monroe County,county
+iso1:us#iso2:us-vt#fips:50009,50009,50,50,Essex,663.62177,44.724022,-71.73273499999999,Essex County,county
+iso1:us#iso2:us-va#fips:51111,51111,51,51,Lunenburg,431.71463,36.945553000000004,-78.240524,Lunenburg County,county
+iso1:us#iso2:us-nd#fips:38097,38097,38,38,Traill,861.90027,47.446213,-97.16476,Traill County,county
+iso1:us#iso2:us-ga#fips:13139,13139,13,13,Hall,393.01232999999996,34.31757,-83.8185,Hall County,county
+iso1:us#iso2:us-ga#fips:13283,13283,13,13,Treutlen,199.4399,32.409584,-82.570885,Treutlen County,county
+iso1:us#iso2:us-ga#fips:13037,13037,13,13,Calhoun,280.39365,31.521278000000002,-84.62629,Calhoun County,county
+iso1:us#iso2:us-wi#fips:55125,55125,55,55,Vilas,857.73645,46.049847,-89.50125,Vilas County,county
+iso1:us#iso2:us-mn#fips:27007,27007,27,27,Beltrami,2504.7896,47.879509999999996,-95.00505,Beltrami County,county
+iso1:us#iso2:us-pr#fips:72043,72043,72,72,Coamo Municipio,78.015495,18.1038,-66.35759,Coamo Municipio,county
+iso1:us#iso2:us-pr#fips:72055,72055,72,72,Guánica Municipio,37.051464,17.948051,-66.92299,Guánica Municipio,county
+iso1:us#iso2:us-md#fips:24019,24019,24,24,Dorchester,540.78296,38.429195,-76.04743,Dorchester County,county
+iso1:us#iso2:us-pa#fips:42037,42037,42,42,Columbia,483.0099,41.045517,-76.40426,Columbia County,county
+iso1:us#iso2:us-oh#fips:39023,39023,39,39,Clark,396.89083999999997,39.91703,-83.783676,Clark County,county
+iso1:us#iso2:us-tx#fips:48323,48323,48,48,Maverick,1279.5157,28.729788,-100.31668,Maverick County,county
+iso1:us#iso2:us-az#fips:04019,4019,4,4,Pima,9189.002,32.128044,-111.78366000000001,Pima County,county
+iso1:us#iso2:us-nm#fips:35006,35006,35,35,Cibola,4540.1387,34.928272,-107.99268000000001,Cibola County,county
+iso1:us#iso2:us-nj#fips:34005,34005,34,34,Burlington,799.3196,39.875786,-74.66301,Burlington County,county
+iso1:us#iso2:us-vt#fips:50021,50021,50,50,Rutland,929.8503,43.580856,-73.0382,Rutland County,county
+iso1:us#iso2:us-ga#fips:13099,13099,13,13,Early,512.61694,31.32419,-84.90671999999999,Early County,county
+iso1:us#iso2:us-ma#fips:25007,25007,25,25,Dukes,103.20883,41.38097,-70.7015,Dukes County,county
+iso1:us#iso2:us-nd#fips:38049,38049,38,38,McHenry,1874.006,48.23384,-100.63327,McHenry County,county
+iso1:us#iso2:us-ne#fips:31179,31179,31,31,Wayne,442.931,42.210747,-97.12624,Wayne County,county
+iso1:us#iso2:us-nd#fips:38045,38045,38,38,LaMoure,1146.0441,46.464195000000004,-98.526054,LaMoure County,county
+iso1:us#iso2:us-id#fips:16023,16023,16,16,Butte,2236.5627,43.6851,-113.17763000000001,Butte County,county
+iso1:us#iso2:us-nh#fips:33007,33007,33,33,Coos,1794.6344,44.652546,-71.28943000000001,Coos County,county
+iso1:us#iso2:us-nd#fips:38043,38043,38,38,Kidder,1351.1078,46.938274,-99.7312,Kidder County,county
+iso1:us#iso2:us-tx#fips:48273,48273,48,48,Kleberg,881.3361,27.438734000000004,-97.66062,Kleberg County,county
+iso1:us#iso2:us-in#fips:18127,18127,18,18,Porter,418.09845,41.509914,-87.07131,Porter County,county
+iso1:us#iso2:us-ms#fips:28101,28101,28,28,Newton,577.8743,32.40197,-89.11841,Newton County,county
+iso1:us#iso2:us-nc#fips:37163,37163,37,37,Sampson,945.7344,34.989296,-78.37118000000001,Sampson County,county
+iso1:us#iso2:us-tn#fips:47127,47127,47,47,Moore,129.22693999999998,35.288887,-86.35868,Moore County,county
+iso1:us#iso2:us-fl#fips:12103,12103,12,12,Pinellas,273.7863,27.903109000000004,-82.73952,Pinellas County,county
+iso1:us#iso2:us-pr#fips:72019,72019,72,72,Barranquitas Municipio,34.25385,18.200018,-66.30928,Barranquitas Municipio,county
+iso1:us#iso2:us-il#fips:17065,17065,17,17,Hamilton,434.66217,38.085228,-88.53901,Hamilton County,county
+iso1:us#iso2:us-ar#fips:05105,5105,5,5,Perry,551.57745,34.94636,-92.92688000000001,Perry County,county
+iso1:us#iso2:us-ks#fips:20023,20023,20,20,Cheyenne,1019.9243,39.789916999999996,-101.727325,Cheyenne County,county
+iso1:us#iso2:us-co#fips:08029,8029,8,8,Delta,1142.1642,38.861595,-107.86488999999999,Delta County,county
+iso1:us#iso2:us-ia#fips:19185,19185,19,19,Wayne,525.50824,40.739983,-93.33261,Wayne County,county
+iso1:us#iso2:us-tx#fips:48165,48165,48,48,Gaines,1502.4153,32.743942,-102.63156,Gaines County,county
+iso1:us#iso2:us-al#fips:01093,1093,1,1,Marion,742.36743,34.138218,-87.88155,Marion County,county
+iso1:us#iso2:us-nc#fips:37189,37189,37,37,Watauga,312.45108,36.235367,-81.709885,Watauga County,county
+iso1:us#iso2:us-va#fips:51770,51770,51,51,Roanoke city,42.522667,37.278458,-79.958176,Roanoke city,county
+iso1:us#iso2:us-tx#fips:48317,48317,48,48,Martin,914.9869,32.30983,-101.96184000000001,Martin County,county
+iso1:us#iso2:us-tx#fips:48037,48037,48,48,Bowie,885.03204,33.446064,-94.42239000000001,Bowie County,county
+iso1:us#iso2:us-ut#fips:49057,49057,49,49,Weber,576.2913,41.270325,-111.876884,Weber County,county
+iso1:us#iso2:us-mo#fips:29127,29127,29,29,Marion,436.93707,39.807536999999996,-91.63537600000001,Marion County,county
+iso1:us#iso2:us-ny#fips:36045,36045,36,36,Jefferson,1268.7452,43.996387,-76.05297,Jefferson County,county
+iso1:us#iso2:us-ia#fips:19097,19097,19,19,Jackson,636.06506,42.164227000000004,-90.574585,Jackson County,county
+iso1:us#iso2:us-nd#fips:38063,38063,38,38,Nelson,981.84845,47.918667,-98.20443,Nelson County,county
+iso1:us#iso2:us-ny#fips:36019,36019,36,36,Clinton,1037.7926,44.752712,-73.70564,Clinton County,county
+iso1:us#iso2:us-co#fips:08045,8045,8,8,Garfield,2947.5251,39.59935,-107.90978,Garfield County,county
+iso1:us#iso2:us-mo#fips:29177,29177,29,29,Ray,568.8286,39.3084,-93.99574,Ray County,county
+iso1:us#iso2:us-oh#fips:39073,39073,39,39,Hocking,421.34265,39.49034,-82.48344399999999,Hocking County,county
+iso1:us#iso2:us-al#fips:01085,1085,1,1,Lowndes,715.9355,32.147890000000004,-86.65059000000001,Lowndes County,county
+iso1:us#iso2:us-ga#fips:13043,13043,13,13,Candler,243.06762999999998,32.40395,-82.07126600000001,Candler County,county
+iso1:us#iso2:us-ia#fips:19113,19113,19,19,Linn,717.1026,42.07795,-91.59767,Linn County,county
+iso1:us#iso2:us-ca#fips:06105,6105,6,6,Trinity,3179.3757,40.647804,-123.11448,Trinity County,county
+iso1:us#iso2:us-ga#fips:13215,13215,13,13,Muscogee,216.48656,32.510197,-84.87495,Muscogee County,county
+iso1:us#iso2:us-ms#fips:28135,28135,28,28,Tallahatchie,645.24506,33.95453,-90.17224,Tallahatchie County,county
+iso1:us#iso2:us-ks#fips:20005,20005,20,20,Atchison,431.18906,39.532543,-95.3134,Atchison County,county
+iso1:us#iso2:us-pr#fips:72081,72081,72,72,Lares Municipio,61.452296999999994,18.277102,-66.869644,Lares Municipio,county
+iso1:us#iso2:us-tx#fips:48003,48003,48,48,Andrews,1500.7723,32.312259999999995,-102.64020500000001,Andrews County,county
+iso1:us#iso2:us-oh#fips:39109,39109,39,39,Miami,406.52637000000004,40.053326,-84.22842,Miami County,county
+iso1:us#iso2:us-tx#fips:48375,48375,48,48,Potter,908.42065,35.398674,-101.89381,Potter County,county
+iso1:us#iso2:us-ok#fips:40133,40133,40,40,Seminole,632.85364,35.158367,-96.60285999999999,Seminole County,county
+iso1:us#iso2:us-sc#fips:45003,45003,45,45,Aiken,1070.7167,33.550014000000004,-81.63298,Aiken County,county
+iso1:us#iso2:us-as:#fips:60020,60020,60,60,Manu'a District,22.248345999999998,-14.219693,-169.50732,Manu'a District,county
+iso1:us#iso2:us-ca#fips:06045,6045,6,6,Mendocino,3506.4778,39.432390000000005,-123.44288,Mendocino County,county
+iso1:us#iso2:us-va#fips:51550,51550,51,51,Chesapeake city,338.5219,36.679375,-76.30179,Chesapeake city,county
+iso1:us#iso2:us-mp#fips:69120,69120,69,69,Tinian Municipality,41.792194,14.936784,145.60103,Tinian Municipality,county
+iso1:us#iso2:us-pr#fips:72153,72153,72,72,Yauco Municipio,67.71378,18.085669,-66.8579,Yauco Municipio,county
+iso1:us#iso2:us-wy#fips:56037,56037,56,56,Sweetwater,10427.335,41.660328,-108.87568,Sweetwater County,county
+iso1:us#iso2:us-tx#fips:48169,48169,48,48,Garza,893.4441,33.183792,-101.30113,Garza County,county
+iso1:us#iso2:us-wv#fips:54031,54031,54,54,Hardy,582.33594,39.011359999999996,-78.84173,Hardy County,county
+iso1:us#iso2:us-pr#fips:72001,72001,72,72,Adjuntas Municipio,66.69205,18.181612,-66.75816,Adjuntas Municipio,county
+iso1:us#iso2:us-wi#fips:55089,55089,55,55,Ozaukee,233.02615,43.360752000000005,-87.499306,Ozaukee County,county
+iso1:us#iso2:us-tn#fips:47163,47163,47,47,Sullivan,413.43036,36.509679999999996,-82.30134,Sullivan County,county
+iso1:us#iso2:us-sc#fips:45059,45059,45,45,Laurens,713.7889,34.483677,-82.0055,Laurens County,county
+iso1:us#iso2:us-wy#fips:56011,56011,56,56,Crook,2854.577,44.589264,-104.5673,Crook County,county
+iso1:us#iso2:us-wi#fips:55117,55117,55,55,Sheboygan,511.54526,43.741234000000006,-87.731514,Sheboygan County,county
+iso1:us#iso2:us-ma#fips:25013,25013,25,25,Hampden,617.0214,42.136196000000005,-72.63565,Hampden County,county
+iso1:us#iso2:us-tx#fips:48055,48055,48,48,Caldwell,545.2586,29.8324,-97.62814,Caldwell County,county
+iso1:us#iso2:us-ks#fips:20029,20029,20,20,Cloud,715.3661,39.487328000000005,-97.64139,Cloud County,county
+iso1:us#iso2:us-ca#fips:06027,6027,6,6,Inyo,10197.567,36.561977,-117.40393,Inyo County,county
+iso1:us#iso2:us-al#fips:01037,1037,1,1,Coosa,650.9328,32.931446,-86.243484,Coosa County,county
+iso1:us#iso2:us-ia#fips:19059,19059,19,19,Dickinson,380.53292999999996,43.38961,-95.19606,Dickinson County,county
+iso1:us#iso2:us-ky#fips:21095,21095,21,21,Harlan,465.84662000000003,36.859221999999995,-83.2215,Harlan County,county
+iso1:us#iso2:us-ks#fips:20061,20061,20,20,Geary,384.67615,39.002140000000004,-96.7681,Geary County,county
+iso1:us#iso2:us-pa#fips:42011,42011,42,42,Berks,856.43555,40.413956,-75.92685999999999,Berks County,county
+iso1:us#iso2:us-tn#fips:47019,47019,47,47,Carter,341.26993,36.284744,-82.126595,Carter County,county
+iso1:us#iso2:us-mn#fips:27083,27083,27,27,Lyon,714.435,44.409195000000004,-95.84727,Lyon County,county
+iso1:us#iso2:us-va#fips:51037,51037,51,51,Charlotte,475.31183,37.00904,-78.65857,Charlotte County,county
+iso1:us#iso2:us-tn#fips:47179,47179,47,47,Washington,326.5014,36.295666,-82.49504,Washington County,county
+iso1:us#iso2:us-sc#fips:45071,45071,45,45,Newberry,630.0651,34.28988,-81.59968,Newberry County,county
+iso1:us#iso2:us-va#fips:51093,51093,51,51,Isle of Wight,315.69067,36.901416999999995,-76.707565,Isle of Wight County,county
+iso1:us#iso2:us-or#fips:41069,41069,41,41,Wheeler,1716.0798,44.736416,-120.02686000000001,Wheeler County,county
+iso1:us#iso2:us-mo#fips:29023,29023,29,29,Butler,694.6939,36.71518,-90.40313,Butler County,county
+iso1:us#iso2:us-la#fips:22047,22047,22,22,Iberville Parish,618.65076,30.270628000000002,-91.365845,Iberville Parish,county
+iso1:us#iso2:us-ms#fips:28125,28125,28,28,Sharkey,431.73467999999997,32.892395,-90.827614,Sharkey County,county
+iso1:us#iso2:us-va#fips:51061,51061,51,51,Fauquier,648.0281,38.744095,-77.8215,Fauquier County,county
+iso1:us#iso2:us-va#fips:51750,51750,51,51,Radford city,9.676716,37.12012,-80.55915,Radford city,county
+iso1:us#iso2:us-nv#fips:32005,32005,32,32,Douglas,709.74567,38.90513,-119.60902,Douglas County,county
+iso1:us#iso2:us-fl#fips:12037,12037,12,12,Franklin,545.1594,29.810175,-84.79916999999999,Franklin County,county
+iso1:us#iso2:us-in#fips:18055,18055,18,18,Greene,542.4858,39.047146000000005,-87.00477,Greene County,county
+iso1:us#iso2:us-in#fips:18139,18139,18,18,Rush,408.13754,39.62238,-85.46644599999999,Rush County,county
+iso1:us#iso2:us-wi#fips:55131,55131,55,55,Washington,430.65842000000004,43.391155,-88.23292,Washington County,county
+iso1:us#iso2:us-mo#fips:29105,29105,29,29,Laclede,764.6562,37.6597,-92.59484,Laclede County,county
+iso1:us#iso2:us-pa#fips:42085,42085,42,42,Mercer,672.5385,41.300014000000004,-80.252785,Mercer County,county
+iso1:us#iso2:us-ar#fips:05031,5031,5,5,Craighead,707.32733,35.827729999999995,-90.631424,Craighead County,county
+iso1:us#iso2:us-mo#fips:29195,29195,29,29,Saline,755.5184,39.13584,-93.20416,Saline County,county
+iso1:us#iso2:us-il#fips:17193,17193,17,17,White,494.9995,38.087326000000004,-88.17862,White County,county
+iso1:us#iso2:us-il#fips:17039,17039,17,17,De Witt,397.57455,40.1815,-88.901855,De Witt County,county
+iso1:us#iso2:us-nv#fips:32033,32033,32,32,White Pine,8886.966999999999,39.418236,-114.900604,White Pine County,county
+iso1:us#iso2:us-mn#fips:27049,27049,27,27,Goodhue,756.7326,44.406178000000004,-92.71600000000001,Goodhue County,county
+iso1:us#iso2:us-nc#fips:37173,37173,37,37,Swain,527.7464,35.568847999999996,-83.465614,Swain County,county
+iso1:us#iso2:us-fl#fips:12101,12101,12,12,Pasco,746.6056,28.307709999999997,-82.464836,Pasco County,county
+iso1:us#iso2:us-fl#fips:12119,12119,12,12,Sumter,557.15155,28.7141,-82.07435,Sumter County,county
+iso1:us#iso2:us-ny#fips:36059,36059,36,36,Nassau,284.6426,40.72961,-73.58941999999999,Nassau County,county
+iso1:us#iso2:us-nd#fips:38091,38091,38,38,Steele,712.16705,47.45106,-97.71892,Steele County,county
+iso1:us#iso2:us-in#fips:18163,18163,18,18,Vanderburgh,233.6834,38.020070000000004,-87.58617,Vanderburgh County,county
+iso1:us#iso2:us-mo#fips:29071,29071,29,29,Franklin,922.6824,38.413002,-91.07283000000001,Franklin County,county
+iso1:us#iso2:us-nc#fips:37011,37011,37,37,Avery,247.34627999999998,36.07209,-81.92029000000001,Avery County,county
+iso1:us#iso2:us-wv#fips:54107,54107,54,54,Wood,366.52047999999996,39.2116,-81.516235,Wood County,county
+iso1:us#iso2:us-wi#fips:55007,55007,55,55,Bayfield,1477.9241,46.6342,-91.177284,Bayfield County,county
+iso1:us#iso2:us-tn#fips:47161,47161,47,47,Stewart,459.7917,36.458465999999994,-87.81189,Stewart County,county
+iso1:us#iso2:us-wi#fips:55097,55097,55,55,Portage,800.9028,44.476246,-89.49807,Portage County,county
+iso1:us#iso2:us-sc#fips:45063,45063,45,45,Lexington,699.0159,33.899475,-81.26626999999999,Lexington County,county
+iso1:us#iso2:us-md#fips:24003,24003,24,24,Anne Arundel,414.82437000000004,38.991620000000005,-76.5609,Anne Arundel County,county
+iso1:us#iso2:us-wi#fips:55039,55039,55,55,Fond du Lac,719.5904,43.754723,-88.493286,Fond du Lac County,county
+iso1:us#iso2:us-wv#fips:54101,54101,54,54,Webster,553.48914,38.48346,-80.44905,Webster County,county
+iso1:us#iso2:us-wi#fips:55061,55061,55,55,Kewaunee,342.46567000000005,44.501034000000004,-87.16331,Kewaunee County,county
+iso1:us#iso2:us-tx#fips:48369,48369,48,48,Parmer,880.8495,34.53216,-102.78485,Parmer County,county
+iso1:us#iso2:us-ok#fips:40151,40151,40,40,Woods,1286.507,36.726986,-98.86365,Woods County,county
+iso1:us#iso2:us-ky#fips:21063,21063,21,21,Elliott,234.32661000000002,38.116882000000004,-83.096115,Elliott County,county
+iso1:us#iso2:us-ma#fips:25003,25003,25,25,Berkshire,926.9086,42.371494,-73.217926,Berkshire County,county
+iso1:us#iso2:us-mo#fips:29041,29041,29,29,Chariton,751.2035,39.517967,-92.961624,Chariton County,county
+iso1:us#iso2:us-co#fips:08103,8103,8,8,Rio Blanco,3221.08,39.972621999999994,-108.20071399999999,Rio Blanco County,county
+iso1:us#iso2:us-co#fips:08087,8087,8,8,Morgan,1280.5288,40.26316,-103.81221,Morgan County,county
+iso1:us#iso2:us-or#fips:41045,41045,41,41,Malheur,9888.046999999999,43.188625,-117.603195,Malheur County,county
+iso1:us#iso2:us-nj#fips:34023,34023,34,34,Middlesex,309.22598,40.43962,-74.40743,Middlesex County,county
+iso1:us#iso2:us-ks#fips:20167,20167,20,20,Russell,886.29016,38.91604,-98.77095,Russell County,county
+iso1:us#iso2:us-il#fips:17155,17155,17,17,Putnam,160.10243,41.198963,-89.29835,Putnam County,county
+iso1:us#iso2:us-sd#fips:46055,46055,46,46,Haakon,1810.6027,44.282883,-101.59544,Haakon County,county
+iso1:us#iso2:us-tn#fips:47111,47111,47,47,Macon,307.15407999999996,36.537758000000004,-86.00095999999999,Macon County,county
+iso1:us#iso2:us-ar#fips:05023,5023,5,5,Cleburne,553.7194,35.566315,-92.05995,Cleburne County,county
+iso1:us#iso2:us-al#fips:01109,1109,1,1,Pike,672.09064,31.79865,-85.94160500000001,Pike County,county
+iso1:us#iso2:us-id#fips:16003,16003,16,16,Adams,1362.8514,44.877003,-116.461624,Adams County,county
+iso1:us#iso2:us-ma#fips:25005,25005,25,25,Bristol,553.1274,41.74859,-71.0889,Bristol County,county
+iso1:us#iso2:us-pa#fips:42107,42107,42,42,Schuylkill,778.6578400000001,40.703682,-76.21779000000001,Schuylkill County,county
+iso1:us#iso2:us-nd#fips:38103,38103,38,38,Wells,1270.576,47.580853000000005,-99.68221,Wells County,county
+iso1:us#iso2:us-nc#fips:37045,37045,37,37,Cleveland,464.2308,35.33463,-81.55711,Cleveland County,county
+iso1:us#iso2:us-ar#fips:05059,5059,5,5,Hot Spring,615.3112,34.315178,-92.94414499999999,Hot Spring County,county
+iso1:us#iso2:us-md#fips:24021,24021,24,24,Frederick,660.5489,39.470215,-77.39763,Frederick County,county
+iso1:us#iso2:us-il#fips:17169,17169,17,17,Schuyler,437.3153,40.156906,-90.61346400000001,Schuyler County,county
+iso1:us#iso2:us-ca#fips:06051,6051,6,6,Mono,3049.09,37.915836,-118.87517,Mono County,county
+iso1:us#iso2:us-ca#fips:06109,6109,6,6,Tuolumne,2220.9465,38.021435,-119.96473999999999,Tuolumne County,county
+iso1:us#iso2:us-nm#fips:35013,35013,35,35,Doña Ana,3808.3186,32.349920000000004,-106.83497,Doña Ana County,county
+iso1:us#iso2:us-ga#fips:13081,13081,13,13,Crisp,272.68883999999997,31.915148,-83.75353,Crisp County,county
+iso1:us#iso2:us-ar#fips:05027,5027,5,5,Columbia,766.0095,33.223038,-93.23284,Columbia County,county
+iso1:us#iso2:us-nd#fips:38039,38039,38,38,Griggs,708.67896,47.456333,-98.232285,Griggs County,county
+iso1:us#iso2:us-ca#fips:06095,6095,6,6,Solano,821.84204,38.267227,-121.93959,Solano County,county
+iso1:us#iso2:us-ia#fips:19043,19043,19,19,Clayton,778.5227,42.840984000000006,-91.32358,Clayton County,county
+iso1:us#iso2:us-tx#fips:48449,48449,48,48,Titus,406.0766,33.2146,-94.96678,Titus County,county
+iso1:us#iso2:us-wv#fips:54027,54027,54,54,Hampshire,640.42377,39.312138,-78.61199,Hampshire County,county
+iso1:us#iso2:us-nc#fips:37125,37125,37,37,Moore,697.70026,35.308273,-79.49271999999999,Moore County,county
+iso1:us#iso2:us-ks#fips:20009,20009,20,20,Barton,895.2876,38.48124,-98.76784,Barton County,county
+iso1:us#iso2:us-nd#fips:38087,38087,38,38,Slope,1215.3057,46.445834999999995,-103.46246,Slope County,county
+iso1:us#iso2:us-la#fips:22083,22083,22,22,Richland Parish,555.747,32.41316,-91.74835,Richland Parish,county
+iso1:us#iso2:us-ne#fips:31071,31071,31,31,Garfield,569.34955,41.906867999999996,-98.95123000000001,Garfield County,county
+iso1:us#iso2:us-la#fips:22099,22099,22,22,St. Martin Parish,737.2469,30.121433000000003,-91.61148,St. Martin Parish,county
+iso1:us#iso2:us-al#fips:01119,1119,1,1,Sumter,903.8569,32.59748,-88.20006,Sumter County,county
+iso1:us#iso2:us-al#fips:01133,1133,1,1,Winston,613.0021,34.154568,-87.36535,Winston County,county
+iso1:us#iso2:us-fl#fips:12117,12117,12,12,Seminole,309.3364,28.690092,-81.13199,Seminole County,county
+iso1:us#iso2:us-ms#fips:28035,28035,28,28,Forrest,466.0577,31.188579999999998,-89.259445,Forrest County,county
+iso1:us#iso2:us-mi#fips:26065,26065,26,26,Ingham,556.0819,42.603535,-84.37380999999999,Ingham County,county
+iso1:us#iso2:us-ks#fips:20177,20177,20,20,Shawnee,544.0414400000001,39.041805,-95.75565999999999,Shawnee County,county
+iso1:us#iso2:us-sd#fips:46061,46061,46,46,Hanson,434.60147,43.680609999999994,-97.796844,Hanson County,county
+iso1:us#iso2:us-mn#fips:27061,27061,27,27,Itasca,2667.4126,47.490818,-93.6111,Itasca County,county
+iso1:us#iso2:us-co#fips:08073,8073,8,8,Lincoln,2577.7668,38.99374,-103.50755,Lincoln County,county
+iso1:us#iso2:us-ny#fips:36053,36053,36,36,Madison,654.8703,42.910027,-75.663574,Madison County,county
+iso1:us#iso2:us-ny#fips:36115,36115,36,36,Washington,831.1956,43.312378,-73.43943,Washington County,county
+iso1:us#iso2:us-in#fips:18081,18081,18,18,Johnson,320.4548,39.496094,-86.09425999999999,Johnson County,county
+iso1:us#iso2:us-tx#fips:48445,48445,48,48,Terry,888.86957,33.17123,-102.33929,Terry County,county
+iso1:us#iso2:us-nm#fips:35021,35021,35,35,Harding,2125.5505,35.858517,-103.84792,Harding County,county
+iso1:us#iso2:us-al#fips:01121,1121,1,1,Talladega,736.8211,33.369312,-86.175934,Talladega County,county
+iso1:us#iso2:us-wi#fips:55067,55067,55,55,Langlade,870.7279,45.262383,-89.06772600000001,Langlade County,county
+iso1:us#iso2:us-tx#fips:48155,48155,48,48,Foard,704.4205,33.963306,-99.816826,Foard County,county
+iso1:us#iso2:us-ia#fips:19021,19021,19,19,Buena Vista,574.91864,42.741524,-95.14143,Buena Vista County,county
+iso1:us#iso2:us-ia#fips:19129,19129,19,19,Mills,437.4466,41.033703,-95.6191,Mills County,county
+iso1:us#iso2:us-tx#fips:48385,48385,48,48,Real,699.18256,29.830097,-99.812546,Real County,county
+iso1:us#iso2:us-oh#fips:39041,39041,39,39,Delaware,443.17465,40.278942,-83.00746,Delaware County,county
+iso1:us#iso2:us-nc#fips:37067,37067,37,37,Forsyth,407.82333,36.132465,-80.25695999999999,Forsyth County,county
+iso1:us#iso2:us-nv#fips:32510,32510,32,32,Carson City,144.66615,39.153059999999996,-119.74736999999999,Carson City,county
+iso1:us#iso2:us-ia#fips:19049,19049,19,19,Dallas,588.3398,41.685320000000004,-94.0407,Dallas County,county
+iso1:us#iso2:us-tx#fips:48065,48065,48,48,Carson,920.2661,35.405495,-101.355354,Carson County,county
+iso1:us#iso2:us-ga#fips:13261,13261,13,13,Sumter,482.89365,32.042266999999995,-84.20429,Sumter County,county
+iso1:us#iso2:us-mo#fips:29223,29223,29,29,Wayne,759.2113,37.111073,-90.45393,Wayne County,county
+iso1:us#iso2:us-sc#fips:45007,45007,45,45,Anderson,713.8774,34.521236,-82.6386,Anderson County,county
+iso1:us#iso2:us-wy#fips:56007,56007,56,56,Carbon,7898.0713,41.703590000000005,-106.93315,Carbon County,county
+iso1:us#iso2:us-mt#fips:30093,30093,30,30,Silver Bow,718.00775,45.896233,-112.66006999999999,Silver Bow County,county
+iso1:us#iso2:us-il#fips:17177,17177,17,17,Stephenson,564.2658,42.349728000000006,-89.66599000000001,Stephenson County,county
+iso1:us#iso2:us-mi#fips:26087,26087,26,26,Lapeer,647.0039,43.088634000000006,-83.22433000000001,Lapeer County,county
+iso1:us#iso2:us-la#fips:22027,22027,22,22,Claiborne Parish,754.9038,32.82716,-92.98973000000001,Claiborne Parish,county
+iso1:us#iso2:us-ms#fips:28161,28161,28,28,Yalobusha,467.16655999999995,34.030666,-89.703804,Yalobusha County,county
+iso1:us#iso2:us-pr#fips:72093,72093,72,72,Maricao Municipio,36.623726,18.173956,-66.93555,Maricao Municipio,county
+iso1:us#iso2:us-mi#fips:26079,26079,26,26,Kalkaska,559.7626,44.678883,-85.08899,Kalkaska County,county
+iso1:us#iso2:us-pr#fips:72005,72005,72,72,Aguadilla Municipio,36.53283,18.48019,-67.14376,Aguadilla Municipio,county
+iso1:us#iso2:us-la#fips:22039,22039,22,22,Evangeline Parish,662.4032599999999,30.720694,-92.40408000000001,Evangeline Parish,county
+iso1:us#iso2:us-tn#fips:47069,47069,47,47,Hardeman,667.7658700000001,35.218784,-88.98869,Hardeman County,county
+iso1:us#iso2:us-az#fips:04003,4003,4,4,Cochise,6209.96,31.840128000000004,-109.77516000000001,Cochise County,county
+iso1:us#iso2:us-nm#fips:35023,35023,35,35,Hidalgo,3438.6504,31.898052000000003,-108.75193,Hidalgo County,county
+iso1:us#iso2:us-nd#fips:38023,38023,38,38,Divide,1260.9208,48.814754,-103.50932,Divide County,county
+iso1:us#iso2:us-ca#fips:06071,6071,6,6,San Bernardino,20068.564,34.85722,-116.1812,San Bernardino County,county
+iso1:us#iso2:us-co#fips:08083,8083,8,8,Montezuma,2029.4181,37.338024,-108.59579,Montezuma County,county
+iso1:us#iso2:us-ms#fips:28023,28023,28,28,Clarke,691.60095,32.045372,-88.68796999999999,Clarke County,county
+iso1:us#iso2:us-ia#fips:19125,19125,19,19,Marion,554.5082,41.331455,-93.09385,Marion County,county
+iso1:us#iso2:us-ne#fips:31055,31055,31,31,Douglas,326.42184,41.297092,-96.15406999999999,Douglas County,county
+iso1:us#iso2:us-va#fips:51600,51600,51,51,Fairfax city,6.240677,38.853184000000006,-77.29903,Fairfax city,county
+iso1:us#iso2:us-ok#fips:40057,40057,40,40,Harmon,537.2763,34.74597,-99.84419,Harmon County,county
+iso1:us#iso2:us-mo#fips:29039,29039,29,29,Cedar,474.48584000000005,37.733654,-93.85001,Cedar County,county
+iso1:us#iso2:us-ga#fips:13059,13059,13,13,Clarke,119.22658500000001,33.952187,-83.36715,Clarke County,county
+iso1:us#iso2:us-id#fips:16085,16085,16,16,Valley,3665.241,44.855959999999996,-115.61806499999999,Valley County,county
+iso1:us#iso2:us-tx#fips:48275,48275,48,48,Knox,850.6501,33.61189,-99.730354,Knox County,county
+iso1:us#iso2:us-ar#fips:05103,5103,5,5,Ouachita,732.8077400000001,33.591167,-92.87841,Ouachita County,county
+iso1:us#iso2:us-oh#fips:39037,39037,39,39,Darke,598.12067,40.131541999999996,-84.62125,Darke County,county
+iso1:us#iso2:us-ok#fips:40071,40071,40,40,Kay,919.6264,36.814884,-97.14386,Kay County,county
+iso1:us#iso2:us-sd#fips:46041,46041,46,46,Dewey,2302.5667,45.14805,-100.83795,Dewey County,county
+iso1:us#iso2:us-or#fips:41057,41057,41,41,Tillamook,1102.4066,45.455890000000004,-123.7593,Tillamook County,county
+iso1:us#iso2:us-ga#fips:13077,13077,13,13,Coweta,440.9485,33.352897999999996,-84.76214,Coweta County,county
+iso1:us#iso2:us-ms#fips:28127,28127,28,28,Simpson,589.18524,31.902503999999997,-89.91771,Simpson County,county
+iso1:us#iso2:us-ms#fips:28131,28131,28,28,Stone,445.49987999999996,30.790184000000004,-89.1123,Stone County,county
+iso1:us#iso2:us-ca#fips:06013,6013,6,6,Contra Costa,717.1048599999999,37.91948,-121.951546,Contra Costa County,county
+iso1:us#iso2:us-tn#fips:47017,47017,47,47,Carroll,597.6779,35.965748,-88.45238,Carroll County,county
+iso1:us#iso2:us-va#fips:51087,51087,51,51,Henrico,233.68398,37.631268,-77.651924,Henrico County,county
+iso1:us#iso2:us-in#fips:18119,18119,18,18,Owen,385.30893,39.31734,-86.838844,Owen County,county
+iso1:us#iso2:us-ny#fips:36119,36119,36,36,Westchester,430.60332999999997,41.152687,-73.74575,Westchester County,county
+iso1:us#iso2:us-mo#fips:29017,29017,29,29,Bollinger,617.9252299999999,37.318428000000004,-90.02464,Bollinger County,county
+iso1:us#iso2:us-wv#fips:54047,54047,54,54,McDowell,533.47565,37.38273,-81.65818,McDowell County,county
+iso1:us#iso2:us-wv#fips:54033,54033,54,54,Harrison,416.02182,39.279182,-80.3865,Harrison County,county
+iso1:us#iso2:us-nc#fips:37077,37077,37,37,Granville,532.0090299999999,36.299884999999996,-78.65763000000001,Granville County,county
+iso1:us#iso2:us-ct#fips:09009,9009,9,9,New Haven,604.5342,41.34972,-72.9002,New Haven County,county
+iso1:us#iso2:us-ne#fips:31139,31139,31,31,Pierce,573.2682,42.271409999999996,-97.61099,Pierce County,county
+iso1:us#iso2:us-ga#fips:13023,13023,13,13,Bleckley,215.87956,32.435402,-83.33171999999999,Bleckley County,county
+iso1:us#iso2:us-ga#fips:13033,13033,13,13,Burke,827.063,33.060179999999995,-82.00016,Burke County,county
+iso1:us#iso2:us-il#fips:17181,17181,17,17,Union,413.42523,37.485653000000006,-89.24464,Union County,county
+iso1:us#iso2:us-il#fips:17091,17091,17,17,Kankakee,676.51825,41.139509999999994,-87.861115,Kankakee County,county
+iso1:us#iso2:us-nd#fips:38051,38051,38,38,McIntosh,974.59625,46.10868,-99.41649,McIntosh County,county
+iso1:us#iso2:us-ne#fips:31141,31141,31,31,Platte,674.12274,41.576865999999995,-97.51346600000001,Platte County,county
+iso1:us#iso2:us-nc#fips:37185,37185,37,37,Warren,429.40555,36.398106,-78.0999,Warren County,county
+iso1:us#iso2:us-pr#fips:72009,72009,72,72,Aibonito Municipio,31.311813,18.130648,-66.26398,Aibonito Municipio,county
+iso1:us#iso2:us-ga#fips:13197,13197,13,13,Marion,366.02936,32.35931,-84.52873000000001,Marion County,county
+iso1:us#iso2:us-sd#fips:46027,46027,46,46,Clay,412.04465,42.91615,-96.98047,Clay County,county
+iso1:us#iso2:us-de#fips:10005,10005,10,10,Sussex,936.16486,38.67323,-75.33702,Sussex County,county
+iso1:us#iso2:us-ga#fips:13159,13159,13,13,Jasper,368.4187,33.316982,-83.68915,Jasper County,county
+iso1:us#iso2:us-mo#fips:29175,29175,29,29,Randolph,482.72824,39.439246999999995,-92.49296,Randolph County,county
+iso1:us#iso2:us-ks#fips:20015,20015,20,20,Butler,1429.7142,37.773647,-96.83884,Butler County,county
+iso1:us#iso2:us-tx#fips:48209,48209,48,48,Hays,678.0478,30.061224,-98.02927,Hays County,county
+iso1:us#iso2:us-tx#fips:48325,48325,48,48,Medina,1325.4038,29.353659999999998,-99.11108399999999,Medina County,county
+iso1:us#iso2:us-mi#fips:26105,26105,26,26,Mason,494.98800000000006,43.996635,-86.75081999999999,Mason County,county
+iso1:us#iso2:us-sc#fips:45013,45013,45,45,Beaufort,576.1696,32.358112,-80.68942,Beaufort County,county
+iso1:us#iso2:us-sd#fips:46135,46135,46,46,Yankton,521.20685,43.006603000000005,-97.38835999999999,Yankton County,county
+iso1:us#iso2:us-wi#fips:55105,55105,55,55,Rock,718.169,42.66988,-89.07529,Rock County,county
+iso1:us#iso2:us-sc#fips:45077,45077,45,45,Pickens,496.9942,34.88537,-82.72338,Pickens County,county
+iso1:us#iso2:us-wa#fips:53013,53013,53,53,Columbia,868.6145,46.29285,-117.91163999999999,Columbia County,county
+iso1:us#iso2:us-in#fips:18023,18023,18,18,Clinton,405.08096,40.305943,-86.47757,Clinton County,county
+iso1:us#iso2:us-il#fips:17027,17027,17,17,Clinton,473.95745999999997,38.606297,-89.42623,Clinton County,county
+iso1:us#iso2:us-id#fips:16067,16067,16,16,Minidoka,757.02167,42.857212,-113.63983999999999,Minidoka County,county
+iso1:us#iso2:us-pa#fips:42113,42113,42,42,Sullivan,449.955,41.439285,-76.51172,Sullivan County,county
+iso1:us#iso2:us-ms#fips:28121,28121,28,28,Rankin,775.52136,32.267124,-89.94606,Rankin County,county
+iso1:us#iso2:us-tx#fips:48345,48345,48,48,Motley,989.59955,34.0579,-100.79315,Motley County,county
+iso1:us#iso2:us-or#fips:41039,41039,41,41,Lane,4556.205,43.928329999999995,-122.89769,Lane County,county
+iso1:us#iso2:us-tx#fips:48485,48485,48,48,Wichita,627.6149,33.988213,-98.70801,Wichita County,county
+iso1:us#iso2:us-mi#fips:26155,26155,26,26,Shiawassee,530.9774,42.951546,-84.146355,Shiawassee County,county
+iso1:us#iso2:us-ks#fips:20089,20089,20,20,Jewell,910.0018,39.777,-98.22261999999999,Jewell County,county
+iso1:us#iso2:us-ks#fips:20123,20123,20,20,Mitchell,701.8158599999999,39.393024,-98.20736,Mitchell County,county
+iso1:us#iso2:us-fl#fips:12007,12007,12,12,Bradford,293.97357,29.952386999999998,-82.16668,Bradford County,county
+iso1:us#iso2:us-ms#fips:28091,28091,28,28,Marion,542.403,31.230166999999998,-89.82171,Marion County,county
+iso1:us#iso2:us-ms#fips:28039,28039,28,28,George,478.71227999999996,30.85543,-88.64226500000001,George County,county
+iso1:us#iso2:us-il#fips:17085,17085,17,17,Jo Daviess,600.9442,42.362390000000005,-90.21146999999999,Jo Daviess County,county
+iso1:us#iso2:us-in#fips:18059,18059,18,18,Hancock,305.967,39.82253,-85.77315,Hancock County,county
+iso1:us#iso2:us-va#fips:51620,51620,51,51,Franklin city,8.277623,36.684013,-76.9414,Franklin city,county
+iso1:us#iso2:us-tx#fips:48329,48329,48,48,Midland,900.3882,31.81427,-102.00246,Midland County,county
+iso1:us#iso2:us-ks#fips:20171,20171,20,20,Scott,717.6095,38.481876,-100.90635999999999,Scott County,county
+iso1:us#iso2:us-mt#fips:30013,30013,30,30,Cascade,2698.2654,47.316573999999996,-111.35026599999999,Cascade County,county
+iso1:us#iso2:us-va#fips:51660,51660,51,51,Harrisonburg city,17.339814999999998,38.436256,-78.87331,Harrisonburg city,county
+iso1:us#iso2:us-il#fips:17199,17199,17,17,Williamson,420.2283,37.730354,-88.93001600000001,Williamson County,county
+iso1:us#iso2:us-mt#fips:30029,30029,30,30,Flathead,5087.3706,48.314679999999996,-114.0543,Flathead County,county
+iso1:us#iso2:us-pr#fips:72111,72111,72,72,Peñuelas Municipio,44.618927,18.026617,-66.72813000000001,Peñuelas Municipio,county
+iso1:us#iso2:us-ks#fips:20189,20189,20,20,Stevens,727.2844,37.2017,-101.31727,Stevens County,county
+iso1:us#iso2:us-ky#fips:21067,21067,21,21,Fayette,283.64648,38.040676,-84.458275,Fayette County,county
+iso1:us#iso2:us-ky#fips:21091,21091,21,21,Hancock,187.67963,37.843327,-86.79276,Hancock County,county
+iso1:us#iso2:us-sd#fips:46013,46013,46,46,Brown,1713.0886,45.589252,-98.35217,Brown County,county
+iso1:us#iso2:us-wv#fips:54001,54001,54,54,Barbour,341.07047,39.139725,-79.99695,Barbour County,county
+iso1:us#iso2:us-tn#fips:47181,47181,47,47,Wayne,734.1341,35.242847,-87.81985,Wayne County,county
+iso1:us#iso2:us-ne#fips:31013,31013,31,31,Box Butte,1075.3291,42.21038,-103.08178000000001,Box Butte County,county
+iso1:us#iso2:us-pa#fips:42097,42097,42,42,Northumberland,458.02286,40.851524,-76.70988,Northumberland County,county
+iso1:us#iso2:us-tx#fips:48469,48469,48,48,Victoria,882.13635,28.79637,-96.9712,Victoria County,county
+iso1:us#iso2:us-va#fips:51530,51530,51,51,Buena Vista city,6.438375,37.729343,-79.35813,Buena Vista city,county
+iso1:us#iso2:us-mi#fips:26147,26147,26,26,St. Clair,721.3605,42.928802000000005,-82.668915,St. Clair County,county
+iso1:us#iso2:us-ne#fips:31173,31173,31,31,Thurston,393.59713999999997,42.15406,-96.53394,Thurston County,county
+iso1:us#iso2:us-vt#fips:50015,50015,50,50,Lamoille,458.88595999999995,44.603703,-72.63892,Lamoille County,county
+iso1:us#iso2:us-va#fips:51067,51067,51,51,Franklin,690.6456,36.991188,-79.88271,Franklin County,county
+iso1:us#iso2:us-ok#fips:40011,40011,40,40,Blaine,928.5195,35.87778,-98.42893000000001,Blaine County,county
+iso1:us#iso2:us-wa#fips:53037,53037,53,53,Kittitas,2297.3872,47.12444,-120.67671000000001,Kittitas County,county
+iso1:us#iso2:us-in#fips:18135,18135,18,18,Randolph,452.3946,40.164078,-85.00579,Randolph County,county
+iso1:us#iso2:us-ut#fips:49025,49025,49,49,Kane,3990.0818,37.275090000000006,-111.81533,Kane County,county
+iso1:us#iso2:us-wv#fips:54093,54093,54,54,Tucker,419.05865,39.111176,-79.55996999999999,Tucker County,county
+iso1:us#iso2:us-pr#fips:72113,72113,72,72,Ponce Municipio,114.94213,18.001717000000003,-66.60665999999999,Ponce Municipio,county
+iso1:us#iso2:us-wi#fips:55023,55023,55,55,Crawford,570.6672,43.24991,-90.95123000000001,Crawford County,county
+iso1:us#iso2:us-al#fips:01071,1071,1,1,Jackson,1078.0239,34.764114,-85.98006,Jackson County,county
+iso1:us#iso2:us-ia#fips:19123,19123,19,19,Mahaska,570.8782,41.330795,-92.63637,Mahaska County,county
+iso1:us#iso2:us-ks#fips:20045,20045,20,20,Douglas,455.78018,38.896415999999995,-95.29095,Douglas County,county
+iso1:us#iso2:us-ky#fips:21059,21059,21,21,Daviess,458.40682999999996,37.73167,-87.087135,Daviess County,county
+iso1:us#iso2:us-ky#fips:21197,21197,21,21,Powell,178.98717,37.809906,-83.83135,Powell County,county
+iso1:us#iso2:us-mo#fips:29097,29097,29,29,Jasper,638.5279,37.205196,-94.33726,Jasper County,county
+iso1:us#iso2:us-or#fips:41061,41061,41,41,Union,2037.0098,45.30408,-117.999146,Union County,county
+iso1:us#iso2:us-ga#fips:13151,13151,13,13,Henry,318.65958,33.452946000000004,-84.15401999999999,Henry County,county
+iso1:us#iso2:us-nd#fips:38001,38001,38,38,Adams,987.5802,46.096813,-102.53319499999999,Adams County,county
+iso1:us#iso2:us-nc#fips:37137,37137,37,37,Pamlico,336.5173,35.147575,-76.66526999999999,Pamlico County,county
+iso1:us#iso2:us-ky#fips:21083,21083,21,21,Graves,551.7747,36.723343,-88.649895,Graves County,county
+iso1:us#iso2:us-pa#fips:42021,42021,42,42,Cambria,688.38586,40.510222999999996,-78.71048,Cambria County,county
+iso1:us#iso2:us-tn#fips:47107,47107,47,47,McMinn,430.13138,35.424473,-84.61995,McMinn County,county
+iso1:us#iso2:us-mi#fips:26093,26093,26,26,Livingston,565.2714,42.60253,-83.91171999999999,Livingston County,county
+iso1:us#iso2:us-co#fips:08001,8001,8,8,Adams,1166.3448,39.874325,-104.33187,Adams County,county
+iso1:us#iso2:us-pa#fips:42069,42069,42,42,Lackawanna,458.7873,41.440284999999996,-75.609665,Lackawanna County,county
+iso1:us#iso2:us-ok#fips:40123,40123,40,40,Pontotoc,720.42773,34.721447,-96.69197,Pontotoc County,county
+iso1:us#iso2:us-ok#fips:40037,40037,40,40,Creek,949.88495,35.907734000000005,-96.37979,Creek County,county
+iso1:us#iso2:us-tx#fips:48457,48457,48,48,Tyler,924.42126,30.769295,-94.375656,Tyler County,county
+iso1:us#iso2:us-tn#fips:47175,47175,47,47,Van Buren,273.42462,35.699234000000004,-85.45841,Van Buren County,county
+iso1:us#iso2:us-ok#fips:40125,40125,40,40,Pottawatomie,787.81836,35.21139,-96.95701,Pottawatomie County,county
+iso1:us#iso2:us-ct#fips:09013,9013,9,9,Tolland,410.3662,41.85808,-72.34098,Tolland County,county
+iso1:us#iso2:us-nm#fips:35053,35053,35,35,Socorro,6646.6123,33.991657000000004,-106.93913,Socorro County,county
+iso1:us#iso2:us-ga#fips:13003,13003,13,13,Atkinson,342.73013,31.296806,-82.87815,Atkinson County,county
+iso1:us#iso2:us-fl#fips:12031,12031,12,12,Duval,762.6553,30.335245,-81.64811,Duval County,county
+iso1:us#iso2:us-tx#fips:48145,48145,48,48,Falls,765.4909700000001,31.251929999999998,-96.93413000000001,Falls County,county
+iso1:us#iso2:us-ar#fips:05149,5149,5,5,Yell,930.1359,34.997715,-93.4083,Yell County,county
+iso1:us#iso2:us-ks#fips:20033,20033,20,20,Comanche,788.3243,37.181442,-99.25129,Comanche County,county
+iso1:us#iso2:us-ky#fips:21113,21113,21,21,Jessamine,172.17096,37.873290000000004,-84.58396,Jessamine County,county
+iso1:us#iso2:us-ky#fips:21171,21171,21,21,Monroe,329.44162,36.714077,-85.71351,Monroe County,county
+iso1:us#iso2:us-ok#fips:40075,40075,40,40,Kiowa,1015.1125,34.921490000000006,-98.98161,Kiowa County,county
+iso1:us#iso2:us-sd#fips:46079,46079,46,46,Lake,562.9105,44.02845,-97.12321999999999,Lake County,county
+iso1:us#iso2:us-nc#fips:37033,37033,37,37,Caswell,425.3812,36.3943,-79.33961,Caswell County,county
+iso1:us#iso2:us-tx#fips:48377,48377,48,48,Presidio,3855.3833,30.005892,-104.26162,Presidio County,county
+iso1:us#iso2:us-oh#fips:39057,39057,39,39,Greene,413.63876,39.687477,-83.8949,Greene County,county
+iso1:us#iso2:us-tx#fips:48489,48489,48,48,Willacy,590.6221,26.481861,-97.594734,Willacy County,county
+iso1:us#iso2:us-pr#fips:72021,72021,72,72,Bayamón Municipio,44.332314000000004,18.350721,-66.16775,Bayamón Municipio,county
+iso1:us#iso2:us-nm#fips:35028,35028,35,35,Los Alamos,109.21016000000002,35.87005,-106.30797,Los Alamos County,county
+iso1:us#iso2:us-ak#fips:02122,2122,2,2,Kenai Peninsula Borough,16023.735,60.360767,-152.05264,Kenai Peninsula Borough,county
+iso1:us#iso2:us-al#fips:01003,1003,1,1,Baldwin,1589.8767,30.659218,-87.74606,Baldwin County,county
+iso1:us#iso2:us-ia#fips:19007,19007,19,19,Appanoose,497.30835,40.744296999999996,-92.87306,Appanoose County,county
+iso1:us#iso2:us-vi#fips:78010,78010,78,78,St. Croix Island,83.36808,17.735321,-64.74674,St. Croix Island,county
+iso1:us#iso2:us-va#fips:51127,51127,51,51,New Kent,210.0429,37.51016,-76.99933,New Kent County,county
+iso1:us#iso2:us-ga#fips:13263,13263,13,13,Talbot,391.39072000000004,32.7046,-84.53003000000001,Talbot County,county
+iso1:us#iso2:us-ny#fips:36049,36049,36,36,Lewis,1274.6852,43.78268,-75.44414,Lewis County,county
+iso1:us#iso2:us-wv#fips:54015,54015,54,54,Clay,341.95038,38.459827000000004,-81.08185999999999,Clay County,county
+iso1:us#iso2:us-in#fips:18077,18077,18,18,Jefferson,360.65157999999997,38.783604,-85.44009,Jefferson County,county
+iso1:us#iso2:us-va#fips:51019,51019,51,51,Bedford,760.1085,37.312256,-79.52722,Bedford County,county
+iso1:us#iso2:us-nm#fips:35033,35033,35,35,Mora,1926.3148,35.98284,-104.9219,Mora County,county
+iso1:us#iso2:us-ne#fips:31011,31011,31,31,Boone,686.5771,41.703934000000004,-98.07047,Boone County,county
+iso1:us#iso2:us-mo#fips:29149,29149,29,29,Oregon,789.82336,36.68531,-91.401825,Oregon County,county
+iso1:us#iso2:us-tn#fips:47083,47083,47,47,Houston,200.30048,36.285779999999995,-87.7056,Houston County,county
+iso1:us#iso2:us-pa#fips:42131,42131,42,42,Wyoming,397.32108,41.525172999999995,-76.00873,Wyoming County,county
+iso1:us#iso2:us-nc#fips:37107,37107,37,37,Lenoir,399.10037,35.240066999999996,-77.63551,Lenoir County,county
+iso1:us#iso2:us-in#fips:18167,18167,18,18,Vigo,403.56412,39.429142,-87.39036999999999,Vigo County,county
+iso1:us#iso2:us-in#fips:18039,18039,18,18,Elkhart,463.18546,41.600693,-85.86398,Elkhart County,county
+iso1:us#iso2:us-va#fips:51077,51077,51,51,Grayson,441.80037999999996,36.652229999999996,-81.215324,Grayson County,county
+iso1:us#iso2:us-tx#fips:48303,48303,48,48,Lubbock,895.6301,33.611470000000004,-101.81995,Lubbock County,county
+iso1:us#iso2:us-mn#fips:27093,27093,27,27,Meeker,608.0903,45.123154,-94.52734,Meeker County,county
+iso1:us#iso2:us-oh#fips:39005,39005,39,39,Ashland,422.97574000000003,40.843272999999996,-82.27013000000001,Ashland County,county
+iso1:us#iso2:us-ne#fips:31119,31119,31,31,Madison,572.64166,41.909929999999996,-97.60686,Madison County,county
+iso1:us#iso2:us-fl#fips:12085,12085,12,12,Martin,543.8383,27.083603000000004,-80.3982,Martin County,county
+iso1:us#iso2:us-co#fips:08079,8079,8,8,Mineral,875.7902,37.54907,-107.003235,Mineral County,county
+iso1:us#iso2:us-ga#fips:13085,13085,13,13,Dawson,210.83527,34.442608,-84.17326,Dawson County,county
+iso1:us#iso2:us-ga#fips:13167,13167,13,13,Johnson,303.02917,32.694584000000006,-82.66396999999999,Johnson County,county
+iso1:us#iso2:us-ar#fips:05095,5095,5,5,Monroe,607.15393,34.679512,-91.20331,Monroe County,county
+iso1:us#iso2:us-mo#fips:29059,29059,29,29,Dallas,540.9697,37.683582,-93.03381,Dallas County,county
+iso1:us#iso2:us-va#fips:51143,51143,51,51,Pittsylvania,969.03577,36.82172,-79.3985,Pittsylvania County,county
+iso1:us#iso2:us-ak#fips:02068,2068,2,2,Denali Borough,12637.391000000001,63.682037,-150.02702,Denali Borough,county
+iso1:us#iso2:us-ks#fips:20145,20145,20,20,Pawnee,754.28845,38.181477,-99.23477,Pawnee County,county
+iso1:us#iso2:us-ks#fips:20209,20209,20,20,Wyandotte,151.64268,39.115383,-94.76308399999999,Wyandotte County,county
+iso1:us#iso2:us-fl#fips:12029,12029,12,12,Dixie,705.1323,29.5809,-83.19566,Dixie County,county
+iso1:us#iso2:us-mi#fips:26157,26157,26,26,Tuscola,804.7283,43.487904,-83.436615,Tuscola County,county
+iso1:us#iso2:us-ak#fips:02240,2240,2,2,Southeast Fairbanks Census Area,24823.629,63.864998,-143.21863000000002,Southeast Fairbanks Census Area,county
+iso1:us#iso2:us-ks#fips:20065,20065,20,20,Graham,898.5574300000001,39.354973,-99.87989,Graham County,county
+iso1:us#iso2:us-la#fips:22097,22097,22,22,St. Landry Parish,923.9441,30.583440000000003,-91.98926999999999,St. Landry Parish,county
+iso1:us#iso2:us-tn#fips:47055,47055,47,47,Giles,610.9521,35.202723999999996,-87.03532,Giles County,county
+iso1:us#iso2:us-oh#fips:39095,39095,39,39,Lucas,339.66672,41.682320000000004,-83.4689,Lucas County,county
+iso1:us#iso2:us-ar#fips:05093,5093,5,5,Mississippi,900.6068,35.766945,-90.05221,Mississippi County,county
+iso1:us#iso2:us-pr#fips:72117,72117,72,72,Rincón Municipio,14.288375,18.34056,-67.2773,Rincón Municipio,county
+iso1:us#iso2:us-in#fips:18043,18043,18,18,Floyd,147.96999,38.31808,-85.91185,Floyd County,county
+iso1:us#iso2:us-ks#fips:20129,20129,20,20,Morton,729.7554299999999,37.18525,-101.80951999999999,Morton County,county
+iso1:us#iso2:us-ky#fips:21081,21081,21,21,Grant,257.9859,38.649165999999994,-84.62592,Grant County,county
+iso1:us#iso2:us-ky#fips:21217,21217,21,21,Taylor,266.37775,37.366209999999995,-85.32806,Taylor County,county
+iso1:us#iso2:us-nc#fips:37075,37075,37,37,Graham,291.97614,35.348366,-83.83091999999999,Graham County,county
+iso1:us#iso2:us-wv#fips:54045,54045,54,54,Logan,453.78545999999994,37.83059,-81.94085,Logan County,county
+iso1:us#iso2:us-wv#fips:54073,54073,54,54,Pleasants,130.12378,39.368134000000005,-81.16117,Pleasants County,county
+iso1:us#iso2:us-va#fips:51071,51071,51,51,Giles,357.2359,37.318073,-80.69832,Giles County,county
+iso1:us#iso2:us-wv#fips:54019,54019,54,54,Fayette,661.6353,38.030933000000005,-81.08605,Fayette County,county
+iso1:us#iso2:us-wa#fips:53061,53061,53,53,Snohomish,2086.595,48.070465000000006,-121.93678,Snohomish County,county
+iso1:us#iso2:us-nm#fips:35015,35015,35,35,Eddy,4176.487,32.457836,-104.306435,Eddy County,county
+iso1:us#iso2:us-ne#fips:31117,31117,31,31,McPherson,859.00366,41.648415,-101.12085,McPherson County,county
+iso1:us#iso2:us-ne#fips:31145,31145,31,31,Red Willow,717.03015,40.16942,-100.468575,Red Willow County,county
+iso1:us#iso2:us-ne#fips:31149,31149,31,31,Rock,1008.327,42.39475,-99.42085,Rock County,county
+iso1:us#iso2:us-tn#fips:47085,47085,47,47,Humphreys,530.7806400000001,36.040820000000004,-87.79045,Humphreys County,county
+iso1:us#iso2:us-il#fips:17125,17125,17,17,Mason,539.3702,40.236990000000006,-89.913574,Mason County,county
+iso1:us#iso2:us-va#fips:51197,51197,51,51,Wythe,461.93976,36.899868,-81.083,Wythe County,county
+iso1:us#iso2:us-ga#fips:13303,13303,13,13,Washington,678.53656,32.971844,-82.79811,Washington County,county
+iso1:us#iso2:us-wa#fips:53077,53077,53,53,Yakima,4294.6577,46.456559999999996,-120.74014,Yakima County,county
+iso1:us#iso2:us-ar#fips:05143,5143,5,5,Washington,942.00916,35.978,-94.21727,Washington County,county
+iso1:us#iso2:us-tx#fips:48213,48213,48,48,Henderson,873.7841,32.21163,-95.85342,Henderson County,county
+iso1:us#iso2:us-wi#fips:55035,55035,55,55,Eau Claire,637.94403,44.726357,-91.286415,Eau Claire County,county
+iso1:us#iso2:us-tn#fips:47153,47153,47,47,Sequatchie,265.86002,35.372337,-85.41008000000001,Sequatchie County,county
+iso1:us#iso2:us-tx#fips:48471,48471,48,48,Walker,784.2484,30.743161999999998,-95.569824,Walker County,county
+iso1:us#iso2:us-az#fips:04005,4005,4,4,Coconino,18617.416,35.829693,-111.77373,Coconino County,county
+iso1:us#iso2:us-ks#fips:20191,20191,20,20,Sumner,1181.6951,37.23666,-97.49335500000001,Sumner County,county
+iso1:us#iso2:us-mi#fips:26127,26127,26,26,Oceana,538.11646,43.647255,-86.80757,Oceana County,county
+iso1:us#iso2:us-mn#fips:27065,27065,27,27,Kanabec,521.6418,45.947759999999995,-93.29779,Kanabec County,county
+iso1:us#iso2:us-oh#fips:39007,39007,39,39,Ashtabula,702.0966,41.906634999999994,-80.74559,Ashtabula County,county
+iso1:us#iso2:us-ca#fips:06003,6003,6,6,Alpine,738.3654,38.621784000000005,-119.798355,Alpine County,county
+iso1:us#iso2:us-tx#fips:48167,48167,48,48,Galveston,378.91412,29.233454,-94.88846,Galveston County,county
+iso1:us#iso2:us-al#fips:01011,1011,1,1,Bullock,622.8333,32.101757,-85.71726,Bullock County,county
+iso1:us#iso2:us-il#fips:17105,17105,17,17,Livingston,1043.6635,40.894375,-88.55285,Livingston County,county
+iso1:us#iso2:us-oh#fips:39135,39135,39,39,Preble,424.24078,39.73881,-84.64475999999999,Preble County,county
+iso1:us#iso2:us-oh#fips:39079,39079,39,39,Jackson,420.3247,39.013477,-82.61414,Jackson County,county
+iso1:us#iso2:us-tx#fips:48201,48201,48,48,Harris,1706.2086,29.857273,-95.393036,Harris County,county
+iso1:us#iso2:us-ma#fips:25017,25017,25,25,Middlesex,817.87933,42.48172,-71.39491,Middlesex County,county
+iso1:us#iso2:us-pr#fips:72145,72145,72,72,Vega Baja Municipio,45.84929,18.455128,-66.39788,Vega Baja Municipio,county
+iso1:us#iso2:us-tx#fips:48115,48115,48,48,Dawson,900.33655,32.742527,-101.94877,Dawson County,county
+iso1:us#iso2:us-ny#fips:36069,36069,36,36,Ontario,644.0716,42.856358,-77.3035,Ontario County,county
+iso1:us#iso2:us-ak#fips:02261,2261,2,2,Valdez-Cordova Census Area,34223.023,61.349842,-145.0231,Valdez-Cordova Census Area,county
+iso1:us#iso2:us-al#fips:01001,1001,1,1,Autauga,594.4639,32.532238,-86.64644,Autauga County,county
+iso1:us#iso2:us-ks#fips:20121,20121,20,20,Miami,575.8983,38.566772,-94.83296,Miami County,county
+iso1:us#iso2:us-ga#fips:13091,13091,13,13,Dodge,495.97335999999996,32.164367999999996,-83.16787,Dodge County,county
+iso1:us#iso2:us-ny#fips:36023,36023,36,36,Cortland,498.78983,42.59404,-76.07624,Cortland County,county
+iso1:us#iso2:us-ga#fips:13039,13039,13,13,Camden,630.3380000000001,30.913359000000003,-81.64202,Camden County,county
+iso1:us#iso2:us-mi#fips:26161,26161,26,26,Washtenaw,705.9876,42.252216,-83.84342,Washtenaw County,county
+iso1:us#iso2:us-in#fips:18087,18087,18,18,LaGrange,379.64258,41.642464000000004,-85.42784,LaGrange County,county
+iso1:us#iso2:us-tx#fips:48371,48371,48,48,Pecos,4763.9966,30.773297999999997,-102.71815500000001,Pecos County,county
+iso1:us#iso2:us-ga#fips:13225,13225,13,13,Peach,150.28949,32.571323,-83.83198,Peach County,county
+iso1:us#iso2:us-ga#fips:13311,13311,13,13,White,240.75153999999998,34.643776,-83.743416,White County,county
+iso1:us#iso2:us-ga#fips:13163,13163,13,13,Jefferson,526.56885,33.058174,-82.420006,Jefferson County,county
+iso1:us#iso2:us-wi#fips:55083,55083,55,55,Oconto,997.5151,44.996574,-88.20651,Oconto County,county
+iso1:us#iso2:us-tx#fips:48347,48347,48,48,Nacogdoches,946.5896,31.620559999999998,-94.62025,Nacogdoches County,county
+iso1:us#iso2:us-ri#fips:44009,44009,44,44,Washington,329.28976,41.396793,-71.620285,Washington County,county
+iso1:us#iso2:us-wa#fips:53047,53047,53,53,Okanogan,5266.3667,48.548454,-119.74223,Okanogan County,county
+iso1:us#iso2:us-wa#fips:53063,53063,53,53,Spokane,1763.9539,47.620377000000005,-117.40337,Spokane County,county
+iso1:us#iso2:us-wi#fips:55041,55041,55,55,Forest,1014.27795,45.66688,-88.77332,Forest County,county
+iso1:us#iso2:us-wi#fips:55113,55113,55,55,Sawyer,1257.6686,45.864914,-91.14713,Sawyer County,county
+iso1:us#iso2:us-nj#fips:34017,34017,34,34,Hudson,46.195156,40.731377,-74.0786,Hudson County,county
+iso1:us#iso2:us-oh#fips:39151,39151,39,39,Stark,575.3337,40.814133,-81.36567,Stark County,county
+iso1:us#iso2:us-tx#fips:48187,48187,48,48,Guadalupe,711.2769,29.583532,-97.94677,Guadalupe County,county
+iso1:us#iso2:us-wa#fips:53029,53029,53,53,Island,208.51918,48.158553999999995,-122.67065,Island County,county
+iso1:us#iso2:us-wv#fips:54037,54037,54,54,Jefferson,209.30268999999998,39.3074,-77.86322,Jefferson County,county
+iso1:us#iso2:us-va#fips:51153,51153,51,51,Prince William,335.75607,38.70112,-77.479576,Prince William County,county
+iso1:us#iso2:us-pa#fips:42029,42029,42,42,Chester,750.5543,39.97403,-75.74975,Chester County,county
+iso1:us#iso2:us-wv#fips:54055,54055,54,54,Mercer,418.97604,37.403446,-81.10645,Mercer County,county
+iso1:us#iso2:us-tn#fips:47145,47145,47,47,Roane,360.76987,35.84725,-84.523926,Roane County,county
+iso1:us#iso2:us-wa#fips:53009,53009,53,53,Clallam,1738.7423,48.110904999999995,-123.88986000000001,Clallam County,county
+iso1:us#iso2:us-wa#fips:53065,53065,53,53,Stevens,2477.4795,48.388725,-117.854454,Stevens County,county
+iso1:us#iso2:us-ia#fips:19177,19177,19,19,Van Buren,484.82425,40.754115999999996,-91.95294,Van Buren County,county
+iso1:us#iso2:us-ne#fips:31073,31073,31,31,Gosper,458.1707,40.509094,-99.823204,Gosper County,county
+iso1:us#iso2:us-ms#fips:28095,28095,28,28,Monroe,765.11456,33.890029999999996,-88.48504,Monroe County,county
+iso1:us#iso2:us-fl#fips:12033,12033,12,12,Escambia,656.9956,30.611639,-87.3389,Escambia County,county
+iso1:us#iso2:us-tx#fips:48439,48439,48,48,Tarrant,863.6872599999999,32.772118,-97.29122,Tarrant County,county
+iso1:us#iso2:us-md#fips:24033,24033,24,24,Prince George's,482.66815,38.82929,-76.84818,Prince George's County,county
+iso1:us#iso2:us-va#fips:51169,51169,51,51,Scott,535.8455,36.712776,-82.613625,Scott County,county
+iso1:us#iso2:us-tx#fips:48239,48239,48,48,Jackson,829.4709,28.959803000000004,-96.58908000000001,Jackson County,county
+iso1:us#iso2:us-ok#fips:40085,40085,40,40,Love,513.9291,33.957806,-97.245094,Love County,county
+iso1:us#iso2:us-ga#fips:13289,13289,13,13,Twiggs,359.27182,32.665848,-83.42588,Twiggs County,county
+iso1:us#iso2:us-oh#fips:39099,39099,39,39,Mahoning,411.51132,41.01088,-80.77039,Mahoning County,county
+iso1:us#iso2:us-al#fips:01087,1087,1,1,Macon,608.8481,32.387028,-85.69289,Macon County,county
+iso1:us#iso2:us-il#fips:17191,17191,17,17,Wayne,713.8539400000001,38.431858,-88.43243000000001,Wayne County,county
+iso1:us#iso2:us-tx#fips:48437,48437,48,48,Swisher,890.1899,34.526317999999996,-101.743866,Swisher County,county
+iso1:us#iso2:us-mo#fips:29151,29151,29,29,Osage,606.6004,38.464252,-91.859505,Osage County,county
+iso1:us#iso2:us-il#fips:17089,17089,17,17,Kane,519.37756,41.939594,-88.42804,Kane County,county
+iso1:us#iso2:us-ca#fips:06017,6017,6,6,El Dorado,1707.9036,38.78561,-120.534225,El Dorado County,county
+iso1:us#iso2:us-sc#fips:45055,45055,45,45,Kershaw,726.6365,34.338356,-80.59088,Kershaw County,county
+iso1:us#iso2:us-nc#fips:37073,37073,37,37,Gates,340.62384,36.442135,-76.702354,Gates County,county
+iso1:us#iso2:us-co#fips:08089,8089,8,8,Otero,1261.9886,37.884170000000005,-103.72126,Otero County,county
+iso1:us#iso2:us-or#fips:41019,41019,41,41,Douglas,5035.8413,43.286327,-123.15446999999999,Douglas County,county
+iso1:us#iso2:us-pa#fips:42089,42089,42,42,Monroe,608.2781,41.05624,-75.32906,Monroe County,county
+iso1:us#iso2:us-ar#fips:05101,5101,5,5,Newton,820.9323,35.910744,-93.2159,Newton County,county
+iso1:us#iso2:us-nd#fips:38019,38019,38,38,Cavalier,1489.1042,48.768440000000005,-98.46379,Cavalier County,county
+iso1:us#iso2:us-ok#fips:40103,40103,40,40,Noble,731.9435,36.3849,-97.236336,Noble County,county
+iso1:us#iso2:us-ks#fips:20063,20063,20,20,Gove,1071.7024,38.91724,-100.48736,Gove County,county
+iso1:us#iso2:us-la#fips:22077,22077,22,22,Pointe Coupee Parish,557.23816,30.708319,-91.60462,Pointe Coupee Parish,county
+iso1:us#iso2:us-ne#fips:31067,31067,31,31,Gage,851.4905,40.255234,-96.68346,Gage County,county
+iso1:us#iso2:us-al#fips:01115,1115,1,1,St. Clair,631.6023,33.712963,-86.31567,St. Clair County,county
+iso1:us#iso2:us-ms#fips:28123,28123,28,28,Scott,609.25214,32.41196,-89.533485,Scott County,county
+iso1:us#iso2:us-ga#fips:13095,13095,13,13,Dougherty,328.65497,31.532587,-84.20904,Dougherty County,county
+iso1:us#iso2:us-in#fips:18061,18061,18,18,Harrison,484.532,38.186455,-86.10377,Harrison County,county
+iso1:us#iso2:us-id#fips:16017,16017,16,16,Bonner,1733.2932,48.316795,-116.612366,Bonner County,county
+iso1:us#iso2:us-ga#fips:13047,13047,13,13,Catoosa,162.16798,34.900220000000004,-85.13939,Catoosa County,county
+iso1:us#iso2:us-la#fips:22059,22059,22,22,LaSalle Parish,624.70575,31.680082000000002,-92.1616,LaSalle Parish,county
+iso1:us#iso2:us-me#fips:23027,23027,23,23,Waldo,729.9955,44.505833,-69.138954,Waldo County,county
+iso1:us#iso2:us-md#fips:24027,24027,24,24,Howard,250.95647000000002,39.252262,-76.92441,Howard County,county
+iso1:us#iso2:us-ut#fips:49035,49035,49,49,Salt Lake,742.0918,40.66788,-111.92424,Salt Lake County,county
+iso1:us#iso2:us-ct#fips:09003,9003,9,9,Hartford,734.9874,41.806053000000006,-72.73292,Hartford County,county
+iso1:us#iso2:us-ct#fips:09015,9015,9,9,Windham,512.9458599999999,41.824996999999996,-71.9907,Windham County,county
+iso1:us#iso2:us-fl#fips:12087,12087,12,12,Monroe,983.06287,24.768883,-80.95326999999999,Monroe County,county
+iso1:us#iso2:us-oh#fips:39157,39157,39,39,Tuscarawas,567.45105,40.44749,-81.47111,Tuscarawas County,county
+iso1:us#iso2:us-ny:#fips:36085,36085,36,36,Richmond,57.522255,40.561264,-74.1399,Richmond County,county
+iso1:us#iso2:us-oh#fips:39071,39071,39,39,Highland,553.1024,39.18442,-83.60136,Highland County,county
+iso1:us#iso2:us-mn#fips:27077,27077,27,27,Lake of the Woods,1297.8761,48.7681,-94.90463000000001,Lake of the Woods County,county
+iso1:us#iso2:us-id#fips:16011,16011,16,16,Bingham,2093.8638,43.216359999999995,-112.39921000000001,Bingham County,county
+iso1:us#iso2:us-pr#fips:72023,72023,72,72,Cabo Rojo Municipio,70.36865,18.008873,-67.209885,Cabo Rojo Municipio,county
+iso1:us#iso2:us-pr#fips:72069,72069,72,72,Humacao Municipio,44.719162,18.135403,-65.78623,Humacao Municipio,county
+iso1:us#iso2:us-pr#fips:72077,72077,72,72,Juncos Municipio,26.4896,18.224133,-65.90854,Juncos Municipio,county
+iso1:us#iso2:us-sc#fips:45045,45045,45,45,Greenville,785.1582,34.892647,-82.37208000000001,Greenville County,county
+iso1:us#iso2:us-sd#fips:46085,46085,46,46,Lyman,1642.2024,43.894814000000004,-99.84193,Lyman County,county
+iso1:us#iso2:us-wi#fips:55121,55121,55,55,Trempealeau,733.02936,44.30305,-91.358864,Trempealeau County,county
+iso1:us#iso2:us-ca#fips:06113,6113,6,6,Yolo,1014.7669,38.679596000000004,-121.90243999999998,Yolo County,county
+iso1:us#iso2:us-tx#fips:48431,48431,48,48,Sterling,923.4807,31.835773,-101.05490999999999,Sterling County,county
+iso1:us#iso2:us-tx#fips:48495,48495,48,48,Winkler,841.2974,31.832859999999997,-103.054924,Winkler County,county
+iso1:us#iso2:us-sd#fips:46071,46071,46,46,Jackson,1863.9459,43.677505,-101.62631999999999,Jackson County,county
+iso1:us#iso2:us-ut#fips:49041,49041,49,49,Sevier,1910.4985,38.746826,-111.81193,Sevier County,county
+iso1:us#iso2:us-va#fips:51036,51036,51,51,Charles City,182.90726999999998,37.361053000000005,-77.05417,Charles City County,county
+iso1:us#iso2:us-al#fips:01023,1023,1,1,Choctaw,913.49854,31.990953,-88.248886,Choctaw County,county
+iso1:us#iso2:us-in#fips:18083,18083,18,18,Knox,516.0378400000001,38.688393,-87.42036,Knox County,county
+iso1:us#iso2:us-ne#fips:31047,31047,31,31,Dawson,1013.123,40.86738,-99.815155,Dawson County,county
+iso1:us#iso2:us-ks#fips:20057,20057,20,20,Ford,1098.3081,37.688416,-99.88475,Ford County,county
+iso1:us#iso2:us-nd#fips:38105,38105,38,38,Williams,2077.667,48.355765999999996,-103.501335,Williams County,county
+iso1:us#iso2:us-nd#fips:38017,38017,38,38,Cass,1764.9944,46.927002,-97.25237,Cass County,county
+iso1:us#iso2:us-il#fips:17069,17069,17,17,Hardin,177.39491,37.517853,-88.26615,Hardin County,county
+iso1:us#iso2:us-ne#fips:31005,31005,31,31,Arthur,715.37885,41.57193,-101.695915,Arthur County,county
+iso1:us#iso2:us-tx#fips:48163,48163,48,48,Frio,1133.5393,28.869334999999996,-99.10879,Frio County,county
+iso1:us#iso2:us-ia#fips:19103,19103,19,19,Johnson,613.0121,41.67067,-91.59053,Johnson County,county
+iso1:us#iso2:us-ks#fips:20133,20133,20,20,Neosho,571.50073,37.56428,-95.31568,Neosho County,county
+iso1:us#iso2:us-ky#fips:21089,21089,21,21,Greenup,344.47402999999997,38.563559999999995,-82.93382,Greenup County,county
+iso1:us#iso2:us-ks#fips:20107,20107,20,20,Linn,594.1012,38.21655,-94.84493,Linn County,county
+iso1:us#iso2:us-ut#fips:49017,49017,49,49,Garfield,5175.3240000000005,37.831665,-111.450905,Garfield County,county
+iso1:us#iso2:us-nv#fips:32011,32011,32,32,Eureka,4175.83,39.977787,-116.27221000000002,Eureka County,county
+iso1:us#iso2:us-ne#fips:31085,31085,31,31,Hayes,713.08606,40.537234999999995,-101.047966,Hayes County,county
+iso1:us#iso2:us-co#fips:08095,8095,8,8,Phillips,687.95123,40.59471,-102.34510999999999,Phillips County,county
+iso1:us#iso2:us-ar#fips:05013,5013,5,5,Calhoun,628.5862,33.56046,-92.51388,Calhoun County,county
+iso1:us#iso2:us-ak#fips:02090,2090,2,2,Fairbanks North Star Borough,7329.8369999999995,64.67604,-146.54816,Fairbanks North Star Borough,county
+iso1:us#iso2:us-ky#fips:21101,21101,21,21,Henderson,436.5071,37.79254,-87.57258,Henderson County,county
+iso1:us#iso2:us-ms#fips:28051,28051,28,28,Holmes,756.6998,33.125941999999995,-90.09119399999999,Holmes County,county
+iso1:us#iso2:us-ms#fips:28105,28105,28,28,Oktibbeha,458.25487999999996,33.422314,-88.87615,Oktibbeha County,county
+iso1:us#iso2:us-pr#fips:72037,72037,72,72,Ceiba Municipio,29.036507,18.273748,-65.53089,Ceiba Municipio,county
+iso1:us#iso2:us-pr#fips:72047,72047,72,72,Corozal Municipio,42.568645000000004,18.303910000000002,-66.32618000000001,Corozal Municipio,county
+iso1:us#iso2:us-mt#fips:30027,30027,30,30,Fergus,4339.477,47.22522,-109.23213999999999,Fergus County,county
+iso1:us#iso2:us-md#fips:24023,24023,24,24,Garrett,649.09937,39.5473,-79.27462,Garrett County,county
+iso1:us#iso2:us-la#fips:22119,22119,22,22,Webster Parish,593.20325,32.73215,-93.33981999999999,Webster Parish,county
+iso1:us#iso2:us-mi#fips:26059,26059,26,26,Hillsdale,598.17255,41.927459999999996,-84.63748000000001,Hillsdale County,county
+iso1:us#iso2:us-ky#fips:21141,21141,21,21,Logan,552.2314,36.859608,-86.88129,Logan County,county
+iso1:us#iso2:us-sd#fips:46033,46033,46,46,Custer,1556.9998,43.684944,-103.46225,Custer County,county
+iso1:us#iso2:us-nh#fips:33013,33013,33,33,Merrimack,932.91364,43.29958,-71.68004,Merrimack County,county
+iso1:us#iso2:us-pa#fips:42133,42133,42,42,York,904.3978,39.921753,-76.72889,York County,county
+iso1:us#iso2:us-nc#fips:37161,37161,37,37,Rutherford,565.4566,35.40275,-81.919586,Rutherford County,county
+iso1:us#iso2:us-sd#fips:46005,46005,46,46,Beadle,1258.7516,44.418265999999996,-98.27942,Beadle County,county
+iso1:us#iso2:us-al#fips:01043,1043,1,1,Cullman,734.7661,34.131924,-86.86927,Cullman County,county
+iso1:us#iso2:us-ga#fips:13097,13097,13,13,Douglas,200.1448,33.701240000000006,-84.76731,Douglas County,county
+iso1:us#iso2:us-ne#fips:31097,31097,31,31,Johnson,376.0853,40.395008000000004,-96.265366,Johnson County,county
+iso1:us#iso2:us-nc#fips:37187,37187,37,37,Washington,346.52158,35.84471,-76.57229,Washington County,county
+iso1:us#iso2:us-sd#fips:46075,46075,46,46,Jones,969.7049,43.951992,-100.68614000000001,Jones County,county
+iso1:us#iso2:us-nc#fips:37007,37007,37,37,Anson,531.47925,34.97497,-80.109764,Anson County,county
+iso1:us#iso2:us-ak#fips:02100,2100,2,2,Haines Borough,2344.607,59.098404,-135.57578999999998,Haines Borough,county
+iso1:us#iso2:us-nd#fips:38007,38007,38,38,Billings,1148.5275,47.007046,-103.36401,Billings County,county
+iso1:us#iso2:us-ne#fips:31003,31003,31,31,Antelope,857.18585,42.183223999999996,-98.05804,Antelope County,county
+iso1:us#iso2:us-mo#fips:29073,29073,29,29,Gasconade,519.0224599999999,38.441179999999996,-91.50578,Gasconade County,county
+iso1:us#iso2:us-ky#fips:21031,21031,21,21,Butler,426.10602,37.207012,-86.68247,Butler County,county
+iso1:us#iso2:us-vi#fips:780120,78020,78,78,St. John Island,19.691292,18.330435,-64.73526,St. John Island,county
+iso1:us#iso2:us-wy#fips:56005,56005,56,56,Campbell,4802.2285,44.192,-105.51701000000001,Campbell County,county
+iso1:us#iso2:us-ga#fips:13211,13211,13,13,Morgan,347.4152,33.598694,-83.49943499999999,Morgan County,county
+iso1:us#iso2:us-ar#fips:05037,5037,5,5,Cross,616.4029,35.28569,-90.76398499999999,Cross County,county
+iso1:us#iso2:us-ar#fips:05107,5107,5,5,Phillips,695.65204,34.423687,-90.85559,Phillips County,county
+iso1:us#iso2:us-la#fips:22093,22093,22,22,St. James Parish,242.84956,30.024776,-90.79395,St. James Parish,county
+iso1:us#iso2:us-ca#fips:06115,6115,6,6,Yuba,632.0375,39.27013,-121.34426,Yuba County,county
+iso1:us#iso2:us-al#fips:01117,1117,1,1,Shelby,785.4106,33.263042,-86.67809,Shelby County,county
+iso1:us#iso2:us-co#fips:08091,8091,8,8,Ouray,541.6114,38.15473,-107.78848,Ouray County,county
+iso1:us#iso2:us-nm#fips:35009,35009,35,35,Curry,1405.5607,34.572983,-103.34605400000001,Curry County,county
+iso1:us#iso2:us-ok#fips:40149,40149,40,40,Washita,1003.12354,35.289497,-98.99143000000001,Washita County,county
+iso1:us#iso2:us-nc#fips:37135,37135,37,37,Orange,397.57245,36.062527,-79.12003,Orange County,county
+iso1:us#iso2:us-in#fips:18131,18131,18,18,Pulaski,433.68964000000005,41.045273,-86.69253499999999,Pulaski County,county
+iso1:us#iso2:us-mi#fips:26019,26019,26,26,Benzie,319.70905,44.64862,-86.49432,Benzie County,county
+iso1:us#iso2:us-ny#fips:36029,36029,36,36,Erie,1042.7617,42.752758,-78.77819000000001,Erie County,county
+iso1:us#iso2:us-md#fips:24031,24031,24,24,Montgomery,493.0797,39.137383,-77.203064,Montgomery County,county
+iso1:us#iso2:us-va#fips:51685,51685,51,51,Manassas Park city,2.5246994,38.768944,-77.44877,Manassas Park city,county
+iso1:us#iso2:us-va#fips:51013,51013,51,51,Arlington,25.998297,38.878338,-77.1007,Arlington County,county
+iso1:us#iso2:us-va#fips:51035,51035,51,51,Carroll,474.76055999999994,36.731964000000005,-80.72783000000001,Carroll County,county
+iso1:us#iso2:us-mo#fips:29183,29183,29,29,St. Charles,560.53076,38.7811,-90.67491,St. Charles County,county
+iso1:us#iso2:us-ca#fips:06069,6069,6,6,San Benito,1388.6989,36.611652,-121.08581000000001,San Benito County,county
+iso1:us#iso2:us-md#fips:24035,24035,24,24,Queen Anne's,371.70285,39.040690000000005,-76.08240500000001,Queen Anne's County,county
+iso1:us#iso2:us-ks#fips:20013,20013,20,20,Brown,570.8908,39.82593,-95.56991,Brown County,county
+iso1:us#iso2:us-ga#fips:13031,13031,13,13,Bulloch,675.97406,32.391712,-81.74401999999999,Bulloch County,county
+iso1:us#iso2:us-ky#fips:21071,21071,21,21,Floyd,393.29556,37.552456,-82.73971999999999,Floyd County,county
+iso1:us#iso2:us-mt#fips:30007,30007,30,30,Broadwater,1192.3997,46.32985,-111.49786999999999,Broadwater County,county
+iso1:us#iso2:us-ga#fips:13309,13309,13,13,Wheeler,295.4996,32.105259999999994,-82.73385,Wheeler County,county
+iso1:us#iso2:us-nc#fips:37049,37049,37,37,Craven,706.5966,35.11683,-77.08131999999999,Craven County,county
+iso1:us#iso2:us-mo#fips:29087,29087,29,29,Holt,462.70883,40.095721999999995,-95.21907,Holt County,county
+iso1:us#iso2:us-tx#fips:48295,48295,48,48,Lipscomb,932.2455,36.2802,-100.27268000000001,Lipscomb County,county
+iso1:us#iso2:us-or#fips:41009,41009,41,41,Columbia,658.1368,45.941933,-123.08108,Columbia County,county
+iso1:us#iso2:us-sc#fips:45041,45041,45,45,Florence,800.5376,34.028534,-79.710236,Florence County,county
+iso1:us#iso2:us-nd#fips:38061,38061,38,38,Mountrail,1825.3207,48.21007,-102.3649,Mountrail County,county
+iso1:us#iso2:us-ut#fips:49053,49053,49,49,Washington,2427.5212,37.26253,-113.4878,Washington County,county
+iso1:us#iso2:us-mt#fips:30003,30003,30,30,Big Horn,4997.9844,45.407866999999996,-107.518166,Big Horn County,county
+iso1:us#iso2:us-pa#fips:42047,42047,42,42,Elk,827.4001,41.42733,-78.65394,Elk County,county
+iso1:us#iso2:us-ne#fips:31165,31165,31,31,Sioux,2066.769,42.47067,-103.73217,Sioux County,county
+iso1:us#iso2:us-ms#fips:28031,28031,28,28,Covington,413.83255,31.633331,-89.5489,Covington County,county
+iso1:us#iso2:us-pr#fips:72099,72099,72,72,Moca Municipio,50.343090000000004,18.377638,-67.079575,Moca Municipio,county
+iso1:us#iso2:us-in#fips:18013,18013,18,18,Brown,311.99807999999996,39.195114000000004,-86.23012,Brown County,county
+iso1:us#iso2:us-in#fips:18019,18019,18,18,Clark,372.85065,38.47622,-85.71112,Clark County,county
+iso1:us#iso2:us-ky#fips:21021,21021,21,21,Boyle,180.35605,37.618103000000005,-84.86835500000001,Boyle County,county
+iso1:us#iso2:us-ky#fips:21065,21065,21,21,Estill,253.10242000000002,37.692448,-83.96398,Estill County,county
+iso1:us#iso2:us-tx#fips:48087,48087,48,48,Collingsworth,918.4717400000001,34.963356,-100.27213,Collingsworth County,county
+iso1:us#iso2:us-tx#fips:48089,48089,48,48,Colorado,960.3189,29.596296000000002,-96.508934,Colorado County,county
+iso1:us#iso2:us-il#fips:17063,17063,17,17,Grundy,418.1399,41.292408,-88.401054,Grundy County,county
+iso1:us#iso2:us-mn#fips:27081,27081,27,27,Lincoln,536.7998,44.408237,-96.27203,Lincoln County,county
+iso1:us#iso2:us-ga#fips:13109,13109,13,13,Evans,182.90085,32.153084,-81.89015,Evans County,county
+iso1:us#iso2:us-tx#fips:48497,48497,48,48,Wise,904.4245,33.219093,-97.654,Wise County,county
+iso1:us#iso2:us-ak#fips:02050,2050,2,2,Bethel Census Area,40632.0,60.929142000000006,-160.15261999999998,Bethel Census Area,county
+iso1:us#iso2:us-ga#fips:13307,13307,13,13,Webster,209.36368000000002,32.046690000000005,-84.553825,Webster County,county
+iso1:us#iso2:us-ga#fips:13169,13169,13,13,Jones,393.95505,33.021664,-83.56219499999999,Jones County,county
+iso1:us#iso2:us-ga#fips:13135,13135,13,13,Gwinnett,430.6377,33.959145,-84.02309,Gwinnett County,county
+iso1:us#iso2:us-wi#fips:55095,55095,55,55,Polk,914.3510000000001,45.46204,-92.44707,Polk County,county
+iso1:us#iso2:us-wi#fips:55045,55045,55,55,Green,584.0639,42.67552,-89.60507,Green County,county
+iso1:us#iso2:us-pr#fips:72107,72107,72,72,Orocovis Municipio,63.627304,18.218733,-66.4369,Orocovis Municipio,county
+iso1:us#iso2:us-ny#fips:36079,36079,36,36,Putnam,230.33437,41.427906,-73.74386,Putnam County,county
+iso1:us#iso2:us-va#fips:51700,51700,51,51,Newport News city,68.99455999999999,37.076138,-76.52198,Newport News city,county
+iso1:us#iso2:us-co#fips:08011,8011,8,8,Bent,1512.8982,37.931892,-103.07758000000001,Bent County,county
+iso1:us#iso2:us-ok#fips:40065,40065,40,40,Jackson,802.6798,34.594006,-99.41223000000001,Jackson County,county
+iso1:us#iso2:us-mt#fips:30089,30089,30,30,Sanders,2760.4946,47.756496000000006,-115.180305,Sanders County,county
+iso1:us#iso2:us-tx#fips:48173,48173,48,48,Glasscock,900.2483,31.868006,-101.52149,Glasscock County,county
+iso1:us#iso2:us-ar#fips:05047,5047,5,5,Franklin,608.86896,35.508556,-93.887665,Franklin County,county
+iso1:us#iso2:us-ok#fips:40093,40093,40,40,Major,955.0325,36.313117999999996,-98.542015,Major County,county
+iso1:us#iso2:us-tn#fips:47125,47125,47,47,Montgomery,539.1832,36.500355,-87.38089000000001,Montgomery County,county
+iso1:us#iso2:us-wa#fips:53051,53051,53,53,Pend Oreille,1400.3063,48.543822999999996,-117.23218999999999,Pend Oreille County,county
+iso1:us#iso2:us-nd#fips:38055,38055,38,38,McLean,2110.331,47.53046,-101.35309000000001,McLean County,county
+iso1:us#iso2:us-or#fips:41027,41027,41,41,Hood River,522.10645,45.511776,-121.655975,Hood River County,county
+iso1:us#iso2:us-ia#fips:19197,19197,19,19,Wright,580.4351,42.733006,-93.73473,Wright County,county
+iso1:us#iso2:us-tx#fips:48419,48419,48,48,Shelby,795.6161,31.79014,-94.14258000000001,Shelby County,county
+iso1:us#iso2:us-mo#fips:29055,29055,29,29,Crawford,742.502,37.96656,-91.313934,Crawford County,county
+iso1:us#iso2:us-va#fips:51017,51017,51,51,Bath,529.2196700000001,38.068366999999995,-79.7312,Bath County,county
+iso1:us#iso2:us-mn#fips:27111,27111,27,27,Otter Tail,1971.9241,46.405727,-95.714584,Otter Tail County,county
+iso1:us#iso2:us-la#fips:22075,22075,22,22,Plaquemines Parish,780.3203,29.282448,-89.576065,Plaquemines Parish,county
+iso1:us#iso2:us-ms#fips:28115,28115,28,28,Pontotoc,497.78045999999995,34.22708,-89.03724,Pontotoc County,county
+iso1:us#iso2:us-la#fips:22067,22067,22,22,Morehouse Parish,794.9574,32.820007000000004,-91.8004,Morehouse Parish,county
+iso1:us#iso2:us-ky#fips:21029,21029,21,21,Bullitt,297.0411,37.969944,-85.70264,Bullitt County,county
+iso1:us#iso2:us-al#fips:01047,1047,1,1,Dallas,978.77124,32.333538,-87.11435999999999,Dallas County,county
+iso1:us#iso2:us-tx#fips:48093,48093,48,48,Comanche,937.78485,31.951645000000003,-98.549614,Comanche County,county
+iso1:us#iso2:us-mt#fips:30053,30053,30,30,Lincoln,3612.6582,48.552383,-115.46319,Lincoln County,county
+iso1:us#iso2:us-pr#fips:72129,72129,72,72,San Lorenzo Municipio,53.109375,18.147108,-65.976166,San Lorenzo Municipio,county
+iso1:us#iso2:us-pr#fips:72135,72135,72,72,Toa Alta Municipio,27.017483000000002,18.364555,-66.24467,Toa Alta Municipio,county
+iso1:us#iso2:us-mn#fips:27021,27021,27,27,Cass,2021.5422,46.951744,-94.3337,Cass County,county
+iso1:us#iso2:us-co#fips:08007,8007,8,8,Archuleta,1350.134,37.202396,-107.05086499999999,Archuleta County,county
+iso1:us#iso2:us-ms#fips:28163,28163,28,28,Yazoo,922.37054,32.765675,-90.38793000000001,Yazoo County,county
+iso1:us#iso2:us-wi#fips:55087,55087,55,55,Outagamie,637.60004,44.418224,-88.46499,Outagamie County,county
+iso1:us#iso2:us-mo#fips:29107,29107,29,29,Lafayette,628.4571,39.068707,-93.802635,Lafayette County,county
+iso1:us#iso2:us-nc#fips:37195,37195,37,37,Wilson,367.5612,35.700356,-77.9216,Wilson County,county
+iso1:us#iso2:us-oh#fips:39117,39117,39,39,Morrow,406.14737,40.525265000000005,-82.79773,Morrow County,county
+iso1:us#iso2:us-mt#fips:30039,30039,30,30,Granite,1727.2207,46.395953999999996,-113.42735,Granite County,county
+iso1:us#iso2:us-nd#fips:38031,38031,38,38,Foster,634.1012599999999,47.47143,-98.87288000000001,Foster County,county
+iso1:us#iso2:us-ar#fips:05033,5033,5,5,Crawford,593.7873,35.583009999999994,-94.23621999999999,Crawford County,county
+iso1:us#iso2:us-tx#fips:48053,48053,48,48,Burnet,994.3098,30.78963,-98.20119,Burnet County,county
+iso1:us#iso2:us-mo#fips:29186,29186,29,29,Ste. Genevieve,499.17004000000003,37.885845,-90.16153,Ste. Genevieve County,county
+iso1:us#iso2:us-tx#fips:48179,48179,48,48,Gray,926.0055,35.402542,-100.81237,Gray County,county
+iso1:us#iso2:us-il#fips:17109,17109,17,17,McDonough,589.3431,40.455807,-90.678955,McDonough County,county
+iso1:us#iso2:us-ia#fips:19137,19137,19,19,Montgomery,424.11127,41.021736,-95.15779,Montgomery County,county
+iso1:us#iso2:us-ar#fips:05067,5067,5,5,Jackson,633.8583,35.596466,-91.223206,Jackson County,county
+iso1:us#iso2:us-tx#fips:48229,48229,48,48,Hudspeth,4570.6807,31.450869,-105.37755,Hudspeth County,county
+iso1:us#iso2:us-la#fips:22079,22079,22,22,Rapides Parish,1320.3892,31.193203000000004,-92.53595,Rapides Parish,county
+iso1:us#iso2:us-ne#fips:31111,31111,31,31,Lincoln,2564.2197,41.050323,-100.744484,Lincoln County,county
+iso1:us#iso2:us-tx#fips:48067,48067,48,48,Cass,936.9976,33.0837,-94.35758,Cass County,county
+iso1:us#iso2:us-tn#fips:47079,47079,47,47,Henry,561.92145,36.325294,-88.300285,Henry County,county
+iso1:us#iso2:us-va#fips:51840,51840,51,51,Winchester city,9.193211,39.17387,-78.17635,Winchester city,county
+iso1:us#iso2:us-nc#fips:37061,37061,37,37,Duplin,814.7866,34.934402,-77.93354000000001,Duplin County,county
+iso1:us#iso2:us-nc#fips:37087,37087,37,37,Haywood,553.57886,35.558884,-82.98131,Haywood County,county
+iso1:us#iso2:us-mn#fips:27037,27037,27,27,Dakota,562.56354,44.670895,-93.062485,Dakota County,county
+iso1:us#iso2:us-or#fips:41025,41025,41,41,Harney,10134.782,43.06445,-118.98716999999999,Harney County,county
+iso1:us#iso2:us-pr#fips:72095,72095,72,72,Maunabo Municipio,21.165573000000002,17.999786,-65.8964,Maunabo Municipio,county
+iso1:us#iso2:us-wi#fips:55001,55001,55,55,Adams,645.6682,43.97376,-89.76723,Adams County,county
+iso1:us#iso2:us-mo#fips:29045,29045,29,29,Clark,504.62363,40.407276,-91.72946999999999,Clark County,county
+iso1:us#iso2:us-ky#fips:21015,21015,21,21,Boone,246.2927,38.9589,-84.736374,Boone County,county
+iso1:us#iso2:us-ky#fips:21229,21229,21,21,Washington,296.9822,37.754208,-85.175415,Washington County,county
+iso1:us#iso2:us-la#fips:22009,22009,22,22,Avoyelles Parish,832.0631,31.088503000000003,-91.98328000000001,Avoyelles Parish,county
+iso1:us#iso2:us-ms#fips:28137,28137,28,28,Tate,404.77722,34.64955,-89.94311,Tate County,county
+iso1:us#iso2:us-mo#fips:29227,29227,29,29,Worth,266.6377,40.4805,-94.4192,Worth County,county
+iso1:us#iso2:us-ne#fips:31163,31163,31,31,Sherman,565.8478,41.218742,-98.97285,Sherman County,county
+iso1:us#iso2:us-sd#fips:46021,46021,46,46,Campbell,733.7018,45.785576,-100.00210600000001,Campbell County,county
+iso1:us#iso2:us-sd#fips:46063,46063,46,46,Harding,2671.6604,45.59661,-103.47386999999999,Harding County,county
+iso1:us#iso2:us-mi#fips:26057,26057,26,26,Gratiot,568.3999,43.292324,-84.60469,Gratiot County,county
+iso1:us#iso2:us-ia#fips:19175,19175,19,19,Union,423.65952000000004,41.02855,-94.245094,Union County,county
+iso1:us#iso2:us-il#fips:17127,17127,17,17,Massac,237.24988,37.216118,-88.70566,Massac County,county
+iso1:us#iso2:us-ne#fips:31113,31113,31,31,Logan,570.67993,41.542156,-100.443665,Logan County,county
+iso1:us#iso2:us-ne#fips:31121,31121,31,31,Merrick,485.86832000000004,41.16979,-98.03106,Merrick County,county
+iso1:us#iso2:us-ne#fips:31161,31161,31,31,Sheridan,2441.0429999999997,42.512287,-102.36828,Sheridan County,county
+iso1:us#iso2:us-ky#fips:21039,21039,21,21,Carlisle,189.44643,36.85718,-88.976616,Carlisle County,county
+iso1:us#iso2:us-wy#fips:56025,56025,56,56,Natrona,5340.719,42.977646,-106.76822,Natrona County,county
+iso1:us#iso2:us-ga#fips:13321,13321,13,13,Worth,570.73157,31.551772999999997,-83.84996,Worth County,county
+iso1:us#iso2:us-in#fips:18109,18109,18,18,Morgan,403.85376,39.482647,-86.44745999999999,Morgan County,county
+iso1:us#iso2:us-tx#fips:48139,48139,48,48,Ellis,935.6919,32.346878000000004,-96.79694,Ellis County,county
+iso1:us#iso2:us-ga#fips:13229,13229,13,13,Pierce,340.46117999999996,31.353997999999997,-82.21037,Pierce County,county
+iso1:us#iso2:us-as:#fips:60010,60010,60,60,Eastern District,25.145706,-14.268114,-170.6257,Eastern District,county
+iso1:us#iso2:us-in#fips:18053,18053,18,18,Grant,414.10266,40.51576,-85.654945,Grant County,county
+iso1:us#iso2:us-fl#fips:12035,12035,12,12,Flagler,485.16152999999997,29.474891999999997,-81.28625500000001,Flagler County,county
+iso1:us#iso2:us-ms#fips:28077,28077,28,28,Lawrence,430.61664,31.550009000000003,-90.10753000000001,Lawrence County,county
+iso1:us#iso2:us-la#fips:22127,22127,22,22,Winn Parish,950.1185,31.941187,-92.641266,Winn Parish,county
+iso1:us#iso2:us-il#fips:17073,17073,17,17,Henry,823.08136,41.35002,-90.13084,Henry County,county
+iso1:us#iso2:us-or#fips:41041,41041,41,41,Lincoln,981.0357,44.641059999999996,-123.91121000000001,Lincoln County,county
+iso1:us#iso2:us-me#fips:23031,23031,23,23,York,991.1096,43.426018,-70.66843,York County,county
+iso1:us#iso2:us-sd#fips:46029,46029,46,46,Codington,687.6084,44.966286,-97.19884,Codington County,county
+iso1:us#iso2:us-ga#fips:13231,13231,13,13,Pike,216.09346000000002,33.081223,-84.38985,Pike County,county
+iso1:us#iso2:us-ga#fips:13259,13259,13,13,Stewart,458.76407,32.073223,-84.83491500000001,Stewart County,county
+iso1:us#iso2:us-nj#fips:34025,34025,34,34,Monmouth,468.19772,40.28705,-74.15244,Monmouth County,county
+iso1:us#iso2:us-ar#fips:05021,5021,5,5,Clay,639.48975,36.367302,-90.4187,Clay County,county
+iso1:us#iso2:us-ar#fips:05045,5045,5,5,Faulkner,647.9786,35.14655,-92.33693000000001,Faulkner County,county
+iso1:us#iso2:us-ok#fips:40041,40041,40,40,Delaware,738.0539,36.393375,-94.80821999999999,Delaware County,county
+iso1:us#iso2:us-ia#fips:19107,19107,19,19,Keokuk,579.2007,41.331179999999996,-92.167725,Keokuk County,county
+iso1:us#iso2:us-il#fips:17061,17061,17,17,Greene,543.0576,39.35544,-90.38768,Greene County,county
+iso1:us#iso2:us-mn#fips:27075,27075,27,27,Lake,2109.3376,47.517113,-91.411705,Lake County,county
+iso1:us#iso2:us-ga#fips:13285,13285,13,13,Troup,414.02158,33.03448,-85.02835999999999,Troup County,county
+iso1:us#iso2:us-ca#fips:06023,6023,6,6,Humboldt,3568.256,40.706654,-123.92618,Humboldt County,county
+iso1:us#iso2:us-tn#fips:47043,47043,47,47,Dickson,489.91492,36.14553,-87.36415,Dickson County,county
+iso1:us#iso2:us-mn#fips:27003,27003,27,27,Anoka,421.97787,45.27411,-93.24271999999999,Anoka County,county
+iso1:us#iso2:us-sd#fips:46009,46009,46,46,Bon Homme,563.5686,42.985797999999996,-97.8842,Bon Homme County,county
+iso1:us#iso2:us-tn#fips:47059,47059,47,47,Greene,622.1899400000001,36.179485,-82.84753,Greene County,county
+iso1:us#iso2:us-va#fips:51183,51183,51,51,Sussex,490.2425,36.926646999999996,-77.25973499999999,Sussex County,county
+iso1:us#iso2:us-in#fips:18141,18141,18,18,St. Joseph,457.9097,41.61772,-86.28805,St. Joseph County,county
+iso1:us#iso2:us-nd#fips:38067,38067,38,38,Pembina,1118.7160000000001,48.766895,-97.5454,Pembina County,county
+iso1:us#iso2:us-sd#fips:46007,46007,46,46,Bennett,1184.682,43.186913,-101.67718,Bennett County,county
+iso1:us#iso2:us-la#fips:22115,22115,22,22,Vernon Parish,1327.9626,31.110563,-93.18151999999999,Vernon Parish,county
+iso1:us#iso2:us-me#fips:23019,23019,23,23,Penobscot,3397.3125,45.409283,-68.66662,Penobscot County,county
+iso1:us#iso2:us-md#fips:24041,24041,24,24,Talbot,268.567,38.74835,-76.178474,Talbot County,county
+iso1:us#iso2:us-ga#fips:13257,13257,13,13,Stephens,179.1563,34.552914,-83.290215,Stephens County,county
+iso1:us#iso2:us-ca#fips:06065,6065,6,6,Riverside,7209.2407,33.729828000000005,-116.00223500000001,Riverside County,county
+iso1:us#iso2:us-ar#fips:05005,5005,5,5,Baxter,554.2701,36.28027,-92.32995,Baxter County,county
+iso1:us#iso2:us-ms#fips:28007,28007,28,28,Attala,734.98175,33.09047,-89.58861999999999,Attala County,county
+iso1:us#iso2:us-ia#fips:19169,19169,19,19,Story,572.5631,42.037537,-93.466095,Story County,county
+iso1:us#iso2:us-ks#fips:20011,20011,20,20,Bourbon,635.49243,37.8561,-94.85093,Bourbon County,county
+iso1:us#iso2:us-va#fips:51049,51049,51,51,Cumberland,297.51184,37.520187,-78.25284,Cumberland County,county
+iso1:us#iso2:us-sc#fips:45085,45085,45,45,Sumter,665.09644,33.916138000000004,-80.38238,Sumter County,county
+iso1:us#iso2:us-ak#fips:02164,2164,2,2,Lake and Peninsula Borough,23905.535,58.10850500000001,-156.4134,Lake and Peninsula Borough,county
+iso1:us#iso2:us-wv#fips:54109,54109,54,54,Wyoming,499.48682,37.60366,-81.54903399999999,Wyoming County,county
+iso1:us#iso2:us-ca#fips:06029,6029,6,6,Kern,8132.5693,35.34663,-118.72951,Kern County,county
+iso1:us#iso2:us-tx#fips:48097,48097,48,48,Cooke,874.8485,33.6392,-97.21034,Cooke County,county
+iso1:us#iso2:us-sc#fips:45075,45075,45,45,Orangeburg,1106.3835,33.436134,-80.80291,Orangeburg County,county
+iso1:us#iso2:us-wi#fips:55119,55119,55,55,Taylor,975.0844,45.211655,-90.50485,Taylor County,county
+iso1:us#iso2:us-mn#fips:27099,27099,27,27,Mower,711.35266,43.66625,-92.759514,Mower County,county
+iso1:us#iso2:us-mn#fips:27101,27101,27,27,Murray,704.6888,44.015594,-95.76158000000001,Murray County,county
+iso1:us#iso2:us-ri#fips:44007,44007,44,44,Providence,409.49987999999996,41.869766,-71.57862,Providence County,county
+iso1:us#iso2:us-mo#fips:29161,29161,29,29,Phelps,671.8093,37.866325,-91.79035,Phelps County,county
+iso1:us#iso2:us-ms#fips:28117,28117,28,28,Prentiss,414.99927,34.620567,-88.52219000000001,Prentiss County,county
+iso1:us#iso2:us-ky#fips:21235,21235,21,21,Whitley,437.84573,36.758022,-84.144646,Whitley County,county
+iso1:us#iso2:us-in#fips:18149,18149,18,18,Starke,309.15472,41.284477,-86.64464,Starke County,county
+iso1:us#iso2:us-tx#fips:48491,48491,48,48,Williamson,1118.3778,30.649082,-97.605064,Williamson County,county
+iso1:us#iso2:us-pr#fips:72109,72109,72,72,Patillas Municipio,46.60244,18.00031,-65.98664000000001,Patillas Municipio,county
+iso1:us#iso2:us-ia#fips:19131,19131,19,19,Mitchell,469.14902,43.348564,-92.78447,Mitchell County,county
+iso1:us#iso2:us-ga#fips:13107,13107,13,13,Emanuel,680.5947,32.5911,-82.29977,Emanuel County,county
+iso1:us#iso2:us-la#fips:22025,22025,22,22,Catahoula Parish,708.05164,31.666517,-91.8467,Catahoula Parish,county
+iso1:us#iso2:us-pa#fips:42025,42025,42,42,Carbon,381.26273,40.918365,-75.70504,Carbon County,county
+iso1:us#iso2:us-ne#fips:31133,31133,31,31,Pawnee,431.0893,40.137848,-96.245224,Pawnee County,county
+iso1:us#iso2:us-tn#fips:47171,47171,47,47,Unicoi,186.0701,36.10013,-82.41821999999999,Unicoi County,county
+iso1:us#iso2:us-sc#fips:45083,45083,45,45,Spartanburg,807.77185,34.93327,-81.99105,Spartanburg County,county
+iso1:us#iso2:us-wi#fips:55073,55073,55,55,Marathon,1545.2306,44.898037,-89.75782,Marathon County,county
+iso1:us#iso2:us-nv#fips:32007,32007,32,32,Elko,17174.03,41.141132,-115.351425,Elko County,county
+iso1:us#iso2:us-wv#fips:54007,54007,54,54,Braxton,510.75195,38.699329999999996,-80.73165999999999,Braxton County,county
+iso1:us#iso2:us-mi#fips:26165,26165,26,26,Wexford,564.9441,44.331375,-85.570045,Wexford County,county
+iso1:us#iso2:us-tx#fips:48079,48079,48,48,Cochran,775.10864,33.60844,-102.83045,Cochran County,county
+iso1:us#iso2:us-pa#fips:42013,42013,42,42,Blair,525.8192,40.498653000000004,-78.3096,Blair County,county
+iso1:us#iso2:us-mo#fips:29085,29085,29,29,Hickory,398.82172,37.93691,-93.32299,Hickory County,county
+iso1:us#iso2:us-mo#fips:29009,29009,29,29,Barry,778.1011,36.699375,-93.834335,Barry County,county
+iso1:us#iso2:us-mn#fips:27123,27123,27,27,Ramsey,152.24837,45.015205,-93.09997,Ramsey County,county
+iso1:us#iso2:us-ar#fips:05081,5081,5,5,Little River,532.2643400000001,33.699496999999994,-94.229774,Little River County,county
+iso1:us#iso2:us-nv#fips:32019,32019,32,32,Lyon,2001.3025,39.022213,-119.19742600000001,Lyon County,county
+iso1:us#iso2:us-fl#fips:12071,12071,12,12,Lee,781.4833,26.559034000000004,-81.89199,Lee County,county
+iso1:us#iso2:us-or#fips:41033,41033,41,41,Josephine,1638.7045,42.386982,-123.57162,Josephine County,county
+iso1:us#iso2:us-pr#fips:72091,72091,72,72,Manatí Municipio,45.1419,18.444647,-66.49288,Manatí Municipio,county
+iso1:us#iso2:us-ms#fips:28113,28113,28,28,Pike,409.03143,31.177515000000003,-90.39773000000001,Pike County,county
+iso1:us#iso2:us-tn#fips:47031,47031,47,47,Coffee,428.9781,35.488766,-86.0782,Coffee County,county
+iso1:us#iso2:us-id#fips:16059,16059,16,16,Lemhi,4563.848,44.928505,-113.88703999999998,Lemhi County,county
+iso1:us#iso2:us-ky#fips:21183,21183,21,21,Ohio,587.3045,37.47786,-86.84487,Ohio County,county
+iso1:us#iso2:us-ne#fips:31153,31153,31,31,Sarpy,238.16038999999998,41.115063,-96.10911999999999,Sarpy County,county
+iso1:us#iso2:us-ga#fips:13071,13071,13,13,Colquitt,547.0554,31.189707000000002,-83.769775,Colquitt County,county
+iso1:us#iso2:us-mn#fips:27167,27167,27,27,Wilkin,751.0251,46.362334999999995,-96.47665400000001,Wilkin County,county
+iso1:us#iso2:us-il#fips:17157,17157,17,17,Randolph,575.3867,38.056515000000005,-89.82121,Randolph County,county
+iso1:us#iso2:us-me#fips:23011,23011,23,23,Kennebec,867.4987,44.41701,-69.76576,Kennebec County,county
+iso1:us#iso2:us-va#fips:51173,51173,51,51,Smyth,451.36575,36.84232,-81.53979,Smyth County,county
+iso1:us#iso2:us-nm#fips:35041,35041,35,35,Roosevelt,2446.134,34.021206,-103.48299999999999,Roosevelt County,county
+iso1:us#iso2:us-pa#fips:42111,42111,42,42,Somerset,1074.3944,39.981297,-79.02849,Somerset County,county
+iso1:us#iso2:us-va#fips:51191,51191,51,51,Washington,561.1799,36.747814,-81.950325,Washington County,county
+iso1:us#iso2:us-nc#fips:37081,37081,37,37,Guilford,645.9473,36.079063,-79.788666,Guilford County,county
+iso1:us#iso2:us-id#fips:16001,16001,16,16,Ada,1052.0485,43.451477000000004,-116.24438,Ada County,county
+iso1:us#iso2:us-ok#fips:40039,40039,40,40,Custer,988.8127,35.6456,-98.99738,Custer County,county
+iso1:us#iso2:us-oh#fips:39101,39101,39,39,Marion,403.82178,40.588035999999995,-83.1688,Marion County,county
+iso1:us#iso2:us-il#fips:17149,17149,17,17,Pike,831.3799,39.625107,-90.88904000000001,Pike County,county
+iso1:us#iso2:us-il#fips:17203,17203,17,17,Woodford,527.7508,40.789787,-89.21059,Woodford County,county
+iso1:us#iso2:us-ga#fips:13245,13245,13,13,Richmond,324.34302,33.361484999999995,-82.075,Richmond County,county
+iso1:us#iso2:us-al#fips:01107,1107,1,1,Pickens,881.37537,33.296795,-88.09685999999999,Pickens County,county
+iso1:us#iso2:us-ok#fips:40045,40045,40,40,Ellis,1231.5188,36.22426,-99.75014,Ellis County,county
+iso1:us#iso2:us-il#fips:17145,17145,17,17,Perry,441.85797,38.084379999999996,-89.36851999999999,Perry County,county
+iso1:us#iso2:us-ia#fips:19075,19075,19,19,Grundy,501.8718,42.40334,-92.790245,Grundy County,county
+iso1:us#iso2:us-co#fips:08107,8107,8,8,Routt,2362.1,40.483665,-106.9877,Routt County,county
+iso1:us#iso2:us-nj#fips:34035,34035,34,34,Somerset,301.87667999999996,40.565529999999995,-74.619934,Somerset County,county
+iso1:us#iso2:us-ca#fips:06011,6011,6,6,Colusa,1150.7521,39.17774,-122.23756399999999,Colusa County,county
+iso1:us#iso2:us-il#fips:17087,17087,17,17,Johnson,343.7464,37.46071,-88.88213,Johnson County,county
+iso1:us#iso2:us-co#fips:08053,8053,8,8,Hinsdale,1117.2688,37.821166999999996,-107.338264,Hinsdale County,county
+iso1:us#iso2:us-id#fips:16031,16031,16,16,Cassia,2565.6968,42.282314,-113.62633000000001,Cassia County,county
+iso1:us#iso2:us-mn#fips:27059,27059,27,27,Isanti,435.7549,45.56243,-93.29634,Isanti County,county
+iso1:us#iso2:us-pa#fips:42049,42049,42,42,Erie,799.0854,42.11795,-80.09638000000001,Erie County,county
+iso1:us#iso2:us-ms#fips:28029,28029,28,28,Copiah,777.3114,31.866915000000002,-90.44876,Copiah County,county
+iso1:us#iso2:us-tx#fips:48467,48467,48,48,Van Zandt,842.5993699999999,32.55879,-95.83691,Van Zandt County,county
+iso1:us#iso2:us-va#fips:51161,51161,51,51,Roanoke,250.55264,37.343586,-79.94399,Roanoke County,county
+iso1:us#iso2:us-va#fips:51015,51015,51,51,Augusta,967.1062,38.17191,-79.14756,Augusta County,county
+iso1:us#iso2:us-ak#fips:02060,2060,2,2,Bristol Bay Borough,481.99698,58.741645999999996,-156.9669,Bristol Bay Borough,county
+iso1:us#iso2:us-ut#fips:49031,49031,49,49,Piute,758.4639999999999,38.335879999999996,-112.12938,Piute County,county
+iso1:us#iso2:us-ky#fips:21161,21161,21,21,Mason,240.13452,38.594134999999994,-83.828125,Mason County,county
+iso1:us#iso2:us-mn#fips:27009,27009,27,27,Benton,408.3105,45.701225,-94.00144,Benton County,county
+iso1:us#iso2:us-tx#fips:48129,48129,48,48,Donley,926.9377400000001,34.955036,-100.81585,Donley County,county
+iso1:us#iso2:us-fl#fips:12005,12005,12,12,Bay,758.61755,30.238218,-85.63168,Bay County,county
+iso1:us#iso2:us-al#fips:01077,1077,1,1,Lauderdale,668.0359,34.90412,-87.65099000000001,Lauderdale County,county
+iso1:us#iso2:us-in#fips:18045,18045,18,18,Fountain,395.68106,40.121235,-87.23487,Fountain County,county
+iso1:us#iso2:us-il#fips:17173,17173,17,17,Shelby,758.53613,39.384926,-88.79885999999999,Shelby County,county
+iso1:us#iso2:us-il#fips:17051,17051,17,17,Fayette,716.4628,39.001125,-89.01791999999999,Fayette County,county
+iso1:us#iso2:us-oh#fips:39127,39127,39,39,Perry,407.94785,39.743187,-82.23795,Perry County,county
+iso1:us#iso2:us-va#fips:51590,51590,51,51,Danville city,42.798767,36.583332,-79.40807,Danville city,county
+iso1:us#iso2:us-ga#fips:13011,13011,13,13,Banks,232.06392999999997,34.35192,-83.49844,Banks County,county
+iso1:us#iso2:us-ga#fips:13305,13305,13,13,Wayne,641.9585599999999,31.547846000000003,-81.91238,Wayne County,county
+iso1:us#iso2:us-ok#fips:40109,40109,40,40,Oklahoma,708.8815,35.55461,-97.4094,Oklahoma County,county
+iso1:us#iso2:us-ok#fips:40069,40069,40,40,Johnston,643.0706,34.313454,-96.65425,Johnston County,county
+iso1:us#iso2:us-nc#fips:37099,37099,37,37,Jackson,491.12363,35.28105,-83.11996500000001,Jackson County,county
+iso1:us#iso2:us-ut#fips:49043,49043,49,49,Summit,1870.6426,40.87206,-110.96848,Summit County,county
+iso1:us#iso2:us-mo#fips:29167,29167,29,29,Polk,635.5481599999999,37.61676,-93.40082,Polk County,county
+iso1:us#iso2:us-nv#fips:32015,32015,32,32,Lander,5519.4346,39.900209999999994,-117.04723999999999,Lander County,county
+iso1:us#iso2:us-ia#fips:19191,19191,19,19,Winneshiek,689.8593,43.292988,-91.85078399999999,Winneshiek County,county
+iso1:us#iso2:us-ky#fips:21023,21023,21,21,Bracken,202.72346000000002,38.680367,-84.115234,Bracken County,county
+iso1:us#iso2:us-wi#fips:55037,55037,55,55,Florence,488.1395,45.871826,-88.40699000000001,Florence County,county
+iso1:us#iso2:us-wv#fips:54087,54087,54,54,Roane,483.57944000000003,38.74295,-81.35449,Roane County,county
+iso1:us#iso2:us-mn#fips:27159,27159,27,27,Wadena,536.295,46.586987,-94.98861,Wadena County,county
+iso1:us#iso2:us-va#fips:51670,51670,51,51,Hopewell city,10.3547125,37.291008000000005,-77.29894,Hopewell city,county
+iso1:us#iso2:us-il#fips:17201,17201,17,17,Winnebago,513.17365,42.337395,-89.16121,Winnebago County,county
+iso1:us#iso2:us-az#fips:04007,4007,4,4,Gila,4758.1577,33.78962,-110.81187,Gila County,county
+iso1:us#iso2:us-md#fips:24045,24045,24,24,Wicomico,374.43323,38.36737,-75.63208,Wicomico County,county
+iso1:us#iso2:us-ky#fips:21043,21043,21,21,Carter,409.5089,38.309546999999995,-83.0488,Carter County,county
+iso1:us#iso2:us-nc#fips:37097,37097,37,37,Iredell,574.3158599999999,35.806248,-80.87451999999999,Iredell County,county
+iso1:us#iso2:us-va#fips:51083,51083,51,51,Halifax,817.75867,36.766459999999995,-78.93961,Halifax County,county
+iso1:us#iso2:us-nc#fips:37091,37091,37,37,Hertford,353.17554,36.363518,-76.98161,Hertford County,county
+iso1:us#iso2:us-ny#fips:36057,36057,36,36,Montgomery,403.13022,42.900890000000004,-74.435356,Montgomery County,county
+iso1:us#iso2:us-mn#fips:27113,27113,27,27,Pennington,616.59863,48.06925,-96.03773000000001,Pennington County,county
+iso1:us#iso2:us-wa#fips:53073,53073,53,53,Whatcom,2107.9482,48.84265,-121.83643000000001,Whatcom County,county
+iso1:us#iso2:us-or#fips:41021,41021,41,41,Gilliam,1204.7623,45.43059,-120.3199,Gilliam County,county
+iso1:us#iso2:us-nj#fips:34029,34029,34,34,Ocean,628.359,39.86567,-74.258865,Ocean County,county
+iso1:us#iso2:us-ar#fips:05009,5009,5,5,Boone,590.01526,36.3043,-93.07924,Boone County,county
+iso1:us#iso2:us-ok#fips:40031,40031,40,40,Comanche,1069.4058,34.66263,-98.47661,Comanche County,county
+iso1:us#iso2:us-tx#fips:48253,48253,48,48,Jones,928.6022300000001,32.74371,-99.87443,Jones County,county
+iso1:us#iso2:us-tx#fips:48185,48185,48,48,Grimes,787.4934,30.543232,-95.98808000000001,Grimes County,county
+iso1:us#iso2:us-mi#fips:26049,26049,26,26,Genesee,636.95654,43.021076,-83.706375,Genesee County,county
+iso1:us#iso2:us-la#fips:22007,22007,22,22,Assumption Parish,338.63467,29.898853000000003,-91.05247,Assumption Parish,county
+iso1:us#iso2:us-ms#fips:28013,28013,28,28,Calhoun,586.59344,33.936634000000005,-89.33711,Calhoun County,county
+iso1:us#iso2:us-ms#fips:28041,28041,28,28,Greene,712.7624,31.212845,-88.63481,Greene County,county
+iso1:us#iso2:us-mt#fips:30017,30017,30,30,Custer,3783.437,46.261414,-105.550354,Custer County,county
+iso1:us#iso2:us-sd#fips:46109,46109,46,46,Roberts,1101.086,45.623398,-96.94755,Roberts County,county
+iso1:us#iso2:us-il#fips:17141,17141,17,17,Ogle,758.6794,42.041885,-89.320175,Ogle County,county
+iso1:us#iso2:us-nd#fips:38077,38077,38,38,Richland,1435.723,46.26522,-96.93796,Richland County,county
+iso1:us#iso2:us-wi#fips:55005,55005,55,55,Barron,863.0707,45.43719,-91.85289,Barron County,county
+iso1:us#iso2:us-wi#fips:55051,55051,55,55,Iron,758.2344,46.32655,-90.2613,Iron County,county
+iso1:us#iso2:us-mn#fips:27157,27157,27,27,Wabasha,522.9684,44.289691999999995,-92.23334,Wabasha County,county
+iso1:us#iso2:us-ca#fips:06015,6015,6,6,Del Norte,1006.262,41.763958,-124.00362,Del Norte County,county
+iso1:us#iso2:us-ok#fips:40127,40127,40,40,Pushmataha,1395.5845,34.3779,-95.40808,Pushmataha County,county
+iso1:us#iso2:us-wa#fips:53007,53007,53,53,Chelan,2921.278,47.860973,-120.61903999999998,Chelan County,county
+iso1:us#iso2:us-mi#fips:26141,26141,26,26,Presque Isle,658.73956,45.489513,-83.38401999999999,Presque Isle County,county
+iso1:us#iso2:us-ok#fips:40027,40027,40,40,Cleveland,538.806,35.206375,-97.32309000000001,Cleveland County,county
+iso1:us#iso2:us-ny#fips:36105,36105,36,36,Sullivan,968.1701,41.719994,-74.771576,Sullivan County,county
+iso1:us#iso2:us-nc#fips:37149,37149,37,37,Polk,237.695,35.2779,-82.16762,Polk County,county
+iso1:us#iso2:us-nc#fips:37165,37165,37,37,Scotland,319.15134,34.840022999999995,-79.47733000000001,Scotland County,county
+iso1:us#iso2:us-nc#fips:37085,37085,37,37,Harnett,595.0423599999999,35.368633,-78.87161,Harnett County,county
+iso1:us#iso2:us-nc#fips:37105,37105,37,37,Lee,255.07062000000002,35.476337,-79.17211999999999,Lee County,county
+iso1:us#iso2:us-in#fips:18159,18159,18,18,Tipton,260.54967999999997,40.31023,-86.056206,Tipton County,county
+iso1:us#iso2:us-ks#fips:20027,20027,20,20,Clay,645.3204,39.344963,-97.16885,Clay County,county
+iso1:us#iso2:us-ok#fips:40145,40145,40,40,Wagoner,561.7006,35.963478,-95.5141,Wagoner County,county
+iso1:us#iso2:us-mt#fips:30083,30083,30,30,Richland,2084.6267,47.785633000000004,-104.56341,Richland County,county
+iso1:us#iso2:us-ar#fips:05003,5003,5,5,Ashley,925.3905,33.190834,-91.77226999999999,Ashley County,county
+iso1:us#iso2:us-ar#fips:05041,5041,5,5,Desha,768.16156,33.82875,-91.2441,Desha County,county
+iso1:us#iso2:us-pr#fips:72147,72147,72,72,Vieques Municipio,50.790146,18.125418,-65.43247,Vieques Municipio,county
+iso1:us#iso2:us-tn#fips:47135,47135,47,47,Perry,414.77603,35.663754,-87.86932,Perry County,county
+iso1:us#iso2:us-mn#fips:27163,27163,27,27,Washington,384.42368,45.037929999999996,-92.890114,Washington County,county
+iso1:us#iso2:us-va#fips:51740,51740,51,51,Portsmouth city,33.301753999999995,36.85934,-76.35696999999999,Portsmouth city,county
+iso1:us#iso2:us-pa#fips:42051,42051,42,42,Fayette,790.3807,39.918907,-79.64012,Fayette County,county
+iso1:us#iso2:us-wv#fips:54023,54023,54,54,Grant,477.38845999999995,39.105988,-79.19506,Grant County,county
+iso1:us#iso2:us-va#fips:51171,51171,51,51,Shenandoah,508.08925999999997,38.856204999999996,-78.57399000000001,Shenandoah County,county
+iso1:us#iso2:us-tx#fips:48235,48235,48,48,Irion,1051.5796,31.303425,-100.9813,Irion County,county
+iso1:us#iso2:us-mo#fips:29025,29025,29,29,Caldwell,426.40665,39.658997,-93.97918,Caldwell County,county
+iso1:us#iso2:us-fl#fips:12107,12107,12,12,Putnam,727.89185,29.593897,-81.73204,Putnam County,county
+iso1:us#iso2:us-in#fips:18025,18025,18,18,Crawford,305.6237,38.289433,-86.44086999999999,Crawford County,county
+iso1:us#iso2:us-mo#fips:29111,29111,29,29,Lewis,505.0591,40.084559999999996,-91.728806,Lewis County,county
+iso1:us#iso2:us-ne#fips:31075,31075,31,31,Grant,776.8954,41.913956,-101.75596999999999,Grant County,county
+iso1:us#iso2:us-pr#fips:72087,72087,72,72,Loíza Municipio,19.362873,18.475039000000002,-65.90328000000001,Loíza Municipio,county
+iso1:us#iso2:us-id#fips:16071,16071,16,16,Oneida,1198.992,42.183895,-112.52045,Oneida County,county
+iso1:us#iso2:us-il#fips:17139,17139,17,17,Moultrie,335.97217,39.636894,-88.625725,Moultrie County,county
+iso1:us#iso2:us-ky#fips:21107,21107,21,21,Hopkins,542.0843,37.31107,-87.5422,Hopkins County,county
+iso1:us#iso2:us-id#fips:16035,16035,16,16,Clearwater,2457.3972,46.67257,-115.6535,Clearwater County,county
+iso1:us#iso2:us-ky#fips:21013,21013,21,21,Bell,359.07397000000003,36.728928,-83.68072,Bell County,county
+iso1:us#iso2:us-mn#fips:27035,27035,27,27,Crow Wing,998.39825,46.491653,-94.07072,Crow Wing County,county
+iso1:us#iso2:us-as:#fips:60050,60050,60,60,Western District,27.992784999999998,-14.335467999999999,-170.78423999999998,Western District,county
+iso1:us#iso2:us-pr#fips:72011,72011,72,72,Añasco Municipio,39.286235999999995,18.286904999999997,-67.13128,Añasco Municipio,county
+iso1:us#iso2:us-az#fips:04009,4009,4,4,Graham,4622.034000000001,32.931828,-109.87831000000001,Graham County,county
+iso1:us#iso2:us-ar#fips:05123,5123,5,5,St. Francis,634.78094,35.02284,-90.7515,St. Francis County,county
+iso1:us#iso2:us-ga#fips:13101,13101,13,13,Echols,420.42145,30.714008000000003,-82.89738,Echols County,county
+iso1:us#iso2:us-ak#fips:02070,2070,2,2,Dillingham Census Area,18332.264,59.543327000000005,-158.26712,Dillingham Census Area,county
+iso1:us#iso2:us-ks#fips:20105,20105,20,20,Lincoln,719.42035,39.04728,-98.21429,Lincoln County,county
+iso1:us#iso2:us-ks#fips:20183,20183,20,20,Smith,895.49475,39.784659999999995,-98.78543,Smith County,county
+iso1:us#iso2:us-fl#fips:12065,12065,12,12,Jefferson,598.0976,30.424559000000002,-83.89086,Jefferson County,county
+iso1:us#iso2:us-pr#fips:72041,72041,72,72,Cidra Municipio,36.022438,18.174404,-66.16162,Cidra Municipio,county
+iso1:us#iso2:us-ms#fips:28005,28005,28,28,Amite,730.12506,31.203934000000004,-90.79554,Amite County,county
+iso1:us#iso2:us-ar#fips:05097,5097,5,5,Montgomery,779.94696,34.545654,-93.66415400000001,Montgomery County,county
+iso1:us#iso2:us-mi#fips:26025,26025,26,26,Calhoun,706.28455,42.24299,-85.01238000000001,Calhoun County,county
+iso1:us#iso2:us-al#fips:01029,1029,1,1,Cleburne,560.1235,33.671963,-85.51613,Cleburne County,county
+iso1:us#iso2:us-co#fips:08123,8123,8,8,Weld,3985.0645,40.55596,-104.38367,Weld County,county
+iso1:us#iso2:us-ok#fips:40009,40009,40,40,Beckham,901.7099,35.2706,-99.69005600000001,Beckham County,county
+iso1:us#iso2:us-ca#fips:06049,6049,6,6,Modoc,3948.0662,41.59292,-120.71837,Modoc County,county
+iso1:us#iso2:us-ia#fips:19153,19153,19,19,Polk,572.2328,41.684814,-93.56897,Polk County,county
+iso1:us#iso2:us-ga#fips:13179,13179,13,13,Liberty,516.4880400000001,31.807459,-81.45787,Liberty County,county
+iso1:us#iso2:us-tx#fips:48349,48349,48,48,Navarro,1009.68207,32.048446999999996,-96.476906,Navarro County,county
+iso1:us#iso2:us-tx#fips:48047,48047,48,48,Brooks,943.3866,27.034994,-98.21528,Brooks County,county
+iso1:us#iso2:us-tn#fips:47187,47187,47,47,Williamson,582.8888,35.894806,-86.89806999999999,Williamson County,county
+iso1:us#iso2:us-wy#fips:56021,56021,56,56,Laramie,2685.955,41.29283,-104.66039,Laramie County,county
+iso1:us#iso2:us-wa#fips:53003,53003,53,53,Asotin,636.0971,46.18186,-117.22778000000001,Asotin County,county
+iso1:us#iso2:us-mn#fips:27155,27155,27,27,Traverse,573.89124,45.769936,-96.47483000000001,Traverse County,county
+iso1:us#iso2:us-il#fips:17017,17017,17,17,Cass,375.76672,39.969204,-90.245705,Cass County,county
+iso1:us#iso2:us-ga#fips:13247,13247,13,13,Rockdale,129.82289,33.65208,-84.02637,Rockdale County,county
+iso1:us#iso2:us-pa#fips:42067,42067,42,42,Juniata,391.4035,40.530674,-77.40044,Juniata County,county
+iso1:us#iso2:us-pa#fips:42083,42083,42,42,McKean,979.2146,41.81459,-78.572464,McKean County,county
+iso1:us#iso2:us-ok#fips:40049,40049,40,40,Garvin,802.1365400000001,34.70935,-97.31272,Garvin County,county
+iso1:us#iso2:us-ne#fips:31021,31021,31,31,Burt,491.6025,41.85418,-96.337746,Burt County,county
+iso1:us#iso2:us-nm#fips:35045,35045,35,35,San Juan,5517.391,36.511623,-108.32458000000001,San Juan County,county
+iso1:us#iso2:us-ny#fips:36073,36073,36,36,Orleans,391.27643,43.502285,-78.22973,Orleans County,county
+iso1:us#iso2:us-la#fips:22031,22031,22,22,De Soto Parish,876.4557,32.059246,-93.7408,De Soto Parish,county
+iso1:us#iso2:us-ca#fips:06019,6019,6,6,Fresno,5958.585,36.761005,-119.65502,Fresno County,county
+iso1:us#iso2:us-ga#fips:13105,13105,13,13,Elbert,351.10956,34.116413,-82.84191,Elbert County,county
+iso1:us#iso2:us-al#fips:01005,1005,1,1,Barbour,885.0381,31.870253,-85.405106,Barbour County,county
+iso1:us#iso2:us-nc#fips:37017,37017,37,37,Bladen,874.8939,34.591938,-78.53949,Bladen County,county
+iso1:us#iso2:us-tx#fips:48111,48111,48,48,Dallam,1503.1836,36.28637,-102.59402,Dallam County,county
+iso1:us#iso2:us-il#fips:17167,17167,17,17,Sangamon,868.29785,39.756865999999995,-89.66242,Sangamon County,county
+iso1:us#iso2:us-ok#fips:40035,40035,40,40,Craig,761.2734,36.76389,-95.20155,Craig County,county
+iso1:us#iso2:us-tn#fips:47035,47035,47,47,Cumberland,681.3567,35.9524,-84.99476,Cumberland County,county
+iso1:us#iso2:us-mi#fips:26137,26137,26,26,Otsego,515.0239,45.021786,-84.57661,Otsego County,county
+iso1:us#iso2:us-ia#fips:19161,19161,19,19,Sac,575.04156,42.387527,-95.105225,Sac County,county
+iso1:us#iso2:us-ut#fips:49015,49015,49,49,Emery,4462.428,39.009026,-110.7211,Emery County,county
+iso1:us#iso2:us-wa#fips:53019,53019,53,53,Ferry,2203.3135,48.473255,-118.53358999999999,Ferry County,county
+iso1:us#iso2:us-mt#fips:30109,30109,30,30,Wibaux,889.60175,46.962967,-104.27452,Wibaux County,county
+iso1:us#iso2:us-nm#fips:35027,35027,35,35,Lincoln,4831.2793,33.740840000000006,-105.44981000000001,Lincoln County,county
+iso1:us#iso2:us-ok#fips:40021,40021,40,40,Cherokee,749.0266,35.904365999999996,-94.996796,Cherokee County,county
+iso1:us#iso2:us-mn#fips:27173,27173,27,27,Yellow Medicine,759.12695,44.715736,-95.862755,Yellow Medicine County,county
+iso1:us#iso2:us-tx#fips:48231,48231,48,48,Hunt,840.44385,33.123306,-96.08423,Hunt County,county
+iso1:us#iso2:us-tx#fips:48335,48335,48,48,Mitchell,911.1205,32.304115,-100.92439,Mitchell County,county
+iso1:us#iso2:us-tx#fips:48499,48499,48,48,Wood,645.26465,32.783590000000004,-95.382164,Wood County,county
+iso1:us#iso2:us-ok#fips:40113,40113,40,40,Osage,2246.681,36.6243,-96.40811,Osage County,county
+iso1:us#iso2:us-nc#fips:37039,37039,37,37,Cherokee,455.55643,35.13715,-84.06145,Cherokee County,county
+iso1:us#iso2:us-mi#fips:26107,26107,26,26,Mecosta,555.1461,43.635296000000004,-85.33275,Mecosta County,county
+iso1:us#iso2:us-ky#fips:21195,21195,21,21,Pike,786.7569599999999,37.48603,-82.41091,Pike County,county
+iso1:us#iso2:us-fl#fips:12067,12067,12,12,Lafayette,543.36316,29.990067,-83.17851,Lafayette County,county
+iso1:us#iso2:us-nc#fips:37035,37035,37,37,Catawba,401.38647000000003,35.661884,-81.214905,Catawba County,county
+iso1:us#iso2:us-ky#fips:21025,21025,21,21,Breathitt,492.4332,37.517807,-83.31716,Breathitt County,county
+iso1:us#iso2:us-tx#fips:48075,48075,48,48,Childress,696.5345,34.524623999999996,-100.20817,Childress County,county
+iso1:us#iso2:us-mo#fips:29181,29181,29,29,Ripley,629.5527,36.65017,-90.87483,Ripley County,county
+iso1:us#iso2:us-il#fips:17179,17179,17,17,Tazewell,646.4866,40.508076,-89.51626,Tazewell County,county
+iso1:us#iso2:us-tx#fips:48243,48243,48,48,Jeff Davis,2264.6328,30.625357,-104.19187,Jeff Davis County,county
+iso1:us#iso2:us-va#fips:51678,51678,51,51,Lexington city,2.4993243,37.782333,-79.44431999999999,Lexington city,county
+iso1:us#iso2:us-ar#fips:05135,5135,5,5,Sharp,604.4255,36.173396999999994,-91.47107,Sharp County,county
+iso1:us#iso2:us-co#fips:08069,8069,8,8,Larimer,2595.8628,40.658091999999996,-105.48676,Larimer County,county
+iso1:us#iso2:us-nc#fips:37177,37177,37,37,Tyrrell,390.7888,35.87042,-76.16534399999999,Tyrrell County,county
+iso1:us#iso2:us-mn#fips:27131,27131,27,27,Rice,495.8551,44.350735,-93.29851,Rice County,county
+iso1:us#iso2:us-mo#fips:29219,29219,29,29,Warren,428.62185999999997,38.7619,-91.15930999999999,Warren County,county
+iso1:us#iso2:us-ky#fips:21227,21227,21,21,Warren,541.73834,36.995632,-86.42358,Warren County,county
+iso1:us#iso2:us-la#fips:22017,22017,22,22,Caddo Parish,879.0971699999999,32.577194,-93.88242,Caddo Parish,county
+iso1:us#iso2:us-sd#fips:46121,46121,46,46,Todd,1388.6427,43.208794,-100.70766400000001,Todd County,county
+iso1:us#iso2:us-ia#fips:19127,19127,19,19,Marshall,572.5225,42.04169,-92.98145,Marshall County,county
+iso1:us#iso2:us-ok#fips:40141,40141,40,40,Tillman,871.1637599999999,34.371086,-98.9317,Tillman County,county
+iso1:us#iso2:us-nc#fips:37113,37113,37,37,Macon,515.5969,35.152958,-83.4219,Macon County,county
+iso1:us#iso2:us-wv#fips:54063,54063,54,54,Monroe,472.7699,37.55406,-80.55033,Monroe County,county
+iso1:us#iso2:us-in#fips:18155,18155,18,18,Switzerland,220.67485,38.825855,-85.02968,Switzerland County,county
+iso1:us#iso2:us-ky#fips:21105,21105,21,21,Hickman,242.2827,36.675896,-88.972084,Hickman County,county
+iso1:us#iso2:us-al#fips:01061,1061,1,1,Geneva,574.50006,31.092382,-85.82101999999999,Geneva County,county
+iso1:us#iso2:us-il#fips:17099,17099,17,17,LaSalle,1135.2063,41.343340000000005,-88.88593,LaSalle County,county
+iso1:us#iso2:us-ia#fips:19055,19055,19,19,Delaware,577.70154,42.47294,-91.36676999999999,Delaware County,county
+iso1:us#iso2:us-ks#fips:20127,20127,20,20,Morris,695.36633,38.688206,-96.65145,Morris County,county
+iso1:us#iso2:us-ia#fips:19051,19051,19,19,Davis,502.20544,40.748090000000005,-92.41035,Davis County,county
+iso1:us#iso2:us-id#fips:16015,16015,16,16,Boise,1899.6202,43.987274,-115.71511000000001,Boise County,county
+iso1:us#iso2:us-wi#fips:55081,55081,55,55,Monroe,900.93427,43.945175,-90.61997,Monroe County,county
+iso1:us#iso2:us-nc#fips:37143,37143,37,37,Perquimans,247.17917999999997,36.180896999999995,-76.403244,Perquimans County,county
+iso1:us#iso2:us-fl#fips:12047,12047,12,12,Hamilton,513.7996,30.491186,-82.95107,Hamilton County,county
+iso1:us#iso2:us-ak#fips:02170,2170,2,2,Matanuska-Susitna Borough,24714.955,62.279095,-149.6191,Matanuska-Susitna Borough,county
+iso1:us#iso2:us-in#fips:18035,18035,18,18,Delaware,392.11407,40.227543,-85.39926,Delaware County,county
+iso1:us#iso2:us-fl#fips:12075,12075,12,12,Levy,1118.2605,29.284456,-82.78345999999999,Levy County,county
+iso1:us#iso2:us-pr#fips:72063,72063,72,72,Gurabo Municipio,27.885738,18.272581,-65.98118000000001,Gurabo Municipio,county
+iso1:us#iso2:us-pr#fips:72065,72065,72,72,Hatillo Municipio,41.777924,18.441141000000002,-66.79821,Hatillo Municipio,county
+iso1:us#iso2:us-ms#fips:28045,28045,28,28,Hancock,473.9802,30.391641999999997,-89.48279000000001,Hancock County,county
+iso1:us#iso2:us-ga#fips:13315,13315,13,13,Wilcox,377.8236,31.962719,-83.438255,Wilcox County,county
+iso1:us#iso2:us-la#fips:22081,22081,22,22,Red River Parish,389.10497999999995,32.101209999999995,-93.34905,Red River Parish,county
+iso1:us#iso2:us-tn#fips:47093,47093,47,47,Knox,508.3435,35.992725,-83.93772,Knox County,county
+iso1:us#iso2:us-me#fips:23017,23017,23,23,Oxford,2077.024,44.4945,-70.73442,Oxford County,county
+iso1:us#iso2:us-mo#fips:29095,29095,29,29,Jackson,604.5368,39.005337,-94.34316,Jackson County,county
+iso1:us#iso2:us-ga#fips:13281,13281,13,13,Towns,166.4696,34.90253,-83.73226,Towns County,county
+iso1:us#iso2:us-ms#fips:28129,28129,28,28,Smith,636.2895,32.019028000000006,-89.49486999999999,Smith County,county
+iso1:us#iso2:us-id#fips:16075,16075,16,16,Payette,406.90612999999996,44.00243,-116.75023999999999,Payette County,county
+iso1:us#iso2:us-id#fips:16079,16079,16,16,Shoshone,2637.5144,47.347694,-115.88508999999999,Shoshone County,county
+iso1:us#iso2:us-nc#fips:37095,37095,37,37,Hyde,612.3661,35.408157,-76.15369,Hyde County,county
+iso1:us#iso2:us-ia#fips:19067,19067,19,19,Floyd,500.61782999999997,43.052741999999995,-92.78737,Floyd County,county
+iso1:us#iso2:us-ky#fips:21145,21145,21,21,McCracken,248.73192000000003,37.054109999999994,-88.712456,McCracken County,county
+iso1:us#iso2:us-ky#fips:21225,21225,21,21,Union,342.8676,37.658028,-87.95165,Union County,county
+iso1:us#iso2:us-sd#fips:46125,46125,46,46,Turner,617.085,43.30867,-97.150185,Turner County,county
+iso1:us#iso2:us-tn#fips:47029,47029,47,47,Cocke,436.14987,35.9162,-83.119225,Cocke County,county
+iso1:us#iso2:us-tn#fips:47067,47067,47,47,Hancock,222.3314,36.521355,-83.22749,Hancock County,county
+iso1:us#iso2:us-tn#fips:47071,47071,47,47,Hardin,577.3478,35.201893,-88.1857,Hardin County,county
+iso1:us#iso2:us-sc#fips:45067,45067,45,45,Marion,489.27472,34.08362,-79.354004,Marion County,county
+iso1:us#iso2:us-pr#fips:72057,72057,72,72,Guayama Municipio,64.990616,17.973928,-66.13747,Guayama Municipio,county
+iso1:us#iso2:us-la#fips:22117,22117,22,22,Washington Parish,669.6187,30.852144,-90.04626,Washington Parish,county
+iso1:us#iso2:us-mo#fips:29207,29207,29,29,Stoddard,823.2459,36.851555,-89.94748,Stoddard County,county
+iso1:us#iso2:us-ga#fips:13093,13093,13,13,Dooly,392.64398,32.151996999999994,-83.80717,Dooly County,county
+iso1:us#iso2:us-mn#fips:27145,27145,27,27,Stearns,1342.8424,45.555233,-94.61048000000001,Stearns County,county
+iso1:us#iso2:us-ne#fips:31155,31155,31,31,Saunders,749.3158,41.22339,-96.6421,Saunders County,county
+iso1:us#iso2:us-mn#fips:27141,27141,27,27,Sherburne,432.9242,45.453175,-93.76913,Sherburne County,county
+iso1:us#iso2:us-sd#fips:46035,46035,46,46,Davison,435.64807,43.680440000000004,-98.15587,Davison County,county
+iso1:us#iso2:us-tn#fips:47025,47025,47,47,Claiborne,434.61492999999996,36.50157,-83.6607,Claiborne County,county
+iso1:us#iso2:us-tx#fips:48337,48337,48,48,Montague,930.9373,33.678356,-97.72501,Montague County,county
+iso1:us#iso2:us-tx#fips:48049,48049,48,48,Brown,944.4844400000001,31.764136999999998,-98.99846,Brown County,county
+iso1:us#iso2:us-wi#fips:55101,55101,55,55,Racine,332.60098,42.75412,-87.420876,Racine County,county
+iso1:us#iso2:us-wi#fips:55115,55115,55,55,Shawano,893.25525,44.789642,-88.75581,Shawano County,county
+iso1:us#iso2:us-ia#fips:19009,19009,19,19,Audubon,442.9764,41.679176,-94.90431,Audubon County,county
+iso1:us#iso2:us-tx#fips:48207,48207,48,48,Haskell,903.1637599999999,33.175964,-99.730774,Haskell County,county
+iso1:us#iso2:us-ok#fips:40083,40083,40,40,Logan,743.8676,35.91415,-97.45076999999999,Logan County,county
+iso1:us#iso2:us-ny#fips:36065,36065,36,36,Oneida,1212.3718,43.24273,-75.43428,Oneida County,county
+iso1:us#iso2:us-co#fips:08065,8065,8,8,Lake,376.9319,39.20534,-106.35008,Lake County,county
+iso1:us#iso2:us-ok#fips:40121,40121,40,40,Pittsburg,1305.5643,34.925540000000005,-95.74813,Pittsburg County,county
+iso1:us#iso2:us-wv#fips:54017,54017,54,54,Doddridge,319.73373,39.26348,-80.70123000000001,Doddridge County,county
+iso1:us#iso2:us-wv#fips:54105,54105,54,54,Wirt,232.51904,39.020035,-81.38297,Wirt County,county
+iso1:us#iso2:us-nh#fips:33003,33003,33,33,Carroll,931.8936,43.867775,-71.20156,Carroll County,county
+iso1:us#iso2:us-wv#fips:54095,54095,54,54,Tyler,256.3105,39.465633000000004,-80.87722,Tyler County,county
+iso1:us#iso2:us-mp:#fips:69085,69085,69,69,Northern Islands Municipality,61.804367000000006,16.028783999999998,146.002,Northern Islands Municipality,county
+iso1:us#iso2:us-mn#fips:27079,27079,27,27,Le Sueur,448.6852,44.373425,-93.73014,Le Sueur County,county
+iso1:us#iso2:us-wa#fips:53017,53017,53,53,Douglas,1819.325,47.741764,-119.69462,Douglas County,county
+iso1:us#iso2:us-ny#fips:36009,36009,36,36,Cattaraugus,1308.3225,42.239098,-78.66233000000001,Cattaraugus County,county
+iso1:us#iso2:us-wi#fips:55027,55027,55,55,Dodge,875.72687,43.429626,-88.70194000000001,Dodge County,county
+iso1:us#iso2:us-ia#fips:19105,19105,19,19,Jones,575.6379400000001,42.12512,-91.11691,Jones County,county
+iso1:us#iso2:us-ks#fips:20007,20007,20,20,Barber,1134.1136,37.222904,-98.68505,Barber County,county
+iso1:us#iso2:us-mo#fips:29169,29169,29,29,Pulaski,547.1304299999999,37.824833,-92.20702,Pulaski County,county
+iso1:us#iso2:us-al#fips:01045,1045,1,1,Dale,561.11993,31.430654999999998,-85.609474,Dale County,county
+iso1:us#iso2:us-ks#fips:20109,20109,20,20,Logan,1073.0298,38.913270000000004,-101.1574,Logan County,county
+iso1:us#iso2:us-ca#fips:06039,6039,6,6,Madera,2137.0005,37.20982,-119.7498,Madera County,county
+iso1:us#iso2:us-mo#fips:29075,29075,29,29,Gentry,491.43857,40.208126,-94.40531999999999,Gentry County,county
+iso1:us#iso2:us-ne#fips:31009,31009,31,31,Blaine,710.7124,41.931946,-99.99641,Blaine County,county
+iso1:us#iso2:us-ut#fips:49009,49009,49,49,Daggett,697.0099,40.8901,-109.50578,Daggett County,county
+iso1:us#iso2:us-wy#fips:56031,56031,56,56,Platte,2081.5193,42.13159,-104.95396399999998,Platte County,county
+iso1:us#iso2:us-nc#fips:37071,37071,37,37,Gaston,355.76132,35.293343,-81.17725,Gaston County,county
+iso1:us#iso2:us-nm#fips:35019,35019,35,35,Guadalupe,3029.8745,34.86978,-104.784966,Guadalupe County,county
+iso1:us#iso2:us-mt#fips:30037,30037,30,30,Golden Valley,1174.4625,46.380623,-109.17458,Golden Valley County,county
+iso1:us#iso2:us-nc#fips:37101,37101,37,37,Johnston,791.2477,35.51342,-78.36735,Johnston County,county
+iso1:us#iso2:us-ca#fips:06085,6085,6,6,Santa Clara,1291.1274,37.220695,-121.690506,Santa Clara County,county
+iso1:us#iso2:us-sc#fips:45019,45019,45,45,Charleston,917.9749,32.800457,-79.94248,Charleston County,county
+iso1:us#iso2:us-wa#fips:53005,53005,53,53,Benton,1700.1547,46.228127,-119.51666000000002,Benton County,county
+iso1:us#iso2:us-mo#fips:29001,29001,29,29,Adair,567.3431400000001,40.190666,-92.60359,Adair County,county
+iso1:us#iso2:us-oh#fips:39043,39043,39,39,Erie,251.3879,41.554005,-82.525894,Erie County,county
+iso1:us#iso2:us-il#fips:17183,17183,17,17,Vermilion,898.3493,40.186752,-87.726776,Vermilion County,county
+iso1:us#iso2:us-mo#fips:29189,29189,29,29,St. Louis,507.45715,38.64069,-90.446075,St. Louis County,county
+iso1:us#iso2:us-il#fips:17007,17007,17,17,Boone,280.77557,42.318985,-88.82429499999999,Boone County,county
+iso1:us#iso2:us-ca#fips:06103,6103,6,6,Tehama,2949.237,40.126156,-122.23228,Tehama County,county
+iso1:us#iso2:us-wi#fips:55025,55025,55,55,Dane,1196.5261,43.067467,-89.417854,Dane County,county
+iso1:us#iso2:us-tx#fips:48151,48151,48,48,Fisher,898.98145,32.740475,-100.40312,Fisher County,county
+iso1:us#iso2:us-la#fips:22085,22085,22,22,Sabine Parish,866.68854,31.560402000000003,-93.55958000000001,Sabine Parish,county
+iso1:us#iso2:us-il#fips:17137,17137,17,17,Morgan,568.9733,39.717667,-90.205,Morgan County,county
+iso1:us#iso2:us-ga#fips:13235,13235,13,13,Pulaski,249.26984,32.238803999999995,-83.48184,Pulaski County,county
+iso1:us#iso2:us-nc#fips:37015,37015,37,37,Bertie,699.2002,36.059044,-76.96236400000001,Bertie County,county
+iso1:us#iso2:us-nc#fips:37167,37167,37,37,Stanly,395.1468,35.310448,-80.25437,Stanly County,county
+iso1:us#iso2:us-tn#fips:47143,47143,47,47,Rhea,315.39365,35.600590000000004,-84.94955,Rhea County,county
+iso1:us#iso2:us-nc#fips:37079,37079,37,37,Greene,266.74374,35.48196,-77.68169,Greene County,county
+iso1:us#iso2:us-ky#fips:21131,21131,21,21,Leslie,400.86722000000003,37.087845,-83.38861999999999,Leslie County,county
+iso1:us#iso2:us-md#fips:24039,24039,24,24,Somerset,319.75955,38.07445,-75.853325,Somerset County,county
+iso1:us#iso2:us-il#fips:17123,17123,17,17,Marshall,386.827,41.03112,-89.34236999999999,Marshall County,county
+iso1:us#iso2:us-ky#fips:21143,21143,21,21,Lyon,213.84942999999998,37.023975,-88.08339000000001,Lyon County,county
+iso1:us#iso2:us-tx#fips:48095,48095,48,48,Concho,983.7886,31.318884000000004,-99.86365,Concho County,county
+iso1:us#iso2:us-tx#fips:48081,48081,48,48,Coke,911.6773699999999,31.87711,-100.63523,Coke County,county
+iso1:us#iso2:us-tn#fips:47133,47133,47,47,Overton,433.49994000000004,36.34485,-85.28307,Overton County,county
+iso1:us#iso2:us-mi#fips:26063,26063,26,26,Huron,836.0498,43.907616,-82.85705,Huron County,county
+iso1:us#iso2:us-mi#fips:26069,26069,26,26,Iosco,549.12305,44.329483,-82.84944,Iosco County,county
+iso1:us#iso2:us-ga#fips:13069,13069,13,13,Coffee,592.2734,31.549246000000004,-82.84494000000001,Coffee County,county
+iso1:us#iso2:us-ga#fips:13299,13299,13,13,Ware,899.2551,31.05088,-82.42151,Ware County,county
+iso1:us#iso2:us-nd#fips:38037,38037,38,38,Grant,1659.2894,46.357826,-101.639046,Grant County,county
+iso1:us#iso2:us-la#fips:22051,22051,22,22,Jefferson Parish,295.70624,29.522282,-90.081,Jefferson Parish,county
+iso1:us#iso2:us-la#fips:22103,22103,22,22,St. Tammany Parish,845.22705,30.410023,-89.951965,St. Tammany Parish,county
+iso1:us#iso2:us-ia#fips:19083,19083,19,19,Hardin,569.3290000000001,42.390209999999996,-93.24167,Hardin County,county
+iso1:us#iso2:us-la#fips:22023,22023,22,22,Cameron Parish,1284.913,29.871813,-93.16495,Cameron Parish,county
+iso1:us#iso2:us-oh#fips:39027,39027,39,39,Clinton,408.6988,39.430225,-83.79568499999999,Clinton County,county
+iso1:us#iso2:us-mn#fips:27137,27137,27,27,St. Louis,6247.53,47.578635999999996,-92.51456999999999,St. Louis County,county
+iso1:us#iso2:us-oh#fips:39093,39093,39,39,Lorain,491.21414000000004,41.438805,-82.179726,Lorain County,county
+iso1:us#iso2:us-pr#fips:72143,72143,72,72,Vega Alta Municipio,27.729364,18.436163,-66.33667,Vega Alta Municipio,county
+iso1:us#iso2:us-ia#fips:19015,19015,19,19,Boone,571.5776400000001,42.038643,-93.938354,Boone County,county
+iso1:us#iso2:us-tx#fips:48373,48373,48,48,Polk,1057.0807,30.784552,-94.83734,Polk County,county
+iso1:us#iso2:us-ne#fips:31051,31051,31,31,Dixon,476.1265,42.485279999999996,-96.85585999999999,Dixon County,county
+iso1:us#iso2:us-md#fips:24025,24025,24,24,Harford,437.13968,39.53743,-76.29979,Harford County,county
+iso1:us#iso2:us-sc#fips:45037,45037,45,45,Edgefield,500.76324000000005,33.776497,-81.96825,Edgefield County,county
+iso1:us#iso2:us-va#fips:51001,51001,51,51,Accomack,449.32562,37.76594,-75.757805,Accomack County,county
+iso1:us#iso2:us-wi#fips:55015,55015,55,55,Calumet,318.29193,44.07841,-88.212135,Calumet County,county
+iso1:us#iso2:us-ky#fips:21121,21121,21,21,Knox,386.3173,36.8885,-83.85555,Knox County,county
+iso1:us#iso2:us-mi#fips:26067,26067,26,26,Ionia,571.339,42.94465,-85.07377,Ionia County,county
+iso1:us#iso2:us-nc#fips:37129,37129,37,37,New Hanover,192.25746,34.183440000000004,-77.86421,New Hanover County,county
+iso1:us#iso2:us-tn#fips:47131,47131,47,47,Obion,544.8659700000001,36.357994,-89.150024,Obion County,county
+iso1:us#iso2:us-ky#fips:21035,21035,21,21,Calloway,385.04355,36.620979999999996,-88.274086,Calloway County,county
+iso1:us#iso2:us-va#fips:51003,51003,51,51,Albemarle,720.49414,38.024184999999996,-78.553505,Albemarle County,county
+iso1:us#iso2:us-tn#fips:47147,47147,47,47,Robertson,476.33047,36.527508000000005,-86.869354,Robertson County,county
+iso1:us#iso2:us-va#fips:51043,51043,51,51,Clarke,175.9389,39.115307,-77.990746,Clarke County,county
+iso1:us#iso2:us-wa#fips:53023,53023,53,53,Garfield,710.8594400000001,46.429478,-117.53671000000001,Garfield County,county
+iso1:us#iso2:us-ky#fips:21109,21109,21,21,Jackson,345.2069,37.403458,-84.02058000000001,Jackson County,county
+iso1:us#iso2:us-mn#fips:27031,27031,27,27,Cook,1452.6177,47.53857,-90.29019,Cook County,county
+iso1:us#iso2:us-sc#fips:45073,45073,45,45,Oconee,626.5392,34.748764,-83.06154000000001,Oconee County,county
+iso1:us#iso2:us-la#fips:22033,22033,22,22,East Baton Rouge Parish,455.40775,30.54393,-91.09313,East Baton Rouge Parish,county
+iso1:us#iso2:us-ms#fips:28021,28021,28,28,Claiborne,487.43195,31.972809,-90.91542,Claiborne County,county
+iso1:us#iso2:us-md#fips:24037,24037,24,24,St. Mary's,358.70932,38.220290000000006,-76.53038000000001,St. Mary's County,county
+iso1:us#iso2:us-mi#fips:26081,26081,26,26,Kent,848.904,43.032497,-85.54745,Kent County,county
+iso1:us#iso2:us-nc#fips:37147,37147,37,37,Pitt,652.3917,35.592490000000005,-77.37274000000001,Pitt County,county
+iso1:us#iso2:us-mt#fips:30009,30009,30,30,Carbon,2047.7743,45.224470000000004,-109.02856000000001,Carbon County,county
+iso1:us#iso2:us-ne#fips:31167,31167,31,31,Stanton,427.62296,41.905045,-97.17711,Stanton County,county
+iso1:us#iso2:us-ga#fips:13001,13001,13,13,Appling,508.29117,31.739712,-82.2901,Appling County,county
+iso1:us#iso2:us-ia#fips:19099,19099,19,19,Jasper,730.4378,41.68555,-93.054146,Jasper County,county
+iso1:us#iso2:us-ms#fips:28153,28153,28,28,Wayne,810.7439,31.642504,-88.67821500000001,Wayne County,county
+iso1:us#iso2:us-tx#fips:48101,48101,48,48,Cottle,900.5941,34.091908000000004,-100.27644000000001,Cottle County,county
+iso1:us#iso2:us-va#fips:51081,51081,51,51,Greensville,295.2371,36.680336,-77.56028,Greensville County,county
+iso1:us#iso2:us-fl#fips:12105,12105,12,12,Polk,1797.5999,27.95365,-81.693535,Polk County,county
+iso1:us#iso2:us-tx#fips:48503,48503,48,48,Young,914.5294,33.15878,-98.67839000000001,Young County,county
+iso1:us#iso2:us-al#fips:01123,1123,1,1,Tallapoosa,716.54614,32.863308,-85.799614,Tallapoosa County,county
+iso1:us#iso2:us-nh#fips:33015,33015,33,33,Rockingham,695.4101,42.988663,-71.09908,Rockingham County,county
+iso1:us#iso2:us-co#fips:08105,8105,8,8,Rio Grande,911.9873699999999,37.485855,-106.453125,Rio Grande County,county
+iso1:us#iso2:us-ia#fips:19149,19149,19,19,Plymouth,862.8577,42.737587,-96.215866,Plymouth County,county
+iso1:us#iso2:us-ny#fips:36123,36123,36,36,Yates,338.16033999999996,42.638237,-77.104324,Yates County,county
+iso1:us#iso2:us-wa#fips:53033,53033,53,53,King,2115.3547,47.4906,-121.834,King County,county
+iso1:us#iso2:us-or#fips:41017,41017,41,41,Deschutes,3017.719,43.91512,-121.22558000000001,Deschutes County,county
+iso1:us#iso2:us-ia#fips:19155,19155,19,19,Pottawattamie,950.5432,41.340183,-95.54491,Pottawattamie County,county
+iso1:us#iso2:us-mo#fips:29229,29229,29,29,Wright,681.79785,37.26763,-92.47999,Wright County,county
+iso1:us#iso2:us-mt#fips:30101,30101,30,30,Toole,1915.0812,48.645126,-111.733475,Toole County,county
+iso1:us#iso2:us-ny#fips:36107,36107,36,36,Tioga,518.6279,42.178055,-76.297455,Tioga County,county
+iso1:us#iso2:us-tx#fips:48287,48287,48,48,Lee,629.04297,30.321499,-96.97681999999999,Lee County,county
+iso1:us#iso2:us-ga#fips:13121,13121,13,13,Fulton,526.7417,33.790034999999996,-84.46818,Fulton County,county
+iso1:us#iso2:us-tx#fips:48073,48073,48,48,Cherokee,1052.9911,31.843882,-95.15634,Cherokee County,county
+iso1:us#iso2:us-mo#fips:29007,29007,29,29,Audrain,692.2684,39.21448,-91.84342,Audrain County,county
+iso1:us#iso2:us-sc#fips:45029,45029,45,45,Colleton,1056.5164,32.83502,-80.65524,Colleton County,county
+iso1:us#iso2:us-wi#fips:55055,55055,55,55,Jefferson,556.5103,43.013805,-88.77399,Jefferson County,county
+iso1:us#iso2:us-ar#fips:05055,5055,5,5,Greene,577.70795,36.120605,-90.566345,Greene County,county
+iso1:us#iso2:us-tx#fips:48191,48191,48,48,Hall,883.5219999999999,34.655623999999996,-100.76389,Hall County,county
+iso1:us#iso2:us-wi#fips:55013,55013,55,55,Burnett,821.5888,45.866898,-92.37573,Burnett County,county
+iso1:us#iso2:us-nm#fips:35057,35057,35,35,Torrance,3345.3267,34.554977,-105.89056000000001,Torrance County,county
+iso1:us#iso2:us-wa#fips:53049,53049,53,53,Pacific,933.6411,46.556587,-123.78242,Pacific County,county
+iso1:us#iso2:us-nc#fips:37141,37141,37,37,Pender,871.32526,34.512558,-77.88811,Pender County,county
+iso1:us#iso2:us-tx#fips:48221,48221,48,48,Hood,420.7229,32.43015,-97.83168,Hood County,county
+iso1:us#iso2:us-sd#fips:46117,46117,46,46,Stanley,1444.4807,44.415546,-100.74916,Stanley County,county
+iso1:us#iso2:us-nv#fips:32031,32031,32,32,Washoe,6316.375,40.731320000000004,-119.66327,Washoe County,county
+iso1:us#iso2:us-ky#fips:21007,21007,21,21,Ballard,246.87727,37.051323,-89.01037,Ballard County,county
+iso1:us#iso2:us-tx#fips:48009,48009,48,48,Archer,903.3199,33.616306,-98.68726,Archer County,county
+iso1:us#iso2:us-tx#fips:48023,48023,48,48,Baylor,867.5102,33.6188,-99.20819,Baylor County,county
+iso1:us#iso2:us-tx#fips:48405,48405,48,48,San Augustine,530.675,31.38245,-94.16318000000001,San Augustine County,county
+iso1:us#iso2:us-nv#fips:32029,32029,32,32,Storey,263.9796,39.438385,-119.52463999999999,Storey County,county
+iso1:us#iso2:us-ga#fips:13249,13249,13,13,Schley,166.91425,32.263443,-84.32271,Schley County,county
+iso1:us#iso2:us-ct#fips:09001,9001,9,9,Fairfield,624.9892,41.227413,-73.36706,Fairfield County,county
+iso1:us#iso2:us-tx#fips:48313,48313,48,48,Madison,466.08112,30.966879,-95.930374,Madison County,county
+iso1:us#iso2:us-ca#fips:06077,6077,6,6,San Joaquin,1392.3811,37.934982,-121.27225,San Joaquin County,county
+iso1:us#iso2:us-ms#fips:28159,28159,28,28,Winston,607.2718,33.078724,-89.03739,Winston County,county
+iso1:us#iso2:us-ky#fips:21103,21103,21,21,Henry,286.3046,38.45138,-85.119644,Henry County,county
+iso1:us#iso2:us-ky#fips:21167,21167,21,21,Mercer,249.0698,37.812084000000006,-84.87969,Mercer County,county
+iso1:us#iso2:us-ne#fips:31183,31183,31,31,Wheeler,575.2029,41.922573,-98.52085,Wheeler County,county
+iso1:us#iso2:us-ky#fips:21135,21135,21,21,Lewis,482.85593,38.535046,-83.37014,Lewis County,county
+iso1:us#iso2:us-mn#fips:27051,27051,27,27,Grant,547.8149400000001,45.930744,-96.0107,Grant County,county
+iso1:us#iso2:us-ms#fips:28053,28053,28,28,Humphreys,418.52862999999996,33.130997,-90.52342,Humphreys County,county
+iso1:us#iso2:us-al#fips:01025,1025,1,1,Clarke,1238.4625,31.68552,-87.81863,Clarke County,county
+iso1:us#iso2:us-ks#fips:20017,20017,20,20,Chase,773.0798,38.299477,-96.59403,Chase County,county
+iso1:us#iso2:us-ky#fips:21221,21221,21,21,Trigg,441.57599999999996,36.807682,-87.85865,Trigg County,county
+iso1:us#iso2:us-al#fips:01069,1069,1,1,Houston,579.8755,31.158184000000002,-85.29641,Houston County,county
+iso1:us#iso2:us-sd#fips:46003,46003,46,46,Aurora,708.4841,43.72472,-98.57759,Aurora County,county
+iso1:us#iso2:us-ak#fips:02013,2013,2,2,Aleutians East Borough,6985.406,55.245045,-161.99748,Aleutians East Borough,county
+iso1:us#iso2:us-ne#fips:31061,31061,31,31,Franklin,575.8353,40.183205,-98.96208,Franklin County,county
+iso1:us#iso2:us-md#fips:24029,24029,24,24,Kent,277.04407000000003,39.241279999999996,-76.125984,Kent County,county
+iso1:us#iso2:us-ks#fips:20037,20037,20,20,Crawford,589.7905,37.50582,-94.8539,Crawford County,county
+iso1:us#iso2:us-mn#fips:27023,27023,27,27,Chippewa,581.2040400000001,45.028625,-95.56411,Chippewa County,county
+iso1:us#iso2:us-sd#fips:46103,46103,46,46,Pennington,2776.8596,44.00235,-102.8238,Pennington County,county
+iso1:us#iso2:us-sc#fips:45049,45049,45,45,Hampton,559.9937,32.778335999999996,-81.14381999999999,Hampton County,county
+iso1:us#iso2:us-id#fips:16043,16043,16,16,Fremont,1864.023,44.218090000000004,-111.48443,Fremont County,county
+iso1:us#iso2:us-ga#fips:13029,13029,13,13,Bryan,437.56244000000004,32.01797,-81.43854499999999,Bryan County,county
+iso1:us#iso2:us-va#fips:51053,51053,51,51,Dinwiddie,503.90128,37.073498,-77.63549,Dinwiddie County,county
+iso1:us#iso2:us-fl#fips:12111,12111,12,12,St. Lucie,571.67,27.379814,-80.443535,St. Lucie County,county
+iso1:us#iso2:us-ny#fips:36055,36055,36,36,Monroe,656.89026,43.464484999999996,-77.66466,Monroe County,county
+iso1:us#iso2:us-sd#fips:46083,46083,46,46,Lincoln,577.3127,43.27942,-96.72228,Lincoln County,county
+iso1:us#iso2:us-wi#fips:55017,55017,55,55,Chippewa,1008.3897,45.06909,-91.28350999999999,Chippewa County,county
+iso1:us#iso2:us-ks#fips:20207,20207,20,20,Woodson,497.83557,37.88819,-95.75846999999999,Woodson County,county
+iso1:us#iso2:us-ky#fips:21157,21157,21,21,Marshall,302.21555,36.882015,-88.332756,Marshall County,county
+iso1:us#iso2:us-ga#fips:13065,13065,13,13,Clinch,815.02344,30.917654,-82.702614,Clinch County,county
+iso1:us#iso2:us-ga#fips:13185,13185,13,13,Lowndes,497.17602999999997,30.833145000000002,-83.26899999999999,Lowndes County,county
+iso1:us#iso2:us-hi#fips:15005,15005,15,15,Kalawao,11.991816,21.218764999999998,-156.97401000000002,Kalawao County,county
+iso1:us#iso2:us-hi#fips:15007,15007,15,15,Kauai,619.90515,22.01204,-159.70596,Kauai County,county
+iso1:us#iso2:us-mi#fips:26099,26099,26,26,Macomb,479.1886,42.67155,-82.91145,Macomb County,county
+iso1:us#iso2:us-ga#fips:13287,13287,13,13,Turner,285.425,31.7248,-83.62031999999999,Turner County,county
+iso1:us#iso2:us-il#fips:17079,17079,17,17,Jasper,494.63055,39.004875,-88.150764,Jasper County,county
+iso1:us#iso2:us-tx#fips:48331,48331,48,48,Milam,1016.9566,30.791242999999998,-96.9844,Milam County,county
+iso1:us#iso2:us-in#fips:18147,18147,18,18,Spencer,396.78125,38.009696999999996,-87.01037600000001,Spencer County,county
+iso1:us#iso2:us-ky#fips:21099,21099,21,21,Hart,412.57583999999997,37.309096999999994,-85.882126,Hart County,county
+iso1:us#iso2:us-ky#fips:21137,21137,21,21,Lincoln,332.8546,37.457172,-84.65833,Lincoln County,county
+iso1:us#iso2:us-mt#fips:30005,30005,30,30,Blaine,4227.266,48.428284000000005,-108.96763999999999,Blaine County,county
+iso1:us#iso2:us-va#fips:51710,51710,51,51,Norfolk city,53.276737,36.923016,-76.244644,Norfolk city,county
+iso1:us#iso2:us-tx#fips:48389,48389,48,48,Reeves,2635.4429999999998,31.308366999999997,-103.71271,Reeves County,county
+iso1:us#iso2:us-va#fips:51155,51155,51,51,Pulaski,319.84902999999997,37.063385,-80.71345,Pulaski County,county
+iso1:us#iso2:us-nc#fips:37179,37179,37,37,Union,632.7448,34.991820000000004,-80.530426,Union County,county
+iso1:us#iso2:us-nd#fips:38053,38053,38,38,McKenzie,2760.2273,47.742474,-103.40321,McKenzie County,county
+iso1:us#iso2:us-fl#fips:12091,12091,12,12,Okaloosa,930.2568,30.665852,-86.594185,Okaloosa County,county
+iso1:us#iso2:us-ca#fips:06001,6001,6,6,Alameda,737.3315,37.647137,-121.91248999999999,Alameda County,county
+iso1:us#iso2:us-il#fips:17013,17013,17,17,Calhoun,253.84085,39.16426,-90.6663,Calhoun County,county
+iso1:us#iso2:us-in#fips:18085,18085,18,18,Kosciusko,531.4538,41.244293,-85.86157,Kosciusko County,county
+iso1:us#iso2:us-ms#fips:28103,28103,28,28,Noxubee,695.182,33.106506,-88.566,Noxubee County,county
+iso1:us#iso2:us-ar#fips:05147,5147,5,5,Woodruff,586.8063400000001,35.192776,-91.24454,Woodruff County,county
+iso1:us#iso2:us-nj#fips:34015,34015,34,34,Gloucester,321.98776000000004,39.722874,-75.145676,Gloucester County,county
+iso1:us#iso2:us-nh#fips:33011,33011,33,33,Hillsborough,876.558,42.911533,-71.72305,Hillsborough County,county
+iso1:us#iso2:us-mt#fips:30045,30045,30,30,Judith Basin,1869.7505,47.03256,-110.30532,Judith Basin County,county
+iso1:us#iso2:us-nc#fips:37121,37121,37,37,Mitchell,221.25806,36.013103,-82.16355,Mitchell County,county
+iso1:us#iso2:us-mt#fips:30077,30077,30,30,Powell,2326.121,46.844227000000004,-112.9311,Powell County,county
+iso1:us#iso2:us-or#fips:41053,41053,41,41,Polk,740.9488,44.900375,-123.398674,Polk County,county
+iso1:us#iso2:us-or#fips:41065,41065,41,41,Wasco,2381.2163,45.164536,-121.16507,Wasco County,county
+iso1:us#iso2:us-sd#fips:46105,46105,46,46,Perkins,2870.5576,45.483387,-102.467995,Perkins County,county
+iso1:us#iso2:us-ia#fips:19173,19173,19,19,Taylor,531.91974,40.73795,-94.69710500000001,Taylor County,county
+iso1:us#iso2:us-al#fips:01129,1129,1,1,Washington,1080.2426,31.405217999999998,-88.19756,Washington County,county
+iso1:us#iso2:us-oh#fips:39039,39039,39,39,Defiance,411.4637,41.32168,-84.486435,Defiance County,county
+iso1:us#iso2:us-wv#fips:54025,54025,54,54,Greenbrier,1019.84766,37.92442,-80.45059,Greenbrier County,county
+iso1:us#iso2:us-il#fips:17121,17121,17,17,Marion,572.5570700000001,38.648235,-88.920364,Marion County,county
+iso1:us#iso2:us-va#fips:51051,51051,51,51,Dickenson,330.4618,37.1367,-82.34921999999999,Dickenson County,county
+iso1:us#iso2:us-va#fips:51007,51007,51,51,Amelia,355.37253,37.33193,-77.97746,Amelia County,county
+iso1:us#iso2:us-ga#fips:13243,13243,13,13,Randolph,428.2506,31.762651,-84.75231,Randolph County,county
+iso1:us#iso2:us-nm#fips:35029,35029,35,35,Luna,2965.2793,32.184525,-107.74718999999999,Luna County,county
+iso1:us#iso2:us-tx#fips:48355,48355,48,48,Nueces,838.3246,27.740032,-97.51621,Nueces County,county
+iso1:us#iso2:us-wy#fips:56045,56045,56,56,Weston,2398.0864,43.846214,-104.57002,Weston County,county
+iso1:us#iso2:us-pr#fips:72137,72137,72,72,Toa Baja Municipio,23.244795,18.45691,-66.19319,Toa Baja Municipio,county
+iso1:us#iso2:us-il#fips:17187,17187,17,17,Warren,542.4025,40.85044,-90.620224,Warren County,county
+iso1:us#iso2:us-al#fips:01089,1089,1,1,Madison,801.6186,34.764236,-86.55108,Madison County,county
+iso1:us#iso2:us-tn#fips:47189,47189,47,47,Wilson,571.10724,36.14953,-86.29124499999999,Wilson County,county
+iso1:us#iso2:us-tx#fips:48063,48063,48,48,Camp,195.85428000000002,32.974583,-94.97909,Camp County,county
+iso1:us#iso2:us-ok#fips:40067,40067,40,40,Jefferson,758.98145,34.105083,-97.83889,Jefferson County,county
+iso1:us#iso2:us-wv#fips:54085,54085,54,54,Ritchie,452.00543,39.177113,-81.066315,Ritchie County,county
+iso1:us#iso2:us-ia#fips:19145,19145,19,19,Page,534.9618,40.739090000000004,-95.14429,Page County,county
+iso1:us#iso2:us-ks#fips:20087,20087,20,20,Jefferson,532.5885,39.239643,-95.37531,Jefferson County,county
+iso1:us#iso2:us-la#fips:22045,22045,22,22,Iberia Parish,574.11285,30.007126,-91.97678,Iberia Parish,county
+iso1:us#iso2:us-ak#fips:02158,2158,2,2,Kusilvak Census Area,17074.797,62.283590000000004,-163.19017,Kusilvak Census Area,county
+iso1:us#iso2:us-nc#fips:37133,37133,37,37,Onslow,762.0969,34.763107,-77.499466,Onslow County,county
+iso1:us#iso2:us-mn#fips:27043,27043,27,27,Faribault,712.5021,43.676520000000004,-93.94723499999999,Faribault County,county
+iso1:us#iso2:us-tn#fips:47057,47057,47,47,Grainger,280.59607,36.277508000000005,-83.50954399999999,Grainger County,county
+iso1:us#iso2:us-tx#fips:48161,48161,48,48,Freestone,877.7605,31.701748,-96.14496,Freestone County,county
+iso1:us#iso2:us-pa#fips:42087,42087,42,42,Mifflin,411.0592,40.601616,-77.65183,Mifflin County,county
+iso1:us#iso2:us-al#fips:01041,1041,1,1,Crenshaw,608.8856,31.732826,-86.31922,Crenshaw County,county
+iso1:us#iso2:us-va#fips:51520,51520,51,51,Bristol city,12.904041000000001,36.616955,-82.15756,Bristol city,county
+iso1:us#iso2:us-tx#fips:48399,48399,48,48,Runnels,1051.106,31.84512,-99.98271,Runnels County,county
+iso1:us#iso2:us-tx#fips:48443,48443,48,48,Terrell,2358.0376,30.232342,-102.07251,Terrell County,county
+iso1:us#iso2:us-ks#fips:20153,20153,20,20,Rawlins,1069.4528,39.786198,-101.07674,Rawlins County,county
+iso1:us#iso2:us-ks#fips:20193,20193,20,20,Thomas,1074.723,39.35771,-101.08339000000001,Thomas County,county
+iso1:us#iso2:us-ga#fips:13161,13161,13,13,Jeff Davis,330.92914,31.811615000000003,-82.636826,Jeff Davis County,county
+iso1:us#iso2:us-ia#fips:19035,19035,19,19,Cherokee,576.9262,42.742737,-95.63325999999999,Cherokee County,county
+iso1:us#iso2:us-ar#fips:05145,5145,5,5,White,1035.1088,35.25512,-91.75304,White County,county
+iso1:us#iso2:us-ms#fips:28083,28083,28,28,Leflore,594.0946700000001,33.54979,-90.29494,Leflore County,county
+iso1:us#iso2:us-mo#fips:29053,29053,29,29,Cooper,564.77234,38.845387,-92.812325,Cooper County,county
+iso1:us#iso2:us-mi#fips:26043,26043,26,26,Dickinson,760.97345,46.012825,-87.86612,Dickinson County,county
+iso1:us#iso2:us-il#fips:17197,17197,17,17,Will,835.8993,41.448475,-87.97845500000001,Will County,county
+iso1:us#iso2:us-tx#fips:48117,48117,48,48,Deaf Smith,1496.8727,34.940765,-102.60757,Deaf Smith County,county
+iso1:us#iso2:us-sd#fips:46011,46011,46,46,Brookings,792.2533599999999,44.376675,-96.7978,Brookings County,county
+iso1:us#iso2:us-mo#fips:29047,29047,29,29,Clay,397.6789,39.31555,-94.4215,Clay County,county
+iso1:us#iso2:us-ms#fips:28027,28027,28,28,Coahoma,552.5075,34.22867,-90.603165,Coahoma County,county
+iso1:us#iso2:us-in#fips:18011,18011,18,18,Boone,422.92633,40.05089,-86.46902,Boone County,county
+iso1:us#iso2:us-ia#fips:19057,19057,19,19,Des Moines,416.14285,40.91534,-91.18693,Des Moines County,county
+iso1:us#iso2:us-ia#fips:19163,19163,19,19,Scott,458.1018,41.64208,-90.62229,Scott County,county
+iso1:us#iso2:us-ks#fips:20143,20143,20,20,Ottawa,720.75494,39.137962,-97.6548,Ottawa County,county
+iso1:us#iso2:us-fl#fips:12023,12023,12,12,Columbia,797.5784,30.221651,-82.623375,Columbia County,county
+iso1:us#iso2:us-fl#fips:12059,12059,12,12,Holmes,478.8729,30.862007000000002,-85.81594,Holmes County,county
+iso1:us#iso2:us-ms#fips:28047,28047,28,28,Harrison,573.6614,30.416535999999997,-89.08337399999999,Harrison County,county
+iso1:us#iso2:us-pr#fips:72141,72141,72,72,Utuado Municipio,113.53542,18.270864000000003,-66.70299,Utuado Municipio,county
+iso1:us#iso2:us-tn#fips:47011,47011,47,47,Bradley,328.77297999999996,35.153915000000005,-84.85941,Bradley County,county
+iso1:us#iso2:us-mn#fips:27017,27017,27,27,Carlton,861.33325,46.603817,-92.67104,Carlton County,county
+iso1:us#iso2:us-tx#fips:48315,48315,48,48,Marion,380.89697,32.798183,-94.35685,Marion County,county
+iso1:us#iso2:us-ny#fips:36095,36095,36,36,Schoharie,621.8401,42.591293,-74.43817,Schoharie County,county
+iso1:us#iso2:us-ok#fips:40117,40117,40,40,Pawnee,568.37067,36.313705,-96.69667,Pawnee County,county
+iso1:us#iso2:us-ny#fips:36007,36007,36,36,Broome,705.8425,42.161976,-75.83028399999999,Broome County,county
+iso1:us#iso2:us-tx#fips:48291,48291,48,48,Liberty,1158.3828,30.158508,-94.84406,Liberty County,county
+iso1:us#iso2:us-oh#fips:39009,39009,39,39,Athens,503.64374000000004,39.332603000000006,-82.045845,Athens County,county
+iso1:us#iso2:us-oh#fips:39081,39081,39,39,Jefferson,408.13815,40.399384000000005,-80.76353,Jefferson County,county
+iso1:us#iso2:us-wv#fips:54083,54083,54,54,Randolph,1039.7355,38.781094,-79.86779,Randolph County,county
+iso1:us#iso2:us-wv#fips:54049,54049,54,54,Marion,308.7636,39.50584,-80.2434,Marion County,county
+iso1:us#iso2:us-nj#fips:34011,34011,34,34,Cumberland,483.37708,39.328434,-75.12163000000001,Cumberland County,county
+iso1:us#iso2:us-ca#fips:06057,6057,6,6,Nevada,957.7927,39.297509999999996,-120.77134,Nevada County,county
+iso1:us#iso2:us-wi#fips:55031,55031,55,55,Douglas,1304.3369,46.46322,-91.89248,Douglas County,county
+iso1:us#iso2:us-ky#fips:21199,21199,21,21,Pulaski,658.4328,37.107372,-84.57695,Pulaski County,county
+iso1:us#iso2:us-nc#fips:37065,37065,37,37,Edgecombe,505.44995,35.917076,-77.602745,Edgecombe County,county
+iso1:us#iso2:us-tx#fips:48241,48241,48,48,Jasper,938.68695,30.752932,-94.02229,Jasper County,county
+iso1:us#iso2:us-ut#fips:49001,49001,49,49,Beaver,2582.9885,38.357535999999996,-113.238945,Beaver County,county
+iso1:us#iso2:us-ga#fips:13213,13213,13,13,Murray,344.50565,34.797096,-84.73799,Murray County,county
+iso1:us#iso2:us-in#fips:18075,18075,18,18,Jay,383.91832999999997,40.434956,-85.002335,Jay County,county
+iso1:us#iso2:us-mi#fips:26117,26117,26,26,Montcalm,705.3529,43.312782,-85.14947,Montcalm County,county
+iso1:us#iso2:us-ny#fips:36083,36083,36,36,Rensselaer,652.4777,42.71042,-73.51385,Rensselaer County,county
+iso1:us#iso2:us-fl#fips:12021,12021,12,12,Collier,1997.006,26.118786,-81.40095500000001,Collier County,county
+iso1:us#iso2:us-nm#fips:35031,35031,35,35,McKinley,5450.8643,35.583878000000006,-108.25326499999998,McKinley County,county
+iso1:us#iso2:us-ga#fips:13017,13017,13,13,Ben Hill,250.13034,31.740771999999996,-83.147194,Ben Hill County,county
+iso1:us#iso2:us-ar#fips:05077,5077,5,5,Lee,602.6417,34.779507,-90.77972,Lee County,county
+iso1:us#iso2:us-fl#fips:12003,12003,12,12,Baker,585.25,30.324441999999998,-82.302284,Baker County,county
+iso1:us#iso2:us-ga#fips:13173,13173,13,13,Lanier,196.54283,31.038196999999997,-83.06316,Lanier County,county
+iso1:us#iso2:us-ks#fips:20159,20159,20,20,Rice,726.2582,38.34718,-98.20141600000001,Rice County,county
+iso1:us#iso2:us-al#fips:01015,1015,1,1,Calhoun,605.8903,33.770515,-85.82791,Calhoun County,county
+iso1:us#iso2:us-ms#fips:28059,28059,28,28,Jackson,722.82166,30.456004999999998,-88.6251,Jackson County,county
+iso1:us#iso2:us-ky#fips:21037,21037,21,21,Campbell,151.34506000000002,38.946979999999996,-84.37958499999999,Campbell County,county
+iso1:us#iso2:us-ky#fips:21057,21057,21,21,Cumberland,305.20602,36.78237,-85.38848,Cumberland County,county
+iso1:us#iso2:us-ms#fips:28107,28107,28,28,Panola,685.19836,34.365204,-89.963066,Panola County,county
+iso1:us#iso2:us-tx#fips:48195,48195,48,48,Hansford,919.8412,36.272846,-101.35693,Hansford County,county
+iso1:us#iso2:us-tx#fips:48071,48071,48,48,Chambers,597.173,29.696375,-94.66945,Chambers County,county
+iso1:us#iso2:us-ga#fips:13239,13239,13,13,Quitman,151.24255,31.862938,-85.0048,Quitman County,county
+iso1:us#iso2:us-tx#fips:48199,48199,48,48,Hardin,890.6183,30.329649,-94.39318,Hardin County,county
+iso1:us#iso2:us-ct#fips:09005,9005,9,9,Litchfield,920.5453,41.79188,-73.235405,Litchfield County,county
+iso1:us#iso2:us-oh#fips:39143,39143,39,39,Sandusky,408.25937000000005,41.35532,-83.14278,Sandusky County,county
+iso1:us#iso2:us-me#fips:23021,23021,23,23,Piscataquis,3961.1638,45.915638,-69.102234,Piscataquis County,county
+iso1:us#iso2:us-il#fips:17153,17153,17,17,Pulaski,199.32245,37.215614,-89.12775400000001,Pulaski County,county
+iso1:us#iso2:us-ok#fips:40107,40107,40,40,Okfuskee,618.467,35.466805,-96.32776,Okfuskee County,county
+iso1:us#iso2:us-mi#fips:26145,26145,26,26,Saginaw,800.7312,43.328266,-84.05541,Saginaw County,county
+iso1:us#iso2:us-nm#fips:35039,35039,35,35,Rio Arriba,5861.071999999999,36.50967,-106.69398500000001,Rio Arriba County,county
+iso1:us#iso2:us-vt#fips:50005,50005,50,50,Caledonia,649.0415,44.468792,-72.11216999999999,Caledonia County,county
+iso1:us#iso2:us-va#fips:51023,51023,51,51,Botetourt,541.2952,37.565483,-79.79755,Botetourt County,county
+iso1:us#iso2:us-il#fips:17119,17119,17,17,Madison,715.5304,38.827118,-89.90023000000001,Madison County,county
+iso1:us#iso2:us-tx#fips:48085,48085,48,48,Collin,841.4307,33.19453,-96.57944499999999,Collin County,county
+iso1:us#iso2:us-sc#fips:45001,45001,45,45,Abbeville,491.44363,34.229042,-82.45405600000001,Abbeville County,county
+iso1:us#iso2:us-ne#fips:31053,31053,31,31,Dodge,529.082,41.577007,-96.64585,Dodge County,county
+iso1:us#iso2:us-fl#fips:12115,12115,12,12,Sarasota,556.0053,27.184385,-82.36584,Sarasota County,county
+iso1:us#iso2:us-wi#fips:55077,55077,55,55,Marquette,455.72733,43.826054,-89.40909599999999,Marquette County,county
+iso1:us#iso2:us-az#fips:04015,4015,4,4,Mohave,13332.313,35.717705,-113.74968999999999,Mohave County,county
+iso1:us#iso2:us-az#fips:04025,4025,4,4,Yavapai,8123.3745,34.63107,-112.577225,Yavapai County,county
+iso1:us#iso2:us-sc#fips:45051,45051,45,45,Horry,1133.0375,33.90927,-78.97668,Horry County,county
+iso1:us#iso2:us-pa#fips:42091,42091,42,42,Montgomery,482.98287999999997,40.21,-75.3702,Montgomery County,county
+iso1:us#iso2:us-id#fips:16061,16061,16,16,Lewis,478.83777000000003,46.23633,-116.42376000000002,Lewis County,county
+iso1:us#iso2:us-pr#fips:72013,72013,72,72,Arecibo Municipio,125.942924,18.434004,-66.674995,Arecibo Municipio,county
+iso1:us#iso2:us-va#fips:51720,51720,51,51,Norton city,7.4775524,36.93155,-82.626,Norton city,county
+iso1:us#iso2:us-nj#fips:34027,34027,34,34,Morris,460.97475999999995,40.858894,-74.54729499999999,Morris County,county
+iso1:us#iso2:us-mo#fips:29211,29211,29,29,Sullivan,648.0038,40.209587,-93.10978,Sullivan County,county
+iso1:us#iso2:us-ks#fips:20135,20135,20,20,Ness,1074.776,38.48044,-99.908745,Ness County,county
+iso1:us#iso2:us-tx#fips:48039,48039,48,48,Brazoria,1363.3168,29.167818,-95.43465,Brazoria County,county
+iso1:us#iso2:us-va#fips:51790,51790,51,51,Staunton city,19.921162,38.157978,-79.061874,Staunton city,county
+iso1:us#iso2:us-ne#fips:31029,31029,31,31,Chase,894.449,40.530390000000004,-101.69419,Chase County,county
+iso1:us#iso2:us-oh#fips:39113,39113,39,39,Montgomery,461.53375,39.753735,-84.29059000000001,Montgomery County,county
+iso1:us#iso2:us-tx#fips:48447,48447,48,48,Throckmorton,912.5833,33.170696,-99.205795,Throckmorton County,county
+iso1:us#iso2:us-ga#fips:13221,13221,13,13,Oglethorpe,439.0773,33.866806,-83.07408000000001,Oglethorpe County,county
+iso1:us#iso2:us-ar#fips:05029,5029,5,5,Conway,552.29474,35.2657,-92.68925,Conway County,county
+iso1:us#iso2:us-mo#fips:29147,29147,29,29,Nodaway,876.99396,40.361137,-94.88315,Nodaway County,county
+iso1:us#iso2:us-nd#fips:38073,38073,38,38,Ransom,862.5016,46.449276,-97.64755,Ransom County,county
+iso1:us#iso2:us-mi#fips:26017,26017,26,26,Bay,442.2561,43.699709999999996,-83.9787,Bay County,county
+iso1:us#iso2:us-tn#fips:47157,47157,47,47,Shelby,763.5857,35.183796,-89.89539,Shelby County,county
+iso1:us#iso2:us-ca#fips:06007,6007,6,6,Butte,1636.545,39.66596,-121.60191999999999,Butte County,county
+iso1:us#iso2:us-mn#fips:27115,27115,27,27,Pine,1411.3367,46.10094,-92.76309,Pine County,county
+iso1:us#iso2:us-tx#fips:48021,48021,48,48,Bastrop,888.2349,30.10077,-97.31064,Bastrop County,county
+iso1:us#iso2:us-wa#fips:53039,53039,53,53,Klickitat,1871.7001,45.870445000000004,-120.77930500000001,Klickitat County,county
+iso1:us#iso2:us-wa#fips:53055,53055,53,53,San Juan,173.91756999999998,48.50719,-123.10377,San Juan County,county
+iso1:us#iso2:us-wi#fips:55009,55009,55,55,Brown,530.1105,44.474026,-87.99613000000001,Brown County,county
+iso1:us#iso2:us-ks#fips:20205,20205,20,20,Wilson,570.4412,37.558514,-95.74518,Wilson County,county
+iso1:us#iso2:us-la#fips:22069,22069,22,22,Natchitoches Parish,1252.3174,31.732552000000002,-93.08261,Natchitoches Parish,county
+iso1:us#iso2:us-la#fips:22109,22109,22,22,Terrebonne Parish,1229.8698,29.33413,-90.84366999999999,Terrebonne Parish,county
+iso1:us#iso2:us-ga#fips:13155,13155,13,13,Irwin,354.3748,31.604305,-83.27704,Irwin County,county
+iso1:us#iso2:us-ak#fips:02185,2185,2,2,North Slope Borough,88827.46,69.44934,-153.47281999999998,North Slope Borough,county
+iso1:us#iso2:us-mi#fips:26011,26011,26,26,Arenac,363.19073,44.03683,-83.74068,Arenac County,county
+iso1:us#iso2:us-ia#fips:19111,19111,19,19,Lee,517.5677,40.647587,-91.47716,Lee County,county
+iso1:us#iso2:us-ks#fips:20141,20141,20,20,Osborne,892.546,39.348259999999996,-98.767944,Osborne County,county
+iso1:us#iso2:us-mi#fips:26047,26047,26,26,Emmet,467.53638,45.590096,-84.986824,Emmet County,county
+iso1:us#iso2:us-ia#fips:19071,19071,19,19,Fremont,511.1841,40.74259,-95.59918,Fremont County,county
+iso1:us#iso2:us-me#fips:23015,23015,23,23,Lincoln,455.88208,43.99478,-69.513626,Lincoln County,county
+iso1:us#iso2:us-ny#fips:36099,36099,36,36,Seneca,323.72046,42.782295,-76.82709,Seneca County,county
+iso1:us#iso2:us-ky#fips:21125,21125,21,21,Laurel,434.00300000000004,37.113265999999996,-84.11939,Laurel County,county
+iso1:us#iso2:us-tn#fips:47121,47121,47,47,Meigs,195.14177,35.512203,-84.8161,Meigs County,county
+iso1:us#iso2:us-mo#fips:29213,29213,29,29,Taney,632.39197,36.649826000000004,-93.042816,Taney County,county
+iso1:us#iso2:us-ga#fips:13269,13269,13,13,Taylor,376.69912999999997,32.55467,-84.25143,Taylor County,county
+iso1:us#iso2:us-va#fips:51830,51830,51,51,Williamsburg city,8.940619,37.26948,-76.70819,Williamsburg city,county
+iso1:us#iso2:us-tx#fips:48415,48415,48,48,Scurry,905.4753,32.744354,-100.91334499999999,Scurry County,county
+iso1:us#iso2:us-co#fips:08047,8047,8,8,Gilpin,150.0277,39.861156,-105.52888,Gilpin County,county
+iso1:us#iso2:us-ok#fips:40087,40087,40,40,McClain,570.7364,35.016438,-97.44981,McClain County,county
+iso1:us#iso2:us-wv#fips:54071,54071,54,54,Pendleton,696.0730599999999,38.67445,-79.340614,Pendleton County,county
+iso1:us#iso2:us-va#fips:51139,51139,51,51,Page,310.03116,38.623207,-78.491875,Page County,county
+iso1:us#iso2:us-ok#fips:40079,40079,40,40,Le Flore,1589.2501,34.897358000000004,-94.695076,Le Flore County,county
+iso1:us#iso2:us-wv#fips:54089,54089,54,54,Summers,360.60474,37.656,-80.85632,Summers County,county
+iso1:us#iso2:us-nc#fips:37119,37119,37,37,Mecklenburg,523.5989400000001,35.24686,-80.83383,Mecklenburg County,county
+iso1:us#iso2:us-nj#fips:34013,34013,34,34,Essex,126.08883,40.7874,-74.24629,Essex County,county
+iso1:us#iso2:us-mo#fips:29115,29115,29,29,Linn,615.6093,39.86444,-93.10802,Linn County,county
+iso1:us#iso2:us-ga#fips:13209,13209,13,13,Montgomery,241.15335,32.172108,-82.53335,Montgomery County,county
+iso1:us#iso2:us-or#fips:41055,41055,41,41,Sherman,823.6424599999999,45.399215999999996,-120.67851,Sherman County,county
+iso1:us#iso2:us-ga#fips:13133,13133,13,13,Greene,387.67645,33.57674,-83.16660999999999,Greene County,county
+iso1:us#iso2:us-sd#fips:46017,46017,46,46,Buffalo,471.4212,44.044308,-99.20399499999999,Buffalo County,county
+iso1:us#iso2:us-sd#fips:46095,46095,46,46,Mellette,1307.3699,43.58469,-100.76095600000001,Mellette County,county
+iso1:us#iso2:us-tx#fips:48135,48135,48,48,Ector,897.8425,31.865301000000002,-102.5425,Ector County,county
+iso1:us#iso2:us-tx#fips:48293,48293,48,48,Limestone,905.4609,31.547543,-96.59362,Limestone County,county
+iso1:us#iso2:us-wa#fips:53027,53027,53,53,Grays Harbor,1901.5276,47.11373,-123.82673999999999,Grays Harbor County,county
+iso1:us#iso2:us-wv#fips:54003,54003,54,54,Berkeley,321.15945,39.447936999999996,-78.03775,Berkeley County,county
+iso1:us#iso2:us-pr#fips:72149,72149,72,72,Villalba Municipio,35.637890000000006,18.130717999999998,-66.47224399999999,Villalba Municipio,county
+iso1:us#iso2:us-mt#fips:30067,30067,30,30,Park,2802.5657,45.42143,-110.53276000000001,Park County,county
+iso1:us#iso2:us-tx#fips:48121,48121,48,48,Denton,879.6072,33.20513,-97.12114,Denton County,county
+iso1:us#iso2:us-sc#fips:45021,45021,45,45,Cherokee,393.34955,35.049797,-81.60764,Cherokee County,county
+iso1:us#iso2:us-nc#fips:37199,37199,37,37,Yancey,312.6028,35.889324,-82.303955,Yancey County,county
+iso1:us#iso2:us-tx#fips:48387,48387,48,48,Red River,1043.9116,33.619625,-95.04843000000001,Red River County,county
+iso1:us#iso2:us-tx#fips:48321,48321,48,48,Matagorda,1092.9393,28.774759999999997,-96.00153,Matagorda County,county
+iso1:us#iso2:us-mn#fips:27149,27149,27,27,Stevens,563.62964,45.59346,-95.99231999999999,Stevens County,county
+iso1:us#iso2:us-ga#fips:13301,13301,13,13,Warren,284.36758,33.41917,-82.68800999999999,Warren County,county
+iso1:us#iso2:us-tx#fips:48197,48197,48,48,Hardeman,695.1378,34.2899,-99.7457,Hardeman County,county
+iso1:us#iso2:us-il#fips:17133,17133,17,17,Monroe,385.33865,38.277985,-90.17908,Monroe County,county
+iso1:us#iso2:us-ga#fips:13165,13165,13,13,Jenkins,347.33673,32.794563000000004,-81.97153,Jenkins County,county
+iso1:us#iso2:us-ky#fips:21085,21085,21,21,Grayson,499.94504000000006,37.458576,-86.34401,Grayson County,county
+iso1:us#iso2:us-tx#fips:48363,48363,48,48,Palo Pinto,952.5814,32.752205,-98.31796999999999,Palo Pinto County,county
+iso1:us#iso2:us-ga#fips:13149,13149,13,13,Heard,295.98233,33.291348,-85.137886,Heard County,county
+iso1:us#iso2:us-al#fips:01079,1079,1,1,Lawrence,690.7078,34.529778,-87.32186999999999,Lawrence County,county
+iso1:us#iso2:us-pr#fips:72061,72061,72,72,Guaynabo Municipio,27.585866999999997,18.344357000000002,-66.11405,Guaynabo Municipio,county
+iso1:us#iso2:us-ms#fips:28093,28093,28,28,Marshall,706.20917,34.76619,-89.504234,Marshall County,county
+iso1:us#iso2:us-ks#fips:20025,20025,20,20,Clark,974.6709599999999,37.23383,-99.813866,Clark County,county
+iso1:us#iso2:us-ks#fips:20081,20081,20,20,Haskell,577.5407,37.554977,-100.87995,Haskell County,county
+iso1:us#iso2:us-la#fips:22013,22013,22,22,Bienville Parish,811.3083,32.34095,-93.04115,Bienville Parish,county
+iso1:us#iso2:us-ga#fips:13295,13295,13,13,Walker,446.40536,34.7358,-85.30546,Walker County,county
+iso1:us#iso2:us-ia#fips:19095,19095,19,19,Iowa,586.47504,41.683918,-92.05912,Iowa County,county
+iso1:us#iso2:us-ne#fips:31019,31019,31,31,Buffalo,968.2533,40.855225,-99.07498000000001,Buffalo County,county
+iso1:us#iso2:us-ok#fips:40007,40007,40,40,Beaver,1814.8993,36.748333,-100.48305500000001,Beaver County,county
+iso1:us#iso2:us-ia#fips:19023,19023,19,19,Butler,580.1578400000001,42.734756,-92.78015,Butler County,county
+iso1:us#iso2:us-mt#fips:30085,30085,30,30,Roosevelt,2354.6824,48.282745,-104.99517,Roosevelt County,county
+iso1:us#iso2:us-pr#fips:72017,72017,72,72,Barceloneta Municipio,18.696434,18.46999,-66.55823000000001,Barceloneta Municipio,county
+iso1:us#iso2:us-wa#fips:53015,53015,53,53,Cowlitz,1141.212,46.196785,-122.67846000000002,Cowlitz County,county
+iso1:us#iso2:us-tx#fips:48297,48297,48,48,Live Oak,1039.7301,28.351536,-98.12696,Live Oak County,county
+iso1:us#iso2:us-mo#fips:29135,29135,29,29,Moniteau,415.0421,38.633038,-92.58364,Moniteau County,county
+iso1:us#iso2:us-va#fips:51193,51193,51,51,Westmoreland,229.33345,38.10931,-76.80393000000001,Westmoreland County,county
+iso1:us#iso2:us-nc#fips:37197,37197,37,37,Yadkin,334.95352,36.158764,-80.66516,Yadkin County,county
+iso1:us#iso2:us-ca#fips:06047,6047,6,6,Merced,1936.1777,37.194805,-120.7228,Merced County,county
+iso1:us#iso2:us-ok#fips:40043,40043,40,40,Dewey,999.6687599999999,35.977959999999996,-99.01438,Dewey County,county
+iso1:us#iso2:us-nc#fips:37023,37023,37,37,Burke,506.25388,35.746179999999995,-81.70618,Burke County,county
+iso1:us#iso2:us-nc#fips:37191,37191,37,37,Wayne,553.9377400000001,35.35419,-78.00867,Wayne County,county
+iso1:us#iso2:us-pa#fips:42123,42123,42,42,Warren,884.16864,41.834297,-79.29818,Warren County,county
+iso1:us#iso2:us-ar#fips:05061,5061,5,5,Howard,588.58655,34.083065000000005,-93.99093,Howard County,county
+iso1:us#iso2:us-nc#fips:37059,37059,37,37,Davie,263.7034,35.929356,-80.54255,Davie County,county
+iso1:us#iso2:us-nc#fips:37111,37111,37,37,McDowell,439.96964,35.68227,-82.04804,McDowell County,county
+iso1:us#iso2:us-ar#fips:05099,5099,5,5,Nevada,617.8641,33.6667,-93.30507,Nevada County,county
+iso1:us#iso2:us-co#fips:08125,8125,8,8,Yuma,2364.4788,40.00077,-102.421646,Yuma County,county
+iso1:us#iso2:us-tx#fips:48421,48421,48,48,Sherman,922.89105,36.27859,-101.89926,Sherman County,county
+iso1:us#iso2:us-tx#fips:48463,48463,48,48,Uvalde,1551.9734,29.350307,-99.768425,Uvalde County,county
+iso1:us#iso2:us-oh#fips:39011,39011,39,39,Auglaize,401.4017,40.56131,-84.224014,Auglaize County,county
+iso1:us#iso2:us-la#fips:22015,22015,22,22,Bossier Parish,840.3432,32.698483,-93.626564,Bossier Parish,county
+iso1:us#iso2:us-ia#fips:19063,19063,19,19,Emmet,395.90305,43.377983,-94.66937,Emmet County,county
+iso1:us#iso2:us-ks#fips:20169,20169,20,20,Saline,720.2665,38.791805,-97.65148,Saline County,county
+iso1:us#iso2:us-ky#fips:21153,21153,21,21,Magoffin,308.45468,37.698982,-83.06971999999999,Magoffin County,county
+iso1:us#iso2:us-tx#fips:48017,48017,48,48,Bailey,826.99994,34.06752,-102.830345,Bailey County,county
+iso1:us#iso2:us-mo#fips:29027,29027,29,29,Callaway,834.5952,38.83555,-91.92345,Callaway County,county
+iso1:us#iso2:us-wy#fips:56001,56001,56,56,Albany,4274.472,41.665516,-105.72188600000001,Albany County,county
+iso1:us#iso2:us-wy#fips:56029,56029,56,56,Park,6939.275,44.492385999999996,-109.5936,Park County,county
+iso1:us#iso2:us-pa#fips:42093,42093,42,42,Montour,130.24683000000002,41.029284999999994,-76.66521999999999,Montour County,county
+iso1:us#iso2:us-ny:#fips:36081,36081,36,36,Queens,108.78198,40.658566,-73.83802,Queens County,county
+iso1:us#iso2:us-fl#fips:12121,12121,12,12,Suwannee,688.5757,30.189242999999998,-82.99275,Suwannee County,county
+iso1:us#iso2:us-mi#fips:26031,26031,26,26,Cheboygan,715.29865,45.47602,-84.49543,Cheboygan County,county
+iso1:us#iso2:us-mi#fips:26051,26051,26,26,Gladwin,501.80334000000005,43.98975,-84.38982,Gladwin County,county
+iso1:us#iso2:us-ky#fips:21173,21173,21,21,Montgomery,197.35619,38.038109999999996,-83.912415,Montgomery County,county
+iso1:us#iso2:us-sc#fips:45057,45057,45,45,Lancaster,549.087,34.686817,-80.70369000000001,Lancaster County,county
+iso1:us#iso2:us-ky#fips:21123,21123,21,21,Larue,261.56186,37.544464000000005,-85.69684000000001,Larue County,county
+iso1:us#iso2:us-ia#fips:19193,19193,19,19,Woodbury,872.9259599999999,42.39322,-96.0533,Woodbury County,county
+iso1:us#iso2:us-fl#fips:12123,12123,12,12,Taylor,1043.3531,30.009909000000004,-83.60948,Taylor County,county
+iso1:us#iso2:us-il#fips:17003,17003,17,17,Alexander,235.40205,37.183659999999996,-89.34952,Alexander County,county
+iso1:us#iso2:us-mo#fips:29099,29099,29,29,Jefferson,656.48956,38.25763,-90.54368000000001,Jefferson County,county
+iso1:us#iso2:us-mo#fips:29113,29113,29,29,Lincoln,626.5916,39.062256,-90.96291,Lincoln County,county
+iso1:us#iso2:us-ga#fips:13051,13051,13,13,Chatham,433.1314,31.980403999999997,-81.08518000000001,Chatham County,county
+iso1:us#iso2:us-fl#fips:12125,12125,12,12,Union,243.56328,30.05428,-82.36692,Union County,county
+iso1:us#iso2:us-ny#fips:36037,36037,36,36,Genesee,492.9555,43.000908,-78.19278,Genesee County,county
+iso1:us#iso2:us-ia#fips:19041,19041,19,19,Clay,567.2572,43.081223,-95.14986999999999,Clay County,county
+iso1:us#iso2:us-mt#fips:30025,30025,30,30,Fallon,1620.6497,46.318184,-104.405716,Fallon County,county
+iso1:us#iso2:us-sd#fips:46107,46107,46,46,Potter,861.16705,45.05271,-99.962006,Potter County,county
+iso1:us#iso2:us-tx#fips:48109,48109,48,48,Culberson,3812.2861,31.445908000000003,-104.52695,Culberson County,county
+iso1:us#iso2:us-me#fips:23005,23005,23,23,Cumberland,835.9734,43.80835,-70.330376,Cumberland County,county
+iso1:us#iso2:us-tx#fips:48013,48013,48,48,Atascosa,1219.5825,28.891478000000003,-98.53538,Atascosa County,county
+iso1:us#iso2:us-ks#fips:20095,20095,20,20,Kingman,863.4484,37.55295,-98.14453,Kingman County,county
+iso1:us#iso2:us-ga#fips:13241,13241,13,13,Rabun,370.1527,34.883934,-83.40486999999999,Rabun County,county
+iso1:us#iso2:us-wv#fips:54097,54097,54,54,Upshur,354.64957000000004,38.90253,-80.231606,Upshur County,county
+iso1:us#iso2:us-mo#fips:29215,29215,29,29,Texas,1177.3057,37.314254999999996,-91.96448000000001,Texas County,county
+iso1:us#iso2:us-ar#fips:05119,5119,5,5,Pulaski,758.4617,34.770309999999995,-92.312996,Pulaski County,county
+iso1:us#iso2:us-ia#fips:19047,19047,19,19,Crawford,714.2139999999999,42.043118,-95.38909,Crawford County,county
+iso1:us#iso2:us-id#fips:16005,16005,16,16,Bannock,1112.5292,42.69292,-112.22898,Bannock County,county
+iso1:us#iso2:us-oh#fips:39055,39055,39,39,Geauga,400.3141,41.499320000000004,-81.17351,Geauga County,county
+iso1:us#iso2:us-pr#fips:72035,72035,72,72,Cayey Municipio,51.93632,18.103624,-66.15166500000001,Cayey Municipio,county
+iso1:us#iso2:us-ca#fips:06107,6107,6,6,Tulare,4824.468,36.228832000000004,-118.78105,Tulare County,county
+iso1:us#iso2:us-pr#fips:72015,72015,72,72,Arroyo Municipio,15.008104000000001,17.97206,-66.04195,Arroyo Municipio,county
+iso1:us#iso2:us-pr#fips:72125,72125,72,72,San Germán Municipio,54.49825,18.1078,-67.03726,San Germán Municipio,county
+iso1:us#iso2:us-ny#fips:36117,36117,36,36,Wayne,603.8507,43.45876,-77.06316,Wayne County,county
+iso1:us#iso2:us-va#fips:51163,51163,51,51,Rockbridge,596.5628,37.814518,-79.447754,Rockbridge County,county
+iso1:us#iso2:us-nd#fips:38095,38095,38,38,Towner,1024.9437,48.682182,-99.24816,Towner County,county
+iso1:us#iso2:us-pa#fips:42045,42045,42,42,Delaware,183.82106000000002,39.916686999999996,-75.39882,Delaware County,county
+iso1:us#iso2:us-ny#fips:36063,36063,36,36,Niagara,522.3706,43.45673,-78.79214499999999,Niagara County,county
+iso1:us#iso2:us-vt#fips:50003,50003,50,50,Bennington,675.0193,43.035323999999996,-73.11146,Bennington County,county
+iso1:us#iso2:us-fl#fips:12019,12019,12,12,Clay,604.63586,29.986584000000004,-81.865036,Clay County,county
+iso1:us#iso2:us-nc#fips:37183,37183,37,37,Wake,834.8569,35.789845,-78.65063,Wake County,county
+iso1:us#iso2:us-oh#fips:39061,39061,39,39,Hamilton,405.42096000000004,39.196926,-84.54419,Hamilton County,county
+iso1:us#iso2:us-nj#fips:34003,34003,34,34,Bergen,232.7932,40.959697999999996,-74.07473,Bergen County,county
+iso1:us#iso2:us-nv#fips:32017,32017,32,32,Lincoln,10633.747,37.634605,-114.86303999999998,Lincoln County,county
+iso1:us#iso2:us-ak#fips:02180,2180,2,2,Nome Census Area,22970.799,64.78368,-164.18892,Nome Census Area,county
+iso1:us#iso2:us-mt#fips:30055,30055,30,30,McCone,2642.3152,47.629627,-105.757225,McCone County,county
+iso1:us#iso2:us-ia#fips:19019,19019,19,19,Buchanan,571.09937,42.47033,-91.83867,Buchanan County,county
+iso1:us#iso2:us-il#fips:17043,17043,17,17,DuPage,327.7701,41.852059999999994,-88.08604,DuPage County,county
+iso1:us#iso2:us-sd#fips:46047,46047,46,46,Fall River,1739.9482,43.22162,-103.51261,Fall River County,county
+iso1:us#iso2:us-mn#fips:27069,27069,27,27,Kittson,1098.8516,48.77604,-96.78035,Kittson County,county
+iso1:us#iso2:us-ga#fips:13219,13219,13,13,Oconee,184.3411,33.834126,-83.43773,Oconee County,county
+iso1:us#iso2:us-tx#fips:48493,48493,48,48,Wilson,803.76184,29.173883,-98.08673,Wilson County,county
+iso1:us#iso2:us-ne#fips:31059,31059,31,31,Fillmore,575.3901,40.525040000000004,-97.5967,Fillmore County,county
+iso1:us#iso2:us-fl#fips:12079,12079,12,12,Madison,696.55255,30.447233,-83.47041,Madison County,county
+iso1:us#iso2:us-pr#fips:72031,72031,72,72,Carolina Municipio,45.372017,18.396776000000003,-65.96878000000001,Carolina Municipio,county
+iso1:us#iso2:us-in#fips:18153,18153,18,18,Sullivan,447.18747,39.089226000000004,-87.41584,Sullivan County,county
+iso1:us#iso2:us-az#fips:04012,4012,4,4,La Paz,4496.5103,33.72761,-114.0388,La Paz County,county
+iso1:us#iso2:us-ga#fips:13027,13027,13,13,Brooks,493.20099999999996,30.822933000000003,-83.58191,Brooks County,county
+iso1:us#iso2:us-ak#fips:02016,2016,2,2,Aleutians West Census Area,4394.5977,51.948963,179.62118999999998,Aleutians West Census Area,county
+iso1:us#iso2:us-ak#fips:02150,2150,2,2,Kodiak Island Borough,6615.5884,57.7044,-153.91836999999998,Kodiak Island Borough,county
+iso1:us#iso2:us-ks#fips:20185,20185,20,20,Stafford,792.07294,38.03563,-98.71989,Stafford County,county
+iso1:us#iso2:us-ga#fips:13271,13271,13,13,Telfair,437.32232999999997,31.913641,-82.93106,Telfair County,county
+iso1:us#iso2:us-mi#fips:26115,26115,26,26,Monroe,549.3688400000001,41.916096,-83.48711,Monroe County,county
+iso1:us#iso2:us-in#fips:18181,18181,18,18,White,505.15732,40.75095,-86.864296,White County,county
+iso1:us#iso2:us-in#fips:18113,18113,18,18,Noble,410.858,41.40468,-85.417274,Noble County,county
+iso1:us#iso2:us-ky#fips:21139,21139,21,21,Livingston,313.139,37.20952,-88.36343000000001,Livingston County,county
+iso1:us#iso2:us-ga#fips:13201,13201,13,13,Miller,282.43242999999995,31.162931,-84.7304,Miller County,county
+iso1:us#iso2:us-tn#fips:47103,47103,47,47,Lincoln,570.3615,35.142784000000006,-86.59340999999999,Lincoln County,county
+iso1:us#iso2:us-ky#fips:21211,21211,21,21,Shelby,379.78722999999997,38.23901,-85.22825,Shelby County,county
+iso1:us#iso2:us-ne#fips:31185,31185,31,31,York,572.5295,40.873055,-97.59674,York County,county
+iso1:us#iso2:us-pa#fips:42001,42001,42,42,Adams,518.70575,39.869473,-77.21773,Adams County,county
+iso1:us#iso2:us-sc#fips:45005,45005,45,45,Allendale,408.1045,32.979755,-81.36326600000001,Allendale County,county
+iso1:us#iso2:us-tn#fips:47037,47037,47,47,Davidson,503.46902,36.169129999999996,-86.78479,Davidson County,county
+iso1:us#iso2:us-ut#fips:49047,49047,49,49,Uintah,4482.5356,40.125890000000005,-109.517746,Uintah County,county
+iso1:us#iso2:us-ut#fips:49049,49049,49,49,Utah,2004.1359,40.120426,-111.66851000000001,Utah County,county
+iso1:us#iso2:us-in#fips:18021,18021,18,18,Clay,357.61462,39.39393,-87.11586,Clay County,county
+iso1:us#iso2:us-ny:#fips:36047,36047,36,36,Kings,69.37384,40.635044,-73.95064,Kings County,county
+iso1:us#iso2:us-mo#fips:29141,29141,29,29,Morgan,597.65497,38.420807,-92.87483,Morgan County,county
+iso1:us#iso2:us-oh#fips:39075,39075,39,39,Holmes,422.56683,40.565598,-81.93,Holmes County,county
+iso1:us#iso2:us-ia#fips:19143,19143,19,19,Osceola,398.70026,43.378544,-95.63379,Osceola County,county
+iso1:us#iso2:us-in#fips:18079,18079,18,18,Jennings,376.61005,38.996227000000005,-85.628105,Jennings County,county
+iso1:us#iso2:us-id#fips:16083,16083,16,16,Twin Falls,1921.7731,42.352309999999996,-114.66564,Twin Falls County,county
+iso1:us#iso2:us-il#fips:17165,17165,17,17,Saline,380.0032,37.751507000000004,-88.54502,Saline County,county
+iso1:us#iso2:us-mi#fips:26077,26077,26,26,Kalamazoo,561.99994,42.246265,-85.53285,Kalamazoo County,county
+iso1:us#iso2:us-sc#fips:45061,45061,45,45,Lee,410.1982,34.158640000000005,-80.251205,Lee County,county
+iso1:us#iso2:us-wy#fips:56019,56019,56,56,Johnson,4154.2935,44.04405,-106.58854,Johnson County,county
+iso1:us#iso2:us-in#fips:18027,18027,18,18,Daviess,429.51334,38.696090000000005,-87.07694000000001,Daviess County,county
+iso1:us#iso2:us-mi#fips:26055,26055,26,26,Grand Traverse,464.35193,44.71869,-85.55385,Grand Traverse County,county
+iso1:us#iso2:us-la#fips:22003,22003,22,22,Allen Parish,761.8378,30.652744000000002,-92.8196,Allen Parish,county
+iso1:us#iso2:us-sd#fips:46065,46065,46,46,Hughes,741.55225,44.384453,-99.975685,Hughes County,county
+iso1:us#iso2:us-sd#fips:46069,46069,46,46,Hyde,860.6586,44.537174,-99.47273,Hyde County,county
+iso1:us#iso2:us-sc#fips:45027,45027,45,45,Clarendon,606.9808,33.66468,-80.21789,Clarendon County,county
+iso1:us#iso2:us-mt#fips:30095,30095,30,30,Stillwater,1796.8073,45.658546,-109.38158,Stillwater County,county
+iso1:us#iso2:us-tn#fips:47007,47007,47,47,Bledsoe,406.44226000000003,35.593563,-85.20591,Bledsoe County,county
+iso1:us#iso2:us-ky#fips:21219,21219,21,21,Todd,374.51572000000004,36.840340000000005,-87.18364,Todd County,county
+iso1:us#iso2:us-tn#fips:47183,47183,47,47,Weakley,580.3729,36.303596,-88.72119,Weakley County,county
+iso1:us#iso2:us-mo#fips:29077,29077,29,29,Greene,675.3498,37.258194,-93.34064000000001,Greene County,county
+iso1:us#iso2:us-pa#fips:42077,42077,42,42,Lehigh,345.30606,40.614243,-75.59063,Lehigh County,county
+iso1:us#iso2:us-ne#fips:31159,31159,31,31,Seward,571.4490000000001,40.871944,-97.14038000000001,Seward County,county
+iso1:us#iso2:us-ny#fips:36015,36015,36,36,Chemung,407.3664,42.15528,-76.74718,Chemung County,county
+iso1:us#iso2:us-ny#fips:36121,36121,36,36,Wyoming,592.7717,42.701363,-78.22856999999999,Wyoming County,county
+iso1:us#iso2:us-ca#fips:06099,6099,6,6,Stanislaus,1496.0684,37.562317,-121.00283,Stanislaus County,county
+iso1:us#iso2:us-pa#fips:42095,42095,42,42,Northampton,369.7945,40.752792,-75.30745,Northampton County,county
+iso1:us#iso2:us-al#fips:01103,1103,1,1,Morgan,579.6196,34.454483,-86.846405,Morgan County,county
+iso1:us#iso2:us-ky#fips:21027,21027,21,21,Breckinridge,569.82526,37.77799,-86.43292,Breckinridge County,county
+iso1:us#iso2:us-ms#fips:28043,28043,28,28,Grenada,422.1364,33.77003,-89.80274,Grenada County,county
+iso1:us#iso2:us-ky#fips:21213,21213,21,21,Simpson,234.21336000000002,36.740936,-86.581795,Simpson County,county
+iso1:us#iso2:us-vt#fips:50013,50013,50,50,Grand Isle,81.81074,44.801790000000004,-73.30076,Grand Isle County,county
+iso1:us#iso2:us-oh#fips:39029,39029,39,39,Columbiana,531.935,40.770073,-80.77846,Columbiana County,county
+iso1:us#iso2:us-va#fips:51125,51125,51,51,Nelson,470.76122999999995,37.789078,-78.88344000000001,Nelson County,county
+iso1:us#iso2:us-fl#fips:12097,12097,12,12,Osceola,1327.6084,28.059027,-81.13931,Osceola County,county
+iso1:us#iso2:us-ar#fips:05053,5053,5,5,Grant,631.8330000000001,34.28557,-92.42298000000001,Grant County,county
+iso1:us#iso2:us-ga#fips:13175,13175,13,13,Laurens,807.35736,32.39322,-82.926315,Laurens County,county
+iso1:us#iso2:us-ny#fips:36061,36061,36,36,New York,22.661299,40.77664,-73.970184,New York County,county
+iso1:us#iso2:us-ar#fips:05007,5007,5,5,Benton,847.93,36.33782,-94.2563,Benton County,county
+iso1:us#iso2:us-pr#fips:72071,72071,72,72,Isabela Municipio,55.313269999999996,18.48387,-67.01414,Isabela Municipio,county
+iso1:us#iso2:us-fl#fips:12083,12083,12,12,Marion,1588.4701,29.202804999999998,-82.0431,Marion County,county
+iso1:us#iso2:us-va#fips:51135,51135,51,51,Nottoway,314.4004,37.141166999999996,-78.05386,Nottoway County,county
+iso1:us#iso2:us-nj#fips:34041,34041,34,34,Warren,356.54828,40.853493,-75.0095,Warren County,county
+iso1:us#iso2:us-ny#fips:36021,36021,36,36,Columbia,634.6850599999999,42.24773,-73.62680999999999,Columbia County,county
+iso1:us#iso2:us-va#fips:51690,51690,51,51,Martinsville city,10.956643,36.683525,-79.86365,Martinsville city,county
+iso1:us#iso2:us-ok#fips:40023,40023,40,40,Choctaw,770.3348,34.027645,-95.55421,Choctaw County,county
+iso1:us#iso2:us-ks#fips:20041,20041,20,20,Dickinson,847.0961,38.867737,-97.15794,Dickinson County,county
+iso1:us#iso2:us-tx#fips:48427,48427,48,48,Starr,1223.2207,26.530903000000002,-98.740234,Starr County,county
+iso1:us#iso2:us-ga#fips:13103,13103,13,13,Effingham,478.83495999999997,32.36168,-81.34337,Effingham County,county
+iso1:us#iso2:us-ok#fips:40129,40129,40,40,Roger Mills,1141.1649,35.708553,-99.74157,Roger Mills County,county
+iso1:us#iso2:us-wi#fips:55103,55103,55,55,Richland,586.16943,43.376197999999995,-90.43569000000001,Richland County,county
+iso1:us#iso2:us-nm#fips:35025,35025,35,35,Lea,4391.619000000001,32.795685,-103.41327,Lea County,county
+iso1:us#iso2:us-al#fips:01075,1075,1,1,Lamar,604.8668,33.787085999999995,-88.08743,Lamar County,county
+iso1:us#iso2:us-pr#fips:72054,72054,72,72,Florida Municipio,15.209660999999999,18.373953,-66.56008,Florida Municipio,county
+iso1:us#iso2:us-tn#fips:47117,47117,47,47,Marshall,375.47485,35.468340000000005,-86.76586,Marshall County,county
+iso1:us#iso2:us-va#fips:51011,51011,51,51,Appomattox,334.23007,37.370723999999996,-78.81094,Appomattox County,county
+iso1:us#iso2:us-ar#fips:05087,5087,5,5,Madison,834.2873,36.012547,-93.72405,Madison County,county
+iso1:us#iso2:us-wy#fips:56033,56033,56,56,Sheridan,2523.4468,44.78137,-106.88121000000001,Sheridan County,county
+iso1:us#iso2:us-pa#fips:42041,42041,42,42,Cumberland,545.4973,40.164806,-77.26344,Cumberland County,county
+iso1:us#iso2:us-pa#fips:42055,42055,42,42,Franklin,772.3254,39.926773,-77.72452,Franklin County,county
+iso1:us#iso2:us-pa#fips:42079,42079,42,42,Luzerne,889.9962,41.172787,-75.976036,Luzerne County,county
+iso1:us#iso2:us-mi#fips:26039,26039,26,26,Crawford,556.4222,44.680176,-84.61134,Crawford County,county
+iso1:us#iso2:us-al#fips:01113,1113,1,1,Russell,641.1919,32.289809999999996,-85.18698,Russell County,county
+iso1:us#iso2:us-oh#fips:39019,39019,39,39,Carroll,394.62192000000005,40.579884,-81.09079,Carroll County,county
+iso1:us#iso2:us-va#fips:51065,51065,51,51,Fluvanna,287.12708,37.830585,-78.28349,Fluvanna County,county
+iso1:us#iso2:us-il#fips:17097,17097,17,17,Lake,443.91504000000003,42.326443,-87.435974,Lake County,county
+iso1:us#iso2:us-ga#fips:13195,13195,13,13,Madison,282.3374,34.128525,-83.203735,Madison County,county
+iso1:us#iso2:us-ar#fips:05039,5039,5,5,Dallas,667.409,33.967822999999996,-92.654,Dallas County,county
+iso1:us#iso2:us-co#fips:08057,8057,8,8,Jackson,1613.7805,40.663433000000005,-106.32925,Jackson County,county
+iso1:us#iso2:us-co#fips:08063,8063,8,8,Kit Carson,2160.895,39.30534,-102.60302,Kit Carson County,county
+iso1:us#iso2:us-id#fips:16073,16073,16,16,Owyhee,7668.467,42.57285,-116.18968999999998,Owyhee County,county
+iso1:us#iso2:us-wi#fips:55141,55141,55,55,Wood,793.0427,44.461414000000005,-90.038826,Wood County,county
+iso1:us#iso2:us-ny#fips:36013,36013,36,36,Chautauqua,1060.2909,42.304214,-79.40759,Chautauqua County,county
+iso1:us#iso2:us-ga#fips:13067,13067,13,13,Cobb,339.8017,33.93993,-84.57411,Cobb County,county
+iso1:us#iso2:us-tn#fips:47091,47091,47,47,Johnson,298.4502,36.4532,-81.861244,Johnson County,county
+iso1:us#iso2:us-oh#fips:39013,39013,39,39,Belmont,532.1437400000001,40.01768,-80.96773,Belmont County,county
+iso1:us#iso2:us-va#fips:51195,51195,51,51,Wise,403.45306,36.97456,-82.62156,Wise County,county
+iso1:us#iso2:us-mo#fips:29035,29035,29,29,Carter,507.37573,36.94486,-90.9457,Carter County,county
+iso1:us#iso2:us-ok#fips:40013,40013,40,40,Bryan,904.2726,33.964005,-96.26414,Bryan County,county
+iso1:us#iso2:us-ne#fips:31035,31035,31,31,Clay,572.30896,40.52367,-98.05086,Clay County,county
+iso1:us#iso2:us-md#fips:24017,24017,24,24,Charles,457.8125,38.472854999999996,-77.01543000000001,Charles County,county
+iso1:us#iso2:us-ia#fips:19033,19033,19,19,Cerro Gordo,568.3192,43.074974,-93.25095999999999,Cerro Gordo County,county
+iso1:us#iso2:us-ia#fips:19073,19073,19,19,Greene,569.63715,42.042496,-94.3887,Greene County,county
+iso1:us#iso2:us-ky#fips:21205,21205,21,21,Rowan,279.84924,38.204266,-83.42808000000001,Rowan County,county
+iso1:us#iso2:us-ut#fips:49055,49055,49,49,Wayne,2461.1033,38.259842,-110.990875,Wayne County,county
+iso1:us#iso2:us-mo#fips:29031,29031,29,29,Cape Girardeau,578.5607,37.38414,-89.68565,Cape Girardeau County,county
+iso1:us#iso2:us-wa#fips:53071,53071,53,53,Walla Walla,1270.0757,46.254604,-118.48037,Walla Walla County,county
+iso1:us#iso2:us-mo#fips:29133,29133,29,29,Mississippi,411.59713999999997,36.826263,-89.29593,Mississippi County,county
+iso1:us#iso2:us-ar#fips:05025,5025,5,5,Cleveland,597.799,33.8932,-92.18871,Cleveland County,county
+iso1:us#iso2:us-tx#fips:48113,48113,48,48,Dallas,872.40436,32.766987,-96.77843,Dallas County,county
+iso1:us#iso2:us-pr#fips:72079,72079,72,72,Lajas Municipio,59.95900699999999,17.978512,-67.04011,Lajas Municipio,county
+iso1:us#iso2:us-in#fips:18033,18033,18,18,DeKalb,362.84488,41.401188,-85.00018,DeKalb County,county
+iso1:us#iso2:us-la#fips:22073,22073,22,22,Ouachita Parish,610.4225,32.48093,-92.15158000000001,Ouachita Parish,county
+iso1:us#iso2:us-la#fips:22095,22095,22,22,St. John the Baptist Parish,214.32724,30.144068,-90.49096,St. John the Baptist Parish,county
+iso1:us#iso2:us-la#fips:22091,22091,22,22,St. Helena Parish,408.4222,30.822538,-90.70830500000001,St. Helena Parish,county
+iso1:us#iso2:us-mo#fips:29197,29197,29,29,Schuyler,307.3155,40.469359999999995,-92.51901,Schuyler County,county
+iso1:us#iso2:us-al#fips:01059,1059,1,1,Franklin,633.94006,34.441990000000004,-87.84281,Franklin County,county
+iso1:us#iso2:us-ky#fips:21041,21041,21,21,Carroll,128.5748,38.668392,-85.12402,Carroll County,county
+iso1:us#iso2:us-co#fips:08019,8019,8,8,Clear Creek,395.0863,39.66973,-105.69256999999999,Clear Creek County,county
+iso1:us#iso2:us-tx#fips:48267,48267,48,48,Kimble,1251.0275,30.479471000000004,-99.7464,Kimble County,county
+iso1:us#iso2:us-mi#fips:26097,26097,26,26,Mackinac,1021.8994,46.16787,-85.303764,Mackinac County,county
+iso1:us#iso2:us-tx#fips:48307,48307,48,48,McCulloch,1065.6371,31.205477000000002,-99.35985600000001,McCulloch County,county
+iso1:us#iso2:us-ms#fips:28141,28141,28,28,Tishomingo,424.3171,34.737697999999995,-88.23606,Tishomingo County,county
+iso1:us#iso2:us-tx#fips:48105,48105,48,48,Crockett,2807.4192,30.717531,-101.40420999999999,Crockett County,county
+iso1:us#iso2:us-tx#fips:48217,48217,48,48,Hill,958.88904,31.982681,-97.13067,Hill County,county
+iso1:us#iso2:us-co#fips:08075,8075,8,8,Logan,1838.6609,40.728092,-103.09046,Logan County,county
+iso1:us#iso2:us-ks#fips:20055,20055,20,20,Finney,1302.0417,38.04981,-100.73997,Finney County,county
+iso1:us#iso2:us-ks#fips:20125,20125,20,20,Montgomery,643.6156,37.189537,-95.7424,Montgomery County,county
+iso1:us#iso2:us-sc#fips:45039,45039,45,45,Fairfield,686.3281,34.395668,-81.127,Fairfield County,county
+iso1:us#iso2:us-ne#fips:31033,31033,31,31,Cheyenne,1196.3271,41.214237,-103.01193,Cheyenne County,county
+iso1:us#iso2:us-mn#fips:27091,27091,27,27,Martin,712.3549,43.677116,-94.537254,Martin County,county
+iso1:us#iso2:us-tn#fips:47155,47155,47,47,Sevier,592.5087,35.795345000000005,-83.51849,Sevier County,county
+iso1:us#iso2:us-tn#fips:47139,47139,47,47,Polk,434.62015,35.109435999999995,-84.541115,Polk County,county
+iso1:us#iso2:us-tx#fips:48263,48263,48,48,Kent,902.53754,33.184779999999996,-100.76971999999999,Kent County,county
+iso1:us#iso2:us-mt#fips:30099,30099,30,30,Teton,2271.6804,47.819035,-112.28171999999999,Teton County,county
+iso1:us#iso2:us-ne#fips:31069,31069,31,31,Garden,1705.5037,41.633365999999995,-102.302986,Garden County,county
+iso1:us#iso2:us-il#fips:17117,17117,17,17,Macoupin,863.00305,39.265915,-89.92633000000001,Macoupin County,county
+iso1:us#iso2:us-oh#fips:39141,39141,39,39,Ross,689.21063,39.3239,-83.05954,Ross County,county
+iso1:us#iso2:us-il#fips:17195,17195,17,17,Whiteside,684.1225,41.750675,-89.911,Whiteside County,county
+iso1:us#iso2:us-tx#fips:48141,48141,48,48,El Paso,1013.2814300000001,31.766479999999998,-106.241425,El Paso County,county
+iso1:us#iso2:us-tx#fips:48301,48301,48,48,Loving,668.8405,31.844935999999997,-103.561226,Loving County,county
+iso1:us#iso2:us-ok#fips:40077,40077,40,40,Latimer,722.1168,34.875137,-95.27226,Latimer County,county
+iso1:us#iso2:us-oh#fips:39167,39167,39,39,Washington,631.99554,39.450676,-81.49064,Washington County,county
+iso1:us#iso2:us-mo#fips:29091,29091,29,29,Howell,927.2799699999999,36.774370000000005,-91.88736999999999,Howell County,county
+iso1:us#iso2:us-ks#fips:20047,20047,20,20,Edwards,621.9156,37.883595,-99.30475,Edwards County,county
+iso1:us#iso2:us-ky#fips:21111,21111,21,21,Jefferson,380.72213999999997,38.189533000000004,-85.65762,Jefferson County,county
+iso1:us#iso2:us-il#fips:17107,17107,17,17,Logan,618.0771,40.129276000000004,-89.36531,Logan County,county
+iso1:us#iso2:us-wi#fips:55139,55139,55,55,Winnebago,434.71167,44.08571,-88.66815,Winnebago County,county
+iso1:us#iso2:us-ky#fips:21075,21075,21,21,Fulton,205.93822,36.552513,-89.18766,Fulton County,county
+iso1:us#iso2:us-ks#fips:20079,20079,20,20,Harvey,539.7742,38.050144,-97.43670999999999,Harvey County,county
+iso1:us#iso2:us-mt#fips:30021,30021,30,30,Dawson,2371.9983,47.26613,-104.89827,Dawson County,county
+iso1:us#iso2:us-wv#fips:54091,54091,54,54,Taylor,172.77696,39.332478,-80.046555,Taylor County,county
+iso1:us#iso2:us-mi#fips:26111,26111,26,26,Midland,516.29675,43.648205,-84.37942,Midland County,county
+iso1:us#iso2:us-ms#fips:28119,28119,28,28,Quitman,405.02547999999996,34.252834,-90.29016999999999,Quitman County,county
+iso1:us#iso2:us-ky#fips:21093,21093,21,21,Hardin,623.4177,37.695834999999995,-85.96318000000001,Hardin County,county
+iso1:us#iso2:us-il#fips:17081,17081,17,17,Jefferson,571.22363,38.300779999999996,-88.92421,Jefferson County,county
+iso1:us#iso2:us-sd#fips:46057,46057,46,46,Hamlin,506.97574000000003,44.680620000000005,-97.1786,Hamlin County,county
+iso1:us#iso2:us-wi#fips:55069,55069,55,55,Lincoln,878.73376,45.338417,-89.74231,Lincoln County,county
+iso1:us#iso2:us-ny#fips:36033,36033,36,36,Franklin,1629.2692,44.594376000000004,-74.31067,Franklin County,county
+iso1:us#iso2:us-va#fips:51630,51630,51,51,Fredericksburg city,10.451047,38.29927,-77.48666,Fredericksburg city,county
+iso1:us#iso2:us-wv#fips:54081,54081,54,54,Raleigh,605.3784,37.76247,-81.26467,Raleigh County,county
+iso1:us#iso2:us-nm#fips:35005,35005,35,35,Chaves,6067.38,33.361603,-104.46984,Chaves County,county
+iso1:us#iso2:us-nm#fips:35049,35049,35,35,Santa Fe,1910.4429,35.51453,-105.963974,Santa Fe County,county
+iso1:us#iso2:us-ca#fips:06059,6059,6,6,Orange,792.83673,33.675686,-117.77721000000001,Orange County,county
+iso1:us#iso2:us-az#fips:04023,4023,4,4,Santa Cruz,1236.2767,31.525734000000003,-110.84523,Santa Cruz County,county
+iso1:us#iso2:us-nc#fips:37053,37053,37,37,Currituck,261.92136,36.372173,-75.94122,Currituck County,county
+iso1:us#iso2:us-il#fips:17101,17101,17,17,Lawrence,372.19125,38.718956,-87.73021999999999,Lawrence County,county
+iso1:us#iso2:us-in#fips:18067,18067,18,18,Howard,293.08414,40.483536,-86.11412,Howard County,county
+iso1:us#iso2:us-in#fips:18125,18125,18,18,Pike,334.31372000000005,38.39796,-87.23254399999999,Pike County,county
+iso1:us#iso2:us-ky#fips:21047,21047,21,21,Christian,717.53394,36.89206,-87.49299,Christian County,county
+iso1:us#iso2:us-mi#fips:26045,26045,26,26,Eaton,575.222,42.589529999999996,-84.84645,Eaton County,county
+iso1:us#iso2:us-ia#fips:19179,19179,19,19,Wapello,431.8519,41.031277,-92.40947,Wapello County,county
+iso1:us#iso2:us-ca#fips:06025,6025,6,6,Imperial,4175.68,33.040813,-115.3554,Imperial County,county
+iso1:us#iso2:us-mi#fips:26027,26027,26,26,Cass,490.12198,41.917244000000004,-86.00014499999999,Cass County,county
+iso1:us#iso2:us-ms#fips:28157,28157,28,28,Wilkinson,678.12933,31.16109,-91.32461500000001,Wilkinson County,county
+iso1:us#iso2:us-ak#fips:02282,2282,2,2,Yakutat City and Borough,7623.536999999999,60.017452,-140.41695,Yakutat City and Borough,county
+iso1:us#iso2:us-ks#fips:20179,20179,20,20,Sheridan,895.9876,39.350547999999996,-100.44123,Sheridan County,county
+iso1:us#iso2:us-ms#fips:28079,28079,28,28,Leake,582.9172,32.76063,-89.52225,Leake County,county
+iso1:us#iso2:us-pr#fips:72025,72025,72,72,Caguas Municipio,58.604637,18.21111,-66.05096400000001,Caguas Municipio,county
+iso1:us#iso2:us-pr#fips:72027,72027,72,72,Camuy Municipio,46.3565,18.445469,-66.86314,Camuy Municipio,county
+iso1:us#iso2:us-ms#fips:28025,28025,28,28,Clay,410.07993,33.65967,-88.78246999999999,Clay County,county
+iso1:us#iso2:us-ms#fips:28037,28037,28,28,Franklin,563.98267,31.477771999999998,-90.895454,Franklin County,county
+iso1:us#iso2:us-ms#fips:28099,28099,28,28,Neshoba,570.15375,32.752518,-89.11928,Neshoba County,county
+iso1:us#iso2:us-sd#fips:46045,46045,46,46,Edmunds,1126.0189,45.41168,-99.20536,Edmunds County,county
+iso1:us#iso2:us-pr#fips:72119,72119,72,72,Río Grande Municipio,60.62341,18.37637,-65.79843000000001,Río Grande Municipio,county
+iso1:us#iso2:us-al#fips:01035,1035,1,1,Conecuh,850.2289,31.430925,-86.98872,Conecuh County,county
+iso1:us#iso2:us-in#fips:18029,18029,18,18,Dearborn,305.0972,39.14832,-84.973495,Dearborn County,county
+iso1:us#iso2:us-in#fips:18071,18071,18,18,Jackson,509.99158,38.911957,-86.04252,Jackson County,county
+iso1:us#iso2:us-ms#fips:28081,28081,28,28,Lee,449.9804,34.29237,-88.68244,Lee County,county
+iso1:us#iso2:us-la#fips:22125,22125,22,22,West Feliciana Parish,403.33215,30.872702,-91.42100500000001,West Feliciana Parish,county
+iso1:us#iso2:us-ar#fips:05035,5035,5,5,Crittenden,610.4031,35.21188,-90.31533,Crittenden County,county
+iso1:us#iso2:us-fl#fips:12063,12063,12,12,Jackson,918.2077,30.78925,-85.20881999999999,Jackson County,county
+iso1:us#iso2:us-tx#fips:48125,48125,48,48,Dickens,901.7547599999999,33.615364,-100.78761999999999,Dickens County,county
+iso1:us#iso2:us-va#fips:51115,51115,51,51,Mathews,85.91315,37.425346000000005,-76.26881,Mathews County,county
+iso1:us#iso2:us-nd#fips:38075,38075,38,38,Renville,877.29395,48.71278,-101.65815,Renville County,county
+iso1:us#iso2:us-tx#fips:48283,48283,48,48,La Salle,1486.7546,28.351096999999996,-99.09676999999999,La Salle County,county
+iso1:us#iso2:us-ny#fips:36067,36067,36,36,Onondaga,778.4135,43.006516,-76.19614,Onondaga County,county
+iso1:us#iso2:us-ia#fips:19087,19087,19,19,Henry,434.30212,40.984802,-91.54726,Henry County,county
+iso1:us#iso2:us-ne#fips:31083,31083,31,31,Harlan,553.48517,40.17877,-99.40342,Harlan County,county
+iso1:us#iso2:us-mt#fips:30075,30075,30,30,Powder River,3298.3083,45.408928,-105.55533999999999,Powder River County,county
+iso1:us#iso2:us-pr#fips:72075,72075,72,72,Juana Díaz Municipio,60.2792,17.997974,-66.49049000000001,Juana Díaz Municipio,county
+iso1:us#iso2:us-wi#fips:55091,55091,55,55,Pepin,232.01456000000002,44.627438,-91.83489,Pepin County,county
+iso1:us#iso2:us-az#fips:04001,4001,4,4,Apache,11198.13,35.385082000000004,-109.49016999999999,Apache County,county
+iso1:us#iso2:us-mo#fips:29121,29121,29,29,Macon,801.2348,39.829796,-92.56434,Macon County,county
+iso1:us#iso2:us-tx#fips:48279,48279,48,48,Lamb,1016.2159,34.068863,-102.348015,Lamb County,county
+iso1:us#iso2:us-ks#fips:20097,20097,20,20,Kiowa,722.6641,37.56123,-99.28654,Kiowa County,county
+iso1:us#iso2:us-tx#fips:48015,48015,48,48,Austin,646.5137,29.891901,-96.27017,Austin County,county
+iso1:us#iso2:us-mo#fips:29061,29061,29,29,Daviess,563.30115,39.962837,-93.970055,Daviess County,county
+iso1:us#iso2:us-ga#fips:13253,13253,13,13,Seminole,237.54397999999998,30.93396,-84.86768000000001,Seminole County,county
+iso1:us#iso2:us-mi#fips:26101,26101,26,26,Manistee,542.3439,44.350384000000005,-86.60297,Manistee County,county
+iso1:us#iso2:us-ia#fips:19119,19119,19,19,Lyon,587.6702,43.38358,-96.2072,Lyon County,county
+iso1:us#iso2:us-tx#fips:48233,48233,48,48,Hutchinson,887.45056,35.837047999999996,-101.36275,Hutchinson County,county
+iso1:us#iso2:us-ok#fips:40139,40139,40,40,Texas,2041.3428,36.746315,-101.48385999999999,Texas County,county
+iso1:us#iso2:us-ok#fips:40153,40153,40,40,Woodward,1242.8281,36.425616999999995,-99.27365999999999,Woodward County,county
+iso1:us#iso2:us-ia#fips:19003,19003,19,19,Adams,423.44732999999997,41.021656,-94.69691,Adams County,county
+iso1:us#iso2:us-ca#fips:06101,6101,6,6,Sutter,602.5509,39.036190000000005,-121.70393999999999,Sutter County,county
+iso1:us#iso2:us-pa#fips:42105,42105,42,42,Potter,1081.3594,41.748585,-77.89443,Potter County,county
+iso1:us#iso2:us-tx#fips:48465,48465,48,48,Val Verde,3144.8564,29.875286,-101.143326,Val Verde County,county
+iso1:us#iso2:us-ks#fips:20077,20077,20,20,Harper,801.30133,37.188183,-98.06659,Harper County,county
+iso1:us#iso2:us-ia#fips:19133,19133,19,19,Monona,694.09546,42.04943,-95.95656600000001,Monona County,county
+iso1:us#iso2:us-ut#fips:49023,49023,49,49,Juab,3391.7942,39.71412,-112.790474,Juab County,county
+iso1:us#iso2:us-ok#fips:40137,40137,40,40,Stephens,870.2260000000001,34.481359999999995,-97.85560600000001,Stephens County,county
+iso1:us#iso2:us-ny#fips:36017,36017,36,36,Chenango,893.62286,42.478024,-75.60224000000001,Chenango County,county
+iso1:us#iso2:us-il#fips:17143,17143,17,17,Peoria,618.7359,40.785973,-89.76699,Peoria County,county
+iso1:us#iso2:us-ia#fips:19091,19091,19,19,Humboldt,434.38544,42.782222999999995,-94.202774,Humboldt County,county
+iso1:us#iso2:us-ne#fips:31177,31177,31,31,Washington,389.9707,41.533974,-96.22458,Washington County,county
+iso1:us#iso2:us-wi#fips:55049,55049,55,55,Iowa,762.7244,43.001022,-90.13369,Iowa County,county
+iso1:us#iso2:us-mn#fips:27097,27097,27,27,Morrison,1125.1326,46.020485,-94.26661999999999,Morrison County,county
+iso1:us#iso2:us-pa#fips:42003,42003,42,42,Allegheny,730.1419,40.469757,-79.98045,Allegheny County,county
+iso1:us#iso2:us-mo#fips:29205,29205,29,29,Shelby,500.88043,39.79753,-92.08872,Shelby County,county
+iso1:us#iso2:us-oh#fips:39097,39097,39,39,Madison,465.82718,39.896606,-83.40089,Madison County,county
+iso1:us#iso2:us-ks#fips:20201,20201,20,20,Washington,894.79083,39.776714,-97.09561,Washington County,county
+iso1:us#iso2:us-il#fips:17019,17019,17,17,Champaign,996.1466,40.138985,-88.196976,Champaign County,county
+iso1:us#iso2:us-id#fips:16087,16087,16,16,Washington,1452.9019,44.448223,-116.79778999999999,Washington County,county
+iso1:us#iso2:us-il#fips:17045,17045,17,17,Edgar,623.3448,39.679035,-87.74710999999999,Edgar County,county
+iso1:us#iso2:us-co#fips:08121,8121,8,8,Washington,2518.1694,39.965790000000005,-103.20975,Washington County,county
+iso1:us#iso2:us-oh#fips:39065,39065,39,39,Hardin,470.32574000000005,40.660416,-83.66408,Hardin County,county
+iso1:us#iso2:us-mi#fips:26113,26113,26,26,Missaukee,564.807,44.325424,-85.08547,Missaukee County,county
+iso1:us#iso2:us-nd#fips:38093,38093,38,38,Stutsman,2221.979,46.972225,-98.95612,Stutsman County,county
+iso1:us#iso2:us-mo#fips:29203,29203,29,29,Shannon,1003.85516,37.1525,-91.39133000000001,Shannon County,county
+iso1:us#iso2:us-tx#fips:48423,48423,48,48,Smith,921.5044,32.377014,-95.27004000000001,Smith County,county
+iso1:us#iso2:us-ok#fips:40143,40143,40,40,Tulsa,570.10004,36.12032,-95.94181,Tulsa County,county
+iso1:us#iso2:us-ok#fips:40091,40091,40,40,McIntosh,618.30927,35.369106,-95.67178,McIntosh County,county
+iso1:us#iso2:us-tx#fips:48395,48395,48,48,Robertson,855.137,31.025479999999998,-96.51494,Robertson County,county
+iso1:us#iso2:us-tx#fips:48171,48171,48,48,Gillespie,1058.2377,30.325090000000003,-98.94185,Gillespie County,county
+iso1:us#iso2:us-mi#fips:26125,26125,26,26,Oakland,867.1874,42.66045,-83.38421,Oakland County,county
+iso1:us#iso2:us-nd#fips:38033,38033,38,38,Golden Valley,1000.9191,46.938922999999996,-103.84461,Golden Valley County,county
+iso1:us#iso2:us-wy#fips:56027,56027,56,56,Niobrara,2626.1172,43.06216,-104.468376,Niobrara County,county
+iso1:us#iso2:us-mn#fips:27117,27117,27,27,Pipestone,465.07175,44.01536,-96.25701,Pipestone County,county
+iso1:us#iso2:us-va#fips:51099,51099,51,51,King George,179.63397,38.27718,-77.16263599999999,King George County,county
+iso1:us#iso2:us-wa#fips:53025,53025,53,53,Grant,2679.5916,47.213634000000006,-119.46779,Grant County,county
+iso1:us#iso2:us-mn#fips:27129,27129,27,27,Renville,982.9509,44.723698,-94.95562,Renville County,county
+iso1:us#iso2:us-fl#fips:12001,12001,12,12,Alachua,875.5685,29.675741,-82.35722,Alachua County,county
+iso1:us#iso2:us-ne#fips:31091,31091,31,31,Hooker,721.18463,41.920320000000004,-101.117325,Hooker County,county
+iso1:us#iso2:us-va#fips:51147,51147,51,51,Prince Edward,349.97336,37.22488,-78.43296,Prince Edward County,county
+iso1:us#iso2:us-ut#fips:49007,49007,49,49,Carbon,1479.2339,39.673283000000005,-110.588486,Carbon County,county
+iso1:us#iso2:us-pa#fips:42017,42017,42,42,Bucks,604.4223,40.336887,-75.10706,Bucks County,county
+iso1:us#iso2:us-sd#fips:46059,46059,46,46,Hand,1436.6985,44.546715,-99.00458,Hand County,county
+iso1:us#iso2:us-pa#fips:42081,42081,42,42,Lycoming,1228.8063,41.343884,-77.05526,Lycoming County,county
+iso1:us#iso2:us-id#fips:16057,16057,16,16,Latah,1075.9037,46.81892,-116.73097,Latah County,county
+iso1:us#iso2:us-ga#fips:13237,13237,13,13,Putnam,344.69354,33.321059999999996,-83.37179,Putnam County,county
+iso1:us#iso2:us-va#fips:51640,51640,51,51,Galax city,8.236641,36.665638,-80.91431,Galax city,county
+iso1:us#iso2:us-nm#fips:35037,35037,35,35,Quay,2874.0525,35.107018,-103.54807,Quay County,county
+iso1:us#iso2:us-tx#fips:48269,48269,48,48,King,910.90344,33.61427,-100.245346,King County,county
+iso1:us#iso2:us-ar#fips:05073,5073,5,5,Lafayette,528.3131,33.240629999999996,-93.61151,Lafayette County,county
+iso1:us#iso2:us-tx#fips:48451,48451,48,48,Tom Green,1522.0531,31.398822999999997,-100.46379,Tom Green County,county
+iso1:us#iso2:us-fl#fips:12049,12049,12,12,Hardee,637.5966,27.492846000000004,-81.82158000000001,Hardee County,county
+iso1:us#iso2:us-oh#fips:39025,39025,39,39,Clermont,452.13455,39.052054999999996,-84.14948000000001,Clermont County,county
+iso1:us#iso2:us-tx#fips:48501,48501,48,48,Yoakum,799.74225,33.1624,-102.832245,Yoakum County,county
+iso1:us#iso2:us-or#fips:41071,41071,41,41,Yamhill,715.9231,45.247826,-123.3164,Yamhill County,county
+iso1:us#iso2:us-ia#fips:19115,19115,19,19,Louisa,401.7854,41.218212,-91.256996,Louisa County,county
+iso1:us#iso2:us-ks#fips:20049,20049,20,20,Elk,644.2862,37.456024,-96.244644,Elk County,county
+iso1:us#iso2:us-oh#fips:39121,39121,39,39,Noble,398.02557,39.76723,-81.45249,Noble County,county
+iso1:us#iso2:us-oh#fips:39137,39137,39,39,Putnam,482.56055,41.024532,-84.12988,Putnam County,county
+iso1:us#iso2:us-tx#fips:48425,48425,48,48,Somervell,186.47398,32.218070000000004,-97.76921999999999,Somervell County,county
+iso1:us#iso2:us-pa#fips:42075,42075,42,42,Lebanon,361.8247,40.37145,-76.46481999999999,Lebanon County,county
+iso1:us#iso2:us-mt#fips:30035,30035,30,30,Glacier,2995.048,48.70567,-112.9905,Glacier County,county
+iso1:us#iso2:us-nv#fips:32027,32027,32,32,Pershing,6036.7935,40.439640000000004,-118.40948,Pershing County,county
+iso1:us#iso2:us-mn#fips:27087,27087,27,27,Mahnomen,557.8857,47.32839,-95.81109000000001,Mahnomen County,county
+iso1:us#iso2:us-nj#fips:34031,34031,34,34,Passaic,186.01772,41.037890000000004,-74.29828,Passaic County,county
+iso1:us#iso2:us-mt#fips:30047,30047,30,30,Lake,1490.5173,47.642902,-114.08368999999999,Lake County,county
+iso1:us#iso2:us-tx#fips:48261,48261,48,48,Kenedy,1458.5026,26.890213,-97.59114,Kenedy County,county
+iso1:us#iso2:us-tx#fips:48033,48033,48,48,Borden,897.47327,32.73859,-101.4392,Borden County,county
+iso1:us#iso2:us-mo#fips:29157,29157,29,29,Perry,474.37127999999996,37.71113,-89.80212399999999,Perry County,county
+iso1:us#iso2:us-tx#fips:48411,48411,48,48,San Saba,1135.3516,31.155138,-98.81929000000001,San Saba County,county
+iso1:us#iso2:us-ok#fips:40073,40073,40,40,Kingfisher,898.10645,35.949436,-97.934555,Kingfisher County,county
+iso1:us#iso2:us-tx#fips:48051,48051,48,48,Burleson,659.0559,30.493485999999997,-96.62209,Burleson County,county
+iso1:us#iso2:us-ny#fips:36035,36035,36,36,Fulton,495.47652999999997,43.11561,-74.423676,Fulton County,county
+iso1:us#iso2:us-ms#fips:28133,28133,28,28,Sunflower,697.78253,33.60553,-90.59509,Sunflower County,county
+iso1:us#iso2:us-mn#fips:27053,27053,27,27,Hennepin,553.8634,45.006122999999995,-93.47523000000001,Hennepin County,county
+iso1:us#iso2:us-pa#fips:42027,42027,42,42,Centre,1108.7312,40.909126,-77.84788,Centre County,county
+iso1:us#iso2:us-tx#fips:48025,48025,48,48,Bee,880.2693,28.416077,-97.742584,Bee County,county
+iso1:us#iso2:us-tn#fips:47077,47077,47,47,Henderson,520.02655,35.653996,-88.38767,Henderson County,county
+iso1:us#iso2:us-ia#fips:19171,19171,19,19,Tama,721.0357700000001,42.07485,-92.52941,Tama County,county
+iso1:us#iso2:us-ks#fips:20175,20175,20,20,Seward,639.6746,37.18096,-100.855255,Seward County,county
+iso1:us#iso2:us-ia#fips:19135,19135,19,19,Monroe,433.73132000000004,41.028847,-92.869644,Monroe County,county
+iso1:us#iso2:us-ne#fips:31147,31147,31,31,Richardson,551.8597,40.123740000000005,-95.71860500000001,Richardson County,county
+iso1:us#iso2:us-il#fips:17021,17021,17,17,Christian,709.51373,39.545525,-89.27959399999999,Christian County,county
+iso1:us#iso2:us-fl#fips:12089,12089,12,12,Nassau,648.7025,30.605963,-81.76508000000001,Nassau County,county
+iso1:us#iso2:us-fl#fips:12133,12133,12,12,Washington,584.6967,30.602217,-85.662796,Washington County,county
+iso1:us#iso2:us-ga#fips:13007,13007,13,13,Baker,341.96896,31.31958,-84.45488,Baker County,county
+iso1:us#iso2:us-ga#fips:13275,13275,13,13,Thomas,544.6415,30.864620000000002,-83.919815,Thomas County,county
+iso1:us#iso2:us-ky#fips:21005,21005,21,21,Anderson,202.17293999999998,38.005398,-84.98642,Anderson County,county
+iso1:us#iso2:us-ky#fips:21185,21185,21,21,Oldham,187.2479,38.400127000000005,-85.456154,Oldham County,county
+iso1:us#iso2:us-ga#fips:13057,13057,13,13,Cherokee,421.09772000000004,34.244316,-84.47506,Cherokee County,county
+iso1:us#iso2:us-nd#fips:38065,38065,38,38,Oliver,722.4284700000001,47.11808,-101.33142,Oliver County,county
+iso1:us#iso2:us-mi#fips:26133,26133,26,26,Osceola,566.3054,43.99755,-85.32228,Osceola County,county
+iso1:us#iso2:us-tn#fips:47109,47109,47,47,McNairy,562.8609,35.175377000000005,-88.56373599999999,McNairy County,county
+iso1:us#iso2:us-wa#fips:53001,53001,53,53,Adams,1925.0546,47.01124,-118.51286,Adams County,county
+iso1:us#iso2:us-mo#fips:29057,29057,29,29,Dade,490.02704000000006,37.43235,-93.85488000000001,Dade County,county
+iso1:us#iso2:us-la#fips:22101,22101,22,22,St. Mary Parish,555.6032,29.629348999999998,-91.463806,St. Mary Parish,county
+iso1:us#iso2:us-vt#fips:50007,50007,50,50,Chittenden,536.6038,44.46333,-73.06940999999999,Chittenden County,county
+iso1:us#iso2:us-pr#fips:72045,72045,72,72,Comerío Municipio,28.401556,18.22503,-66.21948,Comerío Municipio,county
+iso1:us#iso2:us-hi#fips:15009,15009,15,15,Maui,1161.5695,20.855929999999997,-156.60155,Maui County,county
+iso1:us#iso2:us-la#fips:22057,22057,22,22,Lafourche Parish,1068.3959,29.491993,-90.39485,Lafourche Parish,county
+iso1:us#iso2:us-ia#fips:19139,19139,19,19,Muscatine,437.4598,41.483776,-91.1187,Muscatine County,county
+iso1:us#iso2:us-fl#fips:12113,12113,12,12,Santa Rosa,1012.4139,30.70127,-87.01289,Santa Rosa County,county
+iso1:us#iso2:us-in#fips:18101,18101,18,18,Martin,335.7719,38.705321999999995,-86.80185,Martin County,county
+iso1:us#iso2:us-ky#fips:21203,21203,21,21,Rockcastle,316.5581,37.36105,-84.31437,Rockcastle County,county
+iso1:us#iso2:us-ky#fips:21223,21223,21,21,Trimble,151.65313999999998,38.62004,-85.35120400000001,Trimble County,county
+iso1:us#iso2:us-ga#fips:13055,13055,13,13,Chattooga,313.33734,34.47418,-85.34529,Chattooga County,county
+iso1:us#iso2:us-sc#fips:45033,45033,45,45,Dillon,405.08087,34.39017,-79.37496,Dillon County,county
+iso1:us#iso2:us-nc#fips:37103,37103,37,37,Jones,471.38382,35.032270000000004,-77.35619,Jones County,county
+iso1:us#iso2:us-mo#fips:29199,29199,29,29,Scotland,436.522,40.447685,-92.14282,Scotland County,county
+iso1:us#iso2:us-ks#fips:20131,20131,20,20,Nemaha,717.4516,39.791042,-96.00538,Nemaha County,county
+iso1:us#iso2:us-ks#fips:20137,20137,20,20,Norton,878.07355,39.783867,-99.89924,Norton County,county
+iso1:us#iso2:us-pr#fips:72007,72007,72,72,Aguas Buenas Municipio,30.085907000000002,18.256523,-66.12849399999999,Aguas Buenas Municipio,county
+iso1:us#iso2:us-pr#fips:72033,72033,72,72,Cataño Municipio,4.8763623,18.444614,-66.14882,Cataño Municipio,county
+iso1:us#iso2:us-ne#fips:31065,31065,31,31,Furnas,719.15607,40.191864,-99.90966,Furnas County,county
+iso1:us#iso2:us-ga#fips:13087,13087,13,13,Decatur,597.1921,30.880644,-84.58389,Decatur County,county
+iso1:us#iso2:us-in#fips:18177,18177,18,18,Wayne,401.76813,39.86309,-85.00674000000001,Wayne County,county
+iso1:us#iso2:us-ky#fips:21009,21009,21,21,Barren,487.60074000000003,36.962807,-85.932106,Barren County,county
+iso1:us#iso2:us-ne#fips:31093,31093,31,31,Howard,569.3573,41.21685,-98.51334,Howard County,county
+iso1:us#iso2:us-nd#fips:38025,38025,38,38,Dunn,2008.5599,47.354557,-102.61232,Dunn County,county
+iso1:us#iso2:us-ca#fips:06005,6005,6,6,Amador,594.5919,38.44355,-120.65385400000001,Amador County,county
+iso1:us#iso2:us-tn#fips:47049,47049,47,47,Fentress,498.63574000000006,36.369892,-84.93777,Fentress County,county
+iso1:us#iso2:us-ks#fips:20031,20031,20,20,Coffey,626.906,38.23645,-95.72913,Coffey County,county
+iso1:us#iso2:us-mi#fips:26023,26023,26,26,Branch,506.43094,41.918453,-85.06689,Branch County,county
+iso1:us#iso2:us-va#fips:51031,51031,51,51,Campbell,503.22443,37.21015,-79.09543000000001,Campbell County,county
+iso1:us#iso2:us-oh#fips:39105,39105,39,39,Meigs,430.11618,39.089806,-82.0284,Meigs County,county
+iso1:us#iso2:us-wv#fips:54067,54067,54,54,Nicholas,646.86835,38.29143,-80.797516,Nicholas County,county
+iso1:us#iso2:us-ok#fips:40053,40053,40,40,Grant,1000.7739,36.788253999999995,-97.788155,Grant County,county
+iso1:us#iso2:us-sd#fips:46115,46115,46,46,Spink,1503.5627,44.923770000000005,-98.33961500000001,Spink County,county
+iso1:us#iso2:us-vt#fips:50027,50027,50,50,Windsor,969.6113,43.572685,-72.59881999999999,Windsor County,county
+iso1:us#iso2:us-tx#fips:48455,48455,48,48,Trinity,693.82007,31.096676000000002,-95.15169,Trinity County,county
+iso1:us#iso2:us-nm#fips:35001,35001,35,35,Bernalillo,1161.2977,35.053627,-106.66908000000001,Bernalillo County,county
+iso1:us#iso2:us-ga#fips:13205,13205,13,13,Mitchell,512.1754,31.228996000000002,-84.19204,Mitchell County,county
+iso1:us#iso2:us-hi#fips:15001,15001,15,15,Hawaii,4028.5862,19.597765,-155.50243999999998,Hawaii County,county
+iso1:us#iso2:us-ky#fips:21147,21147,21,21,McCreary,426.8183,36.731136,-84.49105,McCreary County,county
+iso1:us#iso2:us-ky#fips:21191,21191,21,21,Pendleton,277.16766,38.696284999999996,-84.35194399999999,Pendleton County,county
+iso1:us#iso2:us-ky#fips:21215,21215,21,21,Spencer,186.72974,38.02541,-85.31718000000001,Spencer County,county
+iso1:us#iso2:us-mt#fips:30041,30041,30,30,Hill,2899.2686,48.631958000000004,-110.10632,Hill County,county
+iso1:us#iso2:us-ne#fips:31175,31175,31,31,Valley,568.1311,41.564095,-98.98348,Valley County,county
+iso1:us#iso2:us-tx#fips:48069,48069,48,48,Castro,894.47485,34.53362,-102.25879,Castro County,county
+iso1:us#iso2:us-md#fips:24043,24043,24,24,Washington,457.7828,39.603621999999994,-77.814674,Washington County,county
+iso1:us#iso2:us-ky#fips:21133,21133,21,21,Letcher,337.94186,37.118534000000004,-82.86125,Letcher County,county
+iso1:us#iso2:us-nj#fips:34033,34033,34,34,Salem,331.87282999999996,39.57383,-75.35735,Salem County,county
+iso1:us#iso2:us-va#fips:51680,51680,51,51,Lynchburg city,48.975840000000005,37.399017,-79.19546,Lynchburg city,county
+iso1:us#iso2:us-ar#fips:05125,5125,5,5,Saline,723.5983,34.648525,-92.67446,Saline County,county
+iso1:us#iso2:us-wv#fips:54053,54053,54,54,Mason,430.782,38.770912,-82.02901,Mason County,county
+iso1:us#iso2:us-wv#fips:54021,54021,54,54,Gilmer,338.5141,38.915867,-80.84940999999999,Gilmer County,county
+iso1:us#iso2:us-ms#fips:28063,28063,28,28,Jefferson,519.9508,31.733633,-91.04388,Jefferson County,county
+iso1:us#iso2:us-nd#fips:38079,38079,38,38,Rolette,902.922,48.768271999999996,-99.84046,Rolette County,county
+iso1:us#iso2:us-mt#fips:30103,30103,30,30,Treasure,977.8339,46.229442999999996,-107.285774,Treasure County,county
+iso1:us#iso2:us-ky#fips:21049,21049,21,21,Clark,252.4959,37.970314,-84.14511999999999,Clark County,county
+iso1:us#iso2:us-pr#fips:72101,72101,72,72,Morovis Municipio,38.872616,18.319027,-66.42055500000001,Morovis Municipio,county
+iso1:us#iso2:us-mi#fips:26005,26005,26,26,Allegan,825.2812,42.595787,-86.63474000000001,Allegan County,county
+iso1:us#iso2:us-tn#fips:47005,47005,47,47,Benton,394.3196,36.07095,-88.071236,Benton County,county
+iso1:us#iso2:us-mn#fips:27015,27015,27,27,Brown,611.1301,44.24654,-94.73365,Brown County,county
+iso1:us#iso2:us-tn#fips:47137,47137,47,47,Pickett,162.98434,36.559364,-85.075745,Pickett County,county
+iso1:us#iso2:us-va#fips:51109,51109,51,51,Louisa,496.14917,37.972706,-77.95979,Louisa County,county
+iso1:us#iso2:us-in#fips:18145,18145,18,18,Shelby,411.15247,39.524136,-85.792175,Shelby County,county
+iso1:us#iso2:us-oh#fips:39049,39049,39,39,Franklin,532.4291400000001,39.969875,-83.00909,Franklin County,county
+iso1:us#iso2:us-ut#fips:49021,49021,49,49,Iron,3296.4495,37.909306,-113.30673999999999,Iron County,county
+iso1:us#iso2:us-nv#fips:32009,32009,32,32,Esmeralda,3582.011,37.778965,-117.63238500000001,Esmeralda County,county
+iso1:us#iso2:us-mi#fips:26083,26083,26,26,Keweenaw,540.13025,47.681973,-88.14879599999999,Keweenaw County,county
+iso1:us#iso2:us-ut#fips:49039,49039,49,49,Sanpete,1589.9847,39.382529999999996,-111.57288,Sanpete County,county
+iso1:us#iso2:us-ks#fips:20093,20093,20,20,Kearny,870.5729,37.99446,-101.308136,Kearny County,county
+iso1:us#iso2:us-fl#fips:12009,12009,12,12,Brevard,1015.0173300000001,28.298310999999998,-80.70033000000001,Brevard County,county
+iso1:us#iso2:us-in#fips:18105,18105,18,18,Monroe,394.53528,39.16073,-86.52331,Monroe County,county
+iso1:us#iso2:us-ia#fips:19117,19117,19,19,Lucas,430.61804000000006,41.033344,-93.33147,Lucas County,county
+iso1:us#iso2:us-ky#fips:21239,21239,21,21,Woodford,190.11786,38.043102000000005,-84.748856,Woodford County,county
+iso1:us#iso2:us-sc#fips:45053,45053,45,45,Jasper,655.1841,32.43059,-81.02163,Jasper County,county
+iso1:us#iso2:us-tx#fips:48043,48043,48,48,Brewster,6183.972,29.808996,-103.25246,Brewster County,county
+iso1:us#iso2:us-sc#fips:45065,45065,45,45,McCormick,359.14133,33.8976,-82.31619,McCormick County,county
+iso1:us#iso2:us-sc#fips:45087,45087,45,45,Union,514.1884,34.690395,-81.6159,Union County,county
+iso1:us#iso2:us-mn#fips:27103,27103,27,27,Nicollet,448.62505999999996,44.35882,-94.24568000000001,Nicollet County,county
+iso1:us#iso2:us-wi#fips:55075,55075,55,55,Marinette,1399.5132,45.346897,-87.991196,Marinette County,county
+iso1:us#iso2:us-wa#fips:53011,53011,53,53,Clark,628.5052,45.77173,-122.485954,Clark County,county
+iso1:us#iso2:us-wi#fips:55099,55099,55,55,Price,1254.0978,45.679072999999995,-90.35965,Price County,county
+iso1:us#iso2:us-in#fips:18103,18103,18,18,Miami,373.85495,40.772884000000005,-86.04426,Miami County,county
+iso1:us#iso2:us-ks#fips:20053,20053,20,20,Ellsworth,715.5995,38.700844000000004,-98.20535,Ellsworth County,county
+iso1:us#iso2:us-la#fips:22123,22123,22,22,West Carroll Parish,359.65814,32.79248,-91.451996,West Carroll Parish,county
+iso1:us#iso2:us-fl#fips:12077,12077,12,12,Liberty,835.5917400000001,30.25985,-84.86858000000001,Liberty County,county
+iso1:us#iso2:us-ks#fips:20083,20083,20,20,Hodgeman,860.0213,38.087494,-99.89841,Hodgeman County,county
+iso1:us#iso2:us-ks#fips:20119,20119,20,20,Meade,978.1159,37.243885,-100.36009,Meade County,county
+iso1:us#iso2:us-ky#fips:21149,21149,21,21,McLean,252.53522999999998,37.526707,-87.265594,McLean County,county
+iso1:us#iso2:us-ms#fips:28001,28001,28,28,Adams,462.35925,31.486225,-91.3518,Adams County,county
+iso1:us#iso2:us-pr#fips:72083,72083,72,72,Las Marías Municipio,46.361565,18.227594,-66.97758,Las Marías Municipio,county
+iso1:us#iso2:us-ms#fips:28057,28057,28,28,Itawamba,532.81323,34.281075,-88.36313,Itawamba County,county
+iso1:us#iso2:us-ky#fips:21073,21073,21,21,Franklin,207.84805,38.23492,-84.86879,Franklin County,county
+iso1:us#iso2:us-me#fips:23009,23009,23,23,Hancock,1587.1798,44.564907,-68.370705,Hancock County,county
+iso1:us#iso2:us-me#fips:23013,23013,23,23,Knox,365.1482,44.042046,-69.03851,Knox County,county
+iso1:us#iso2:us-ga#fips:13217,13217,13,13,Newton,273.8101,33.54404,-83.85519000000001,Newton County,county
+iso1:us#iso2:us-sd#fips:46049,46049,46,46,Faulk,981.725,45.065475,-99.153564,Faulk County,county
+iso1:us#iso2:us-mi#fips:26061,26061,26,26,Houghton,1009.1349,46.99843,-88.6519,Houghton County,county
+iso1:us#iso2:us-mt#fips:30061,30061,30,30,Mineral,1219.6609,47.151943,-115.06563,Mineral County,county
+iso1:us#iso2:us-tn#fips:47051,47051,47,47,Franklin,554.5138,35.155926,-86.099205,Franklin County,county
+iso1:us#iso2:us-la#fips:22029,22029,22,22,Concordia Parish,697.00464,31.469804999999997,-91.62631,Concordia Parish,county
+iso1:us#iso2:us-la#fips:22063,22063,22,22,Livingston Parish,648.1956,30.44042,-90.72747,Livingston Parish,county
+iso1:us#iso2:us-ma#fips:25009,25009,25,25,Essex,492.5322,42.642708,-70.86491,Essex County,county
+iso1:us#iso2:us-sd#fips:46019,46019,46,46,Butte,2250.094,44.896225,-103.501434,Butte County,county
+iso1:us#iso2:us-co#fips:08035,8035,8,8,Douglas,840.2798,39.325413,-104.92598999999998,Douglas County,county
+iso1:us#iso2:us-sc#fips:45079,45079,45,45,Richland,757.35156,34.029095,-80.89804000000001,Richland County,county
+iso1:us#iso2:us-in#fips:18095,18095,18,18,Madison,451.93542,40.166203,-85.72246,Madison County,county
+iso1:us#iso2:us-ok#fips:40099,40099,40,40,Murray,416.38766,34.485766999999996,-97.071556,Murray County,county
+iso1:us#iso2:us-wv#fips:54009,54009,54,54,Brooke,89.19873,40.272644,-80.57869000000001,Brooke County,county
+iso1:us#iso2:us-wv#fips:54013,54013,54,54,Calhoun,279.25903,38.844159999999995,-81.11548,Calhoun County,county
+iso1:us#iso2:us-va#fips:51021,51021,51,51,Bland,357.66292999999996,37.13061,-81.125854,Bland County,county
+iso1:us#iso2:us-mt#fips:30111,30111,30,30,Yellowstone,2633.5627,45.936985,-108.27666,Yellowstone County,county
+iso1:us#iso2:us-wv#fips:54043,54043,54,54,Lincoln,437.0553,38.17177,-82.07762,Lincoln County,county
+iso1:us#iso2:us-ca#fips:06033,6033,6,6,Lake,1256.5539999999999,39.094803000000006,-122.74676000000001,Lake County,county
+iso1:us#iso2:us-ga#fips:13131,13131,13,13,Grady,454.5168,30.875908000000003,-84.24508,Grady County,county
+iso1:us#iso2:us-co#fips:08021,8021,8,8,Conejos,1287.472,37.213406,-106.176445,Conejos County,county
+iso1:us#iso2:us-ut#fips:49037,49037,49,49,San Juan,7820.1074,37.602634,-109.79157,San Juan County,county
+iso1:us#iso2:us-in#fips:18133,18133,18,18,Putnam,480.55365,39.665546,-86.85337,Putnam County,county
+iso1:us#iso2:us-id#fips:16047,16047,16,16,Gooding,729.3459,42.973186,-114.82141999999999,Gooding County,county
+iso1:us#iso2:us-tn#fips:47167,47167,47,47,Tipton,458.42435,35.50026,-89.7668,Tipton County,county
+iso1:us#iso2:us-la#fips:22121,22121,22,22,West Baton Rouge Parish,192.39876999999998,30.464052000000002,-91.30981,West Baton Rouge Parish,county
+iso1:us#iso2:us-mo#fips:29171,29171,29,29,Putnam,517.3342,40.478607000000004,-93.014534,Putnam County,county
+iso1:us#iso2:us-wy#fips:56039,56039,56,56,Teton,3996.9822,44.04866,-110.42608999999999,Teton County,county
+iso1:us#iso2:us-wi#fips:55043,55043,55,55,Grant,1146.9177,42.870026,-90.69423,Grant County,county
+iso1:us#iso2:us-nd#fips:38059,38059,38,38,Morton,1925.9531,46.71082,-101.29826,Morton County,county
+iso1:us#iso2:us-nc#fips:37041,37041,37,37,Chowan,172.66301,36.12898,-76.60275,Chowan County,county
+iso1:us#iso2:us-nc#fips:37021,37021,37,37,Buncombe,656.51917,35.60937,-82.530426,Buncombe County,county
+iso1:us#iso2:us-ca#fips:06063,6063,6,6,Plumas,2553.1492,39.992294,-120.82437,Plumas County,county
+iso1:us#iso2:us-va#fips:51730,51730,51,51,Petersburg city,22.721062,37.20473,-77.392365,Petersburg city,county
+iso1:us#iso2:us-vt#fips:50023,50023,50,50,Washington,687.066,44.27499,-72.60951,Washington County,county
+iso1:us#iso2:us-sd#fips:46093,46093,46,46,Meade,3471.0518,44.60528,-102.71417,Meade County,county
+iso1:us#iso2:us-in#fips:18097,18097,18,18,Marion,396.5827,39.782973999999996,-86.135796,Marion County,county
+iso1:us#iso2:us-ar#fips:05017,5017,5,5,Chicot,644.7488400000001,33.267140000000005,-91.29715999999999,Chicot County,county
+iso1:us#iso2:us-ga#fips:13021,13021,13,13,Bibb,249.40692,32.808846,-83.69419,Bibb County,county
+iso1:us#iso2:us-pr#fips:72059,72059,72,72,Guayanilla Municipio,42.272053,18.005339000000003,-66.798294,Guayanilla Municipio,county
+iso1:us#iso2:us-pr#fips:72131,72131,72,72,San Sebastián Municipio,70.42546,18.331423,-66.97069499999999,San Sebastián Municipio,county
+iso1:us#iso2:us-ar#fips:05115,5115,5,5,Pope,812.5438,35.456559999999996,-93.02682,Pope County,county
+iso1:us#iso2:us-va#fips:51175,51175,51,51,Southampton,599.2161,36.720065999999996,-77.10381,Southampton County,county
+iso1:us#iso2:us-tx#fips:48183,48183,48,48,Gregg,273.38977,32.486397,-94.81628,Gregg County,county
+iso1:us#iso2:us-ny#fips:36087,36087,36,36,Rockland,173.45009,41.15463,-74.02466,Rockland County,county
+iso1:us#iso2:us-ar#fips:05089,5089,5,5,Marion,596.9769,36.266663,-92.67857,Marion County,county
+iso1:us#iso2:us-va#fips:51800,51800,51,51,Suffolk city,399.16702000000004,36.69716,-76.63478,Suffolk city,county
+iso1:us#iso2:us-co#fips:08041,8041,8,8,El Paso,2126.9216,38.827385,-104.52747,El Paso County,county
+iso1:us#iso2:us-mo#fips:29187,29187,29,29,St. Francois,451.90227999999996,37.810707,-90.47386999999999,St. Francois County,county
+iso1:us#iso2:us-tx#fips:48475,48475,48,48,Ward,835.6311,31.513070000000003,-103.10511,Ward County,county
+iso1:us#iso2:us-co#fips:08061,8061,8,8,Kiowa,1767.8689,38.387665000000005,-102.75685,Kiowa County,county
+iso1:us#iso2:us-tx#fips:48487,48487,48,48,Wilbarger,970.9788,34.084920000000004,-99.24244,Wilbarger County,county
+iso1:us#iso2:us-or#fips:41015,41015,41,41,Curry,1628.4368,42.466440000000006,-124.21093,Curry County,county
+iso1:us#iso2:us-co#fips:08119,8119,8,8,Teller,557.06104,38.869976,-105.18736000000001,Teller County,county
+iso1:us#iso2:us-mo#fips:29049,29049,29,29,Clinton,418.9717,39.608723,-94.39580500000001,Clinton County,county
+iso1:us#iso2:us-ut#fips:49051,49051,49,49,Wasatch,1177.0548,40.334885,-111.16157,Wasatch County,county
+iso1:us#iso2:us-id#fips:16029,16029,16,16,Caribou,1764.2538,42.78607,-111.54427,Caribou County,county
+iso1:us#iso2:us-nc#fips:37157,37157,37,37,Rockingham,565.6578400000001,36.381805,-79.78275,Rockingham County,county
+iso1:us#iso2:us-ar#fips:05117,5117,5,5,Prairie,647.89105,34.831115999999994,-91.55362,Prairie County,county
+iso1:us#iso2:us-ar#fips:05011,5011,5,5,Bradley,649.25757,33.46655,-92.16915999999999,Bradley County,county
+iso1:us#iso2:us-tx#fips:48193,48193,48,48,Hamilton,835.943,31.707341999999997,-98.111755,Hamilton County,county
+iso1:us#iso2:us-md#fips:24011,24011,24,24,Caroline,319.45257999999995,38.871532,-75.831665,Caroline County,county
+iso1:us#iso2:us-mn#fips:27041,27041,27,27,Douglas,636.7753,45.93683,-95.46216,Douglas County,county
+iso1:us#iso2:us-mt#fips:30043,30043,30,30,Jefferson,1656.9192,46.124233000000004,-112.059425,Jefferson County,county
+iso1:us#iso2:us-va#fips:51059,51059,51,51,Fairfax,391.02032,38.82952,-77.27325400000001,Fairfax County,county
+iso1:us#iso2:us-mt#fips:30023,30023,30,30,Deer Lodge,736.7077,46.094673,-113.141624,Deer Lodge County,county
+iso1:us#iso2:us-tn#fips:47001,47001,47,47,Anderson,337.21477999999996,36.11673,-84.19542,Anderson County,county
+iso1:us#iso2:us-oh#fips:39077,39077,39,39,Huron,491.5112,41.14508,-82.59464,Huron County,county
+iso1:us#iso2:us-ga#fips:13005,13005,13,13,Bacon,284.0946,31.550209000000002,-82.45143,Bacon County,county
+iso1:us#iso2:us-de#fips:10001,10001,10,10,Kent,586.0801,39.097088,-75.50298000000001,Kent County,county
+iso1:us#iso2:us-oh#fips:39173,39173,39,39,Wood,617.2093,41.360184000000004,-83.62268,Wood County,county
+iso1:us#iso2:us-ga#fips:13157,13157,13,13,Jackson,339.68015,34.130905,-83.56255,Jackson County,county
+iso1:us#iso2:us-ks#fips:20003,20003,20,20,Anderson,579.6644,38.215115000000004,-95.292046,Anderson County,county
+iso1:us#iso2:us-il#fips:17095,17095,17,17,Knox,716.409,40.930946,-90.21379,Knox County,county
+iso1:us#iso2:us-mt#fips:30107,30107,30,30,Wheatland,1422.5292,46.497046999999995,-109.85715,Wheatland County,county
+iso1:us#iso2:us-tn#fips:47015,47015,47,47,Cannon,265.6444,35.808395000000004,-86.0624,Cannon County,county
+iso1:us#iso2:us-me#fips:23007,23007,23,23,Franklin,1697.0620000000001,44.976723,-70.41493,Franklin County,county
+iso1:us#iso2:us-ky#fips:21165,21165,21,21,Menifee,203.5921,37.9355,-83.58936,Menifee County,county
+iso1:us#iso2:us-sd#fips:46089,46089,46,46,McPherson,1136.682,45.78425,-99.21141999999999,McPherson County,county
+iso1:us#iso2:us-co#fips:08051,8051,8,8,Gunnison,3239.2517,38.670497999999995,-107.05688,Gunnison County,county
+iso1:us#iso2:us-mi#fips:26029,26029,26,26,Charlevoix,416.34378,45.513165,-85.45039,Charlevoix County,county
+iso1:us#iso2:us-mn#fips:27151,27151,27,27,Swift,742.0083,45.27581,-95.690125,Swift County,county
+iso1:us#iso2:us-oh#fips:39147,39147,39,39,Seneca,551.0451,41.11999,-83.12755,Seneca County,county
+iso1:us#iso2:us-ga#fips:13267,13267,13,13,Tattnall,480.8399,32.04377,-82.05921,Tattnall County,county
+iso1:us#iso2:us-tx#fips:48429,48429,48,48,Stephens,896.7517,32.738052,-98.83935,Stephens County,county
+iso1:us#iso2:us-nc#fips:37117,37117,37,37,Martin,456.44046,35.8473,-77.1196,Martin County,county
+iso1:us#iso2:us-mt#fips:30081,30081,30,30,Ravalli,2391.0789999999997,46.077744,-114.1058,Ravalli County,county
+iso1:us#iso2:us-ga#fips:13317,13317,13,13,Wilkes,469.51675,33.77903,-82.747925,Wilkes County,county
+iso1:us#iso2:us-wa#fips:53043,53043,53,53,Lincoln,2310.6765,47.582745,-118.417694,Lincoln County,county
+iso1:us#iso2:us-ca#fips:06081,6081,6,6,San Mateo,448.64938,37.414673,-122.371544,San Mateo County,county
+iso1:us#iso2:us-oh#fips:39171,39171,39,39,Williams,420.6741,41.56496,-84.58431999999999,Williams County,county
+iso1:us#iso2:us-co#fips:08009,8009,8,8,Baca,2555.0796,37.309779999999996,-102.54374,Baca County,county
+iso1:us#iso2:us-id#fips:16021,16021,16,16,Boundary,1268.7223,48.773132000000004,-116.524666,Boundary County,county
+iso1:us#iso2:us-id#fips:16007,16007,16,16,Bear Lake,975.7609,42.285892,-111.32751499999999,Bear Lake County,county
+iso1:us#iso2:us-oh#fips:39159,39159,39,39,Union,431.73944000000006,40.295902000000005,-83.36704,Union County,county
+iso1:us#iso2:us-oh#fips:39035,39035,39,39,Cuyahoga,457.1967,41.76039,-81.72421999999999,Cuyahoga County,county
+iso1:us#iso2:us-tx#fips:48285,48285,48,48,Lavaca,969.7422,29.382578000000002,-96.92363,Lavaca County,county
+iso1:us#iso2:us-ok#fips:40105,40105,40,40,Nowata,565.8367,36.789615999999995,-95.61331,Nowata County,county
+iso1:us#iso2:us-ga#fips:13125,13125,13,13,Glascock,143.75043,33.22749,-82.60691,Glascock County,county
+iso1:us#iso2:us-or#fips:41059,41059,41,41,Umatilla,3215.5583,45.591198,-118.73388,Umatilla County,county
+iso1:us#iso2:us-sd#fips:46102,46102,46,46,Oglala Lakota,2093.6724,43.33358,-102.56168000000001,Oglala Lakota County,county
+iso1:us#iso2:us-ks#fips:20117,20117,20,20,Marshall,900.2054,39.782707,-96.52124,Marshall County,county
+iso1:us#iso2:us-la#fips:22065,22065,22,22,Madison Parish,624.4258,32.346878000000004,-91.23193,Madison Parish,county
+iso1:us#iso2:us-mt#fips:30105,30105,30,30,Valley,4926.267,48.34985,-106.670425,Valley County,county
+iso1:us#iso2:us-ga#fips:13313,13313,13,13,Whitfield,290.44775,34.801727,-84.968544,Whitfield County,county
+iso1:us#iso2:us-ks#fips:20203,20203,20,20,Wichita,718.5907599999999,38.481922,-101.347435,Wichita County,county
+iso1:us#iso2:us-sd#fips:46023,46023,46,46,Charles Mix,1097.5255,43.206184,-98.595146,Charles Mix County,county
+iso1:us#iso2:us-ne#fips:31027,31027,31,31,Cedar,740.2679400000001,42.60456,-97.25686999999999,Cedar County,county
+iso1:us#iso2:us-wa#fips:53035,53035,53,53,Kitsap,395.1398,47.639595,-122.649635,Kitsap County,county
+iso1:us#iso2:us-il#fips:17111,17111,17,17,McHenry,603.4159,42.3243,-88.45225,McHenry County,county
+iso1:us#iso2:us-mt#fips:30069,30069,30,30,Petroleum,1655.6809,47.14192,-108.22658,Petroleum County,county
+iso1:us#iso2:us-mo#fips:29033,29033,29,29,Carroll,694.6453,39.427376,-93.50023,Carroll County,county
+iso1:us#iso2:us-wa#fips:53075,53075,53,53,Whitman,2159.3347,46.905945,-117.53538999999999,Whitman County,county
+iso1:us#iso2:us-mn#fips:27147,27147,27,27,Steele,429.6597,44.015263,-93.22045,Steele County,county
+iso1:us#iso2:us-ne#fips:31169,31169,31,31,Thayer,573.8265,40.173843,-97.59626,Thayer County,county
+iso1:us#iso2:us-tn#fips:47033,47033,47,47,Crockett,265.53722999999997,35.818794,-89.13249,Crockett County,county
+iso1:us#iso2:us-ia#fips:19079,19079,19,19,Hamilton,576.773,42.39077,-93.7092,Hamilton County,county
+iso1:us#iso2:us-oh#fips:39165,39165,39,39,Warren,401.20285,39.42565,-84.16991,Warren County,county
+iso1:us#iso2:us-ga#fips:13255,13255,13,13,Spalding,195.9999,33.26235,-84.284904,Spalding County,county
+iso1:us#iso2:us-nj#fips:34019,34019,34,34,Hunterdon,427.84545999999995,40.565284999999996,-74.91197,Hunterdon County,county
+iso1:us#iso2:us-mo#fips:29217,29217,29,29,Vernon,826.4195,37.850196999999994,-94.3416,Vernon County,county
+iso1:us#iso2:us-in#fips:18121,18121,18,18,Parke,444.7362,39.77425,-87.19695,Parke County,county
+iso1:us#iso2:us-ia#fips:19069,19069,19,19,Franklin,581.99207,42.736546000000004,-93.271416,Franklin County,county
+iso1:us#iso2:us-ga#fips:13035,13035,13,13,Butts,183.6962,33.290356,-83.95822,Butts County,county
+iso1:us#iso2:us-co#fips:08039,8039,8,8,Elbert,1850.8993,39.31516,-104.114075,Elbert County,county
+iso1:us#iso2:us-ri#fips:44001,44001,44,44,Bristol,24.133114000000003,41.706833,-71.28664,Bristol County,county
+iso1:us#iso2:us-tx#fips:48035,48035,48,48,Bosque,983.0141,31.90082,-97.63764,Bosque County,county
+iso1:us#iso2:us-ri#fips:44005,44005,44,44,Newport,102.44097,41.502502,-71.28369,Newport County,county
+iso1:us#iso2:us-oh#fips:39045,39045,39,39,Fairfield,504.42682,39.747692,-82.62668599999999,Fairfield County,county
+iso1:us#iso2:us-nd#fips:38069,38069,38,38,Pierce,1018.3193,48.238884000000006,-99.9665,Pierce County,county
+iso1:us#iso2:us-il#fips:17015,17015,17,17,Carroll,445.4216,42.0709,-89.92419,Carroll County,county
+iso1:us#iso2:us-mn#fips:27125,27125,27,27,Red Lake,432.42184000000003,47.865486,-96.08718,Red Lake County,county
+iso1:us#iso2:us-or#fips:41031,41031,41,41,Jefferson,1782.2993,44.64515,-121.17863500000001,Jefferson County,county
+iso1:us#iso2:us-tn#fips:47021,47021,47,47,Cheatham,302.5351,36.25517,-87.10081,Cheatham County,county
+iso1:us#iso2:us-sd#fips:46127,46127,46,46,Union,460.77243,42.831109999999995,-96.650826,Union County,county
+iso1:us#iso2:us-al#fips:01051,1051,1,1,Elmore,618.46747,32.597229999999996,-86.14274,Elmore County,county
+iso1:us#iso2:us-ga#fips:13187,13187,13,13,Lumpkin,282.95206,34.568142,-83.998924,Lumpkin County,county
+iso1:us#iso2:us-oh#fips:39083,39083,39,39,Knox,525.5233,40.403620000000004,-82.42239000000001,Knox County,county
+iso1:us#iso2:us-ia#fips:19017,19017,19,19,Bremer,435.49387,42.780895,-92.327354,Bremer County,county
+iso1:us#iso2:us-tx#fips:48175,48175,48,48,Goliad,852.0401,28.6607,-97.43041,Goliad County,county
+iso1:us#iso2:us-nc#fips:37089,37089,37,37,Henderson,372.95575,35.336414000000005,-82.479744,Henderson County,county
+iso1:us#iso2:us-fl#fips:12061,12061,12,12,Indian River,502.8008,27.70053,-80.57479000000001,Indian River County,county
+iso1:us#iso2:us-tx#fips:48393,48393,48,48,Roberts,924.0891,35.838596,-100.836685,Roberts County,county
+iso1:us#iso2:us-ne#fips:31049,31049,31,31,Deuel,439.86605999999995,41.111903999999996,-102.33261,Deuel County,county
+iso1:us#iso2:us-ny#fips:36051,36051,36,36,Livingston,631.783,42.727486,-77.76978000000001,Livingston County,county
+iso1:us#iso2:us-ia#fips:19141,19141,19,19,O'Brien,573.0546,43.083744,-95.625626,O'Brien County,county
+iso1:us#iso2:us-tx#fips:48059,48059,48,48,Callahan,899.4028,32.293147999999995,-99.37224599999999,Callahan County,county
+iso1:us#iso2:us-tx#fips:48379,48379,48,48,Rains,229.46094,32.87058,-95.79544,Rains County,county
+iso1:us#iso2:us-ks#fips:20067,20067,20,20,Grant,574.8276,37.547540000000005,-101.29936,Grant County,county
+iso1:us#iso2:us-va#fips:51105,51105,51,51,Lee,435.39224,36.70172,-83.13011,Lee County,county
+iso1:us#iso2:us-nm#fips:35051,35051,35,35,Sierra,4181.3384,33.11947,-107.18816000000001,Sierra County,county
+iso1:us#iso2:us-ar#fips:05043,5043,5,5,Drew,828.4061,33.587241999999996,-91.72278,Drew County,county
+iso1:us#iso2:us-ne#fips:31123,31123,31,31,Morrill,1423.8856,41.732203999999996,-102.99059,Morrill County,county
+iso1:us#iso2:us-mo#fips:29015,29015,29,29,Benton,704.06665,38.301037,-93.28794,Benton County,county
+iso1:us#iso2:us-ar#fips:05109,5109,5,5,Pike,600.6454,34.158190000000005,-93.65866,Pike County,county
+iso1:us#iso2:us-co#fips:08077,8077,8,8,Mesa,3329.0278,39.019524,-108.46056999999999,Mesa County,county
+iso1:us#iso2:us-mo#fips:29065,29065,29,29,Dent,752.78625,37.603072999999995,-91.489716,Dent County,county
+iso1:us#iso2:us-va#fips:51185,51185,51,51,Tazewell,518.8084,37.125397,-81.56293000000001,Tazewell County,county
+iso1:us#iso2:us-pa#fips:42103,42103,42,42,Pike,544.97906,41.325947,-75.03152,Pike County,county
+iso1:us#iso2:us-pa#fips:42115,42115,42,42,Susquehanna,823.52386,41.819664,-75.80096999999999,Susquehanna County,county
+iso1:us#iso2:us-tx#fips:48343,48343,48,48,Morris,251.99777000000003,33.116467,-94.73125999999999,Morris County,county
+iso1:us#iso2:us-pa#fips:42125,42125,42,42,Washington,857.0164,40.200005,-80.25213000000001,Washington County,county
+iso1:us#iso2:us-vt#fips:50001,50001,50,50,Addison,766.3539999999999,44.031246,-73.14158,Addison County,county
+iso1:us#iso2:us-ks#fips:20103,20103,20,20,Leavenworth,463.4208,39.18951,-95.03898000000001,Leavenworth County,county
+iso1:us#iso2:us-mi#fips:26121,26121,26,26,Muskegon,503.9307,43.289257,-86.75189,Muskegon County,county
+iso1:us#iso2:us-ms#fips:28049,28049,28,28,Hinds,869.85956,32.267788,-90.46602,Hinds County,county
+iso1:us#iso2:us-tx#fips:48281,48281,48,48,Lampasas,712.8656,31.196732,-98.24089000000001,Lampasas County,county
+iso1:us#iso2:us-va#fips:51107,51107,51,51,Loudoun,515.783,39.0812,-77.6389,Loudoun County,county
+iso1:us#iso2:us-mo#fips:29185,29185,29,29,St. Clair,675.00415,38.042229999999996,-93.77656,St. Clair County,county
+iso1:us#iso2:us-ny#fips:36025,36025,36,36,Delaware,1442.4718,42.193985,-74.96673,Delaware County,county
+iso1:us#iso2:us-mt#fips:30071,30071,30,30,Phillips,5140.653,48.250145,-107.928894,Phillips County,county
+iso1:us#iso2:us-mo#fips:29129,29129,29,29,Mercer,453.85062,40.421413,-93.567635,Mercer County,county
+iso1:us#iso2:us-wa#fips:53045,53045,53,53,Mason,959.58875,47.354126,-123.17385,Mason County,county
+iso1:us#iso2:us-nc#fips:37127,37127,37,37,Nash,540.4621,35.965946,-77.98756,Nash County,county
+iso1:us#iso2:us-va#fips:51199,51199,51,51,York,104.61229,37.21908,-76.561646,York County,county
+iso1:us#iso2:us-mo#fips:29159,29159,29,29,Pettis,682.2478,38.727367,-93.28520999999999,Pettis County,county
+iso1:us#iso2:us-mt#fips:30063,30063,30,30,Missoula,2593.0972,47.027264,-113.89268999999999,Missoula County,county
+iso1:us#iso2:us-ks#fips:20019,20019,20,20,Chautauqua,638.9027,37.15426,-96.2454,Chautauqua County,county
+iso1:us#iso2:us-tx#fips:48459,48459,48,48,Upshur,582.9997,32.735347999999995,-94.941185,Upshur County,county
+iso1:us#iso2:us-va#fips:51047,51047,51,51,Culpeper,379.19965,38.485929999999996,-77.956474,Culpeper County,county
+iso1:us#iso2:us-ok#fips:40061,40061,40,40,Haskell,576.743,35.232296000000005,-95.10956999999999,Haskell County,county
+iso1:us#iso2:us-wv#fips:54069,54069,54,54,Ohio,105.8338,40.098929999999996,-80.62073000000001,Ohio County,county
+iso1:us#iso2:us-wv#fips:54065,54065,54,54,Morgan,229.08046000000002,39.555,-78.25735,Morgan County,county
+iso1:us#iso2:us-va#fips:51165,51165,51,51,Rockingham,849.818,38.507584,-78.88532,Rockingham County,county
+iso1:us#iso2:us-in#fips:18183,18183,18,18,Whitley,335.5931,41.136425,-85.50189,Whitley County,county
+iso1:us#iso2:us-ca#fips:06093,6093,6,6,Siskiyou,6278.981,41.587986,-122.53329,Siskiyou County,county
+iso1:us#iso2:us-sd#fips:46037,46037,46,46,Day,1028.5295,45.35516,-97.58143000000001,Day County,county
+iso1:us#iso2:us-la#fips:22071,22071,22,22,Orleans Parish,169.4393,30.053420000000003,-89.9345,Orleans Parish,county
+iso1:us#iso2:us-al#fips:01073,1073,1,1,Jefferson,1111.453,33.553444,-86.89654,Jefferson County,county
+iso1:us#iso2:us-al#fips:01127,1127,1,1,Walker,791.02905,33.791557,-87.30109399999999,Walker County,county
+iso1:us#iso2:us-mo#fips:29063,29063,29,29,DeKalb,421.37198,39.894665,-94.40719,DeKalb County,county
+iso1:us#iso2:us-fl#fips:12039,12039,12,12,Gadsden,516.3264,30.578685999999998,-84.61261,Gadsden County,county
+iso1:us#iso2:us-ga#fips:13083,13083,13,13,Dade,173.9856,34.852425,-85.5062,Dade County,county
+iso1:us#iso2:us-ms#fips:28033,28033,28,28,DeSoto,476.32892000000004,34.874268,-89.99324,DeSoto County,county
+iso1:us#iso2:us-va#fips:51187,51187,51,51,Warren,214.5415,38.908221999999995,-78.207596,Warren County,county
+iso1:us#iso2:us-il#fips:17047,17047,17,17,Edwards,222.40722999999997,38.417095,-88.04794,Edwards County,county
+iso1:us#iso2:us-tn#fips:47113,47113,47,47,Madison,557.1929299999999,35.606056,-88.83343,Madison County,county
+iso1:us#iso2:us-mp#fips:69110,69110,69,69,Saipan Municipality,45.905632000000004,15.198095,145.77719,Saipan Municipality,county
+iso1:us#iso2:us-al#fips:01111,1111,1,1,Randolph,580.5691,33.296473999999996,-85.464066,Randolph County,county
+iso1:us#iso2:us-nc#fips:37009,37009,37,37,Ashe,425.08594000000005,36.44347,-81.49934,Ashe County,county
+iso1:us#iso2:us-co#fips:08033,8033,8,8,Dolores,1067.2067,37.711723,-108.52412,Dolores County,county
+iso1:us#iso2:us-oh#fips:39089,39089,39,39,Licking,682.46155,40.091503,-82.48344,Licking County,county
+iso1:us#iso2:us-va#fips:51683,51683,51,51,Manassas city,9.849598,38.746807000000004,-77.482635,Manassas city,county
+iso1:us#iso2:us-ar#fips:05139,5139,5,5,Union,1039.2896,33.168217,-92.598145,Union County,county
+iso1:us#iso2:us-il#fips:17071,17071,17,17,Henderson,378.80896,40.814471999999995,-90.94124599999999,Henderson County,county
+iso1:us#iso2:us-al#fips:01101,1101,1,1,Montgomery,785.36536,32.20288,-86.20446,Montgomery County,county
+iso1:us#iso2:us-co#fips:08005,8005,8,8,Arapahoe,797.9869,39.644554,-104.3317,Arapahoe County,county
+iso1:us#iso2:us-ky#fips:21155,21155,21,21,Marion,343.04944,37.552605,-85.26895999999999,Marion County,county
+iso1:us#iso2:us-wa#fips:53057,53057,53,53,Skagit,1730.28,48.49329,-121.81577,Skagit County,county
+iso1:us#iso2:us-ms#fips:28067,28067,28,28,Jones,694.8353,31.616602,-89.16853,Jones County,county
+iso1:us#iso2:us-wi#fips:55021,55021,55,55,Columbia,765.5725,43.47188,-89.330475,Columbia County,county
+iso1:us#iso2:us-nc#fips:37019,37019,37,37,Brunswick,849.2217,34.038754,-78.22776999999999,Brunswick County,county
+iso1:us#iso2:us-mn#fips:27029,27029,27,27,Clearwater,998.86,47.575874,-95.37111999999999,Clearwater County,county
+iso1:us#iso2:us-va#fips:51131,51131,51,51,Northampton,211.72617000000002,37.302776,-75.92402,Northampton County,county
+iso1:us#iso2:us-ks#fips:20163,20163,20,20,Rooks,890.55725,39.34601,-99.32449,Rooks County,county
+iso1:us#iso2:us-in#fips:18041,18041,18,18,Fayette,215.02821,39.639656,-85.18503,Fayette County,county
+iso1:us#iso2:us-ne#fips:31079,31079,31,31,Hall,546.4096,40.866028,-98.50265999999999,Hall County,county
+iso1:us#iso2:us-ne#fips:31081,31081,31,31,Hamilton,541.9163,40.872818,-98.02233000000001,Hamilton County,county
+iso1:us#iso2:us-ne#fips:31115,31115,31,31,Loup,563.5405,41.903183,-99.50985,Loup County,county
+iso1:us#iso2:us-mt#fips:30091,30091,30,30,Sheridan,1675.8652,48.705524,-104.53390999999999,Sheridan County,county
+iso1:us#iso2:us-ne#fips:31063,31063,31,31,Frontier,974.66437,40.53095,-100.406685,Frontier County,county
+iso1:us#iso2:us-pr#fips:72089,72089,72,72,Luquillo Municipio,25.812345999999998,18.367995999999998,-65.7099,Luquillo Municipio,county
+iso1:us#iso2:us-al#fips:01007,1007,1,1,Bibb,622.4825400000001,33.015892,-87.127144,Bibb County,county
+iso1:us#iso2:us-ms#fips:28075,28075,28,28,Lauderdale,703.6983,32.404,-88.660446,Lauderdale County,county
+iso1:us#iso2:us-mn#fips:27011,27011,27,27,Big Stone,499.19365999999997,45.419926000000004,-96.40223,Big Stone County,county
+iso1:us#iso2:us-mn#fips:27013,27013,27,27,Blue Earth,747.8093,44.03371,-94.06401,Blue Earth County,county
+iso1:us#iso2:us-va#fips:51091,51091,51,51,Highland,415.17699999999996,38.366240000000005,-79.56447,Highland County,county
+iso1:us#iso2:us-va#fips:51177,51177,51,51,Spotsylvania,401.51706,38.18243,-77.65723,Spotsylvania County,county
+iso1:us#iso2:us-nh#fips:33017,33017,33,33,Strafford,367.48337000000004,43.293274,-71.03559,Strafford County,county
+iso1:us#iso2:us-ga#fips:13153,13153,13,13,Houston,376.05612,32.458286,-83.66252,Houston County,county
+iso1:us#iso2:us-mi#fips:26041,26041,26,26,Delta,1171.1409,45.80523,-86.90194,Delta County,county
+iso1:us#iso2:us-ar#fips:05131,5131,5,5,Sebastian,531.18677,35.196979999999996,-94.27499,Sebastian County,county
+iso1:us#iso2:us-ca#fips:06087,6087,6,6,Santa Cruz,445.11166,37.01249,-122.0072,Santa Cruz County,county
+iso1:us#iso2:us-ga#fips:13191,13191,13,13,McIntosh,431.36877000000004,31.488506,-81.37229,McIntosh County,county
+iso1:us#iso2:us-ga#fips:13207,13207,13,13,Monroe,396.10504,33.017437,-83.922935,Monroe County,county
+iso1:us#iso2:us-mo#fips:29069,29069,29,29,Dunklin,541.1168,36.306903999999996,-90.06539000000001,Dunklin County,county
+iso1:us#iso2:us-tx#fips:48483,48483,48,48,Wheeler,914.56396,35.392593,-100.253105,Wheeler County,county
+iso1:us#iso2:us-ga#fips:13117,13117,13,13,Forsyth,224.55907000000002,34.225143,-84.12741,Forsyth County,county
+iso1:us#iso2:us-tx#fips:48409,48409,48,48,San Patricio,693.4596,28.011795000000003,-97.51716,San Patricio County,county
+iso1:us#iso2:us-ms#fips:28147,28147,28,28,Walthall,403.94196,31.164492,-90.10343,Walthall County,county
+iso1:us#iso2:us-mo#fips:29137,29137,29,29,Monroe,647.6805,39.49827,-92.006454,Monroe County,county
+iso1:us#iso2:us-mi#fips:26073,26073,26,26,Isabella,572.7181,43.645233000000005,-84.839424,Isabella County,county
+iso1:us#iso2:us-tx#fips:48341,48341,48,48,Moore,899.72864,35.835674,-101.8905,Moore County,county
+iso1:us#iso2:us-sc#fips:45017,45017,45,45,Calhoun,381.16492,33.67478,-80.78035,Calhoun County,county
+iso1:us#iso2:us-wy#fips:56035,56035,56,56,Sublette,4886.648,42.76793,-109.91617,Sublette County,county
+iso1:us#iso2:us-ky#fips:21069,21069,21,21,Fleming,348.55692,38.367847,-83.6992,Fleming County,county
+iso1:us#iso2:us-wi#fips:55019,55019,55,55,Clark,1209.7369,44.739346000000005,-90.609955,Clark County,county
+iso1:us#iso2:us-sc#fips:45091,45091,45,45,York,680.69604,34.97019,-81.18319,York County,county
+iso1:us#iso2:us-in#fips:18001,18001,18,18,Adams,338.93800000000005,40.74573,-84.93613,Adams County,county
+iso1:us#iso2:us-la#fips:22005,22005,22,22,Ascension Parish,290.07275,30.206444,-90.91250600000001,Ascension Parish,county
+iso1:us#iso2:us-pa#fips:42119,42119,42,42,Union,315.9672,40.962177000000004,-77.05547,Union County,county
+iso1:us#iso2:us-va#fips:51041,51041,51,51,Chesterfield,423.5708,37.378433,-77.58584599999999,Chesterfield County,county
+iso1:us#iso2:us-la#fips:22001,22001,22,22,Acadia Parish,655.1916,30.291496000000002,-92.41103000000001,Acadia Parish,county
+iso1:us#iso2:us-pa#fips:42039,42039,42,42,Crawford,1012.33594,41.687878000000005,-80.107796,Crawford County,county
+iso1:us#iso2:us-sd#fips:46123,46123,46,46,Tripp,1612.513,43.349728000000006,-99.87621999999999,Tripp County,county
+iso1:us#iso2:us-ia#fips:19077,19077,19,19,Guthrie,590.6401400000001,41.683575,-94.501274,Guthrie County,county
+iso1:us#iso2:us-ia#fips:19183,19183,19,19,Washington,568.8312400000001,41.329403000000006,-91.72505,Washington County,county
+iso1:us#iso2:us-sd#fips:46111,46111,46,46,Sanborn,569.2677,44.018944,-98.09170999999999,Sanborn County,county
+iso1:us#iso2:us-ok#fips:40051,40051,40,40,Grady,1100.5779,35.021057,-97.88689000000001,Grady County,county
+iso1:us#iso2:us-wv#fips:54039,54039,54,54,Kanawha,901.6625,38.328068,-81.52351,Kanawha County,county
+iso1:us#iso2:us-wi#fips:55109,55109,55,55,St. Croix,722.47864,45.028957,-92.44728,St. Croix County,county
+iso1:us#iso2:us-pa#fips:42121,42121,42,42,Venango,674.3074,41.400715000000005,-79.765816,Venango County,county
+iso1:us#iso2:us-oh#fips:39153,39153,39,39,Summit,412.80325,41.121845,-81.53493,Summit County,county
+iso1:us#iso2:us-ga#fips:13127,13127,13,13,Glynn,419.56528,31.212709999999998,-81.49645,Glynn County,county
+iso1:us#iso2:us-tx#fips:48479,48479,48,48,Webb,3361.5918,27.7608,-99.34075,Webb County,county
+iso1:us#iso2:us-nc#fips:37123,37123,37,37,Montgomery,491.55395999999996,35.334415,-79.9066,Montgomery County,county
+iso1:us#iso2:us-me#fips:23003,23003,23,23,Aroostook,6671.3193,46.709194000000004,-68.61241,Aroostook County,county
+iso1:us#iso2:us-ms#fips:28065,28065,28,28,Jefferson Davis,408.4603,31.564808000000003,-89.82709,Jefferson Davis County,county
+iso1:us#iso2:us-in#fips:18175,18175,18,18,Washington,513.7088,38.600613,-86.10475,Washington County,county
+iso1:us#iso2:us-tx#fips:48031,48031,48,48,Blanco,709.2759,30.266455,-98.39921600000001,Blanco County,county
+iso1:us#iso2:us-va#fips:51025,51025,51,51,Brunswick,566.25287,36.764206,-77.86148,Brunswick County,county
+iso1:us#iso2:us-tn#fips:47045,47045,47,47,Dyer,512.3688,36.054195,-89.39831,Dyer County,county
+iso1:us#iso2:us-tn#fips:47053,47053,47,47,Gibson,602.7656,35.99163,-88.933815,Gibson County,county
+iso1:us#iso2:us-va#fips:51149,51149,51,51,Prince George,265.3509,37.187325,-77.22099,Prince George County,county
+iso1:us#iso2:us-ar#fips:05075,5075,5,5,Lawrence,587.63416,36.0411,-91.10115,Lawrence County,county
+iso1:us#iso2:us-nd#fips:38027,38027,38,38,Eddy,630.26013,47.723434000000005,-98.900475,Eddy County,county
+iso1:us#iso2:us-wa#fips:53053,53053,53,53,Pierce,1668.1056,47.051414,-122.15324,Pierce County,county
+iso1:us#iso2:us-id#fips:16063,16063,16,16,Lincoln,1201.4045,42.98618,-114.1539,Lincoln County,county
+iso1:us#iso2:us-pa#fips:42071,42071,42,42,Lancaster,943.9559300000001,40.041992,-76.2502,Lancaster County,county
+iso1:us#iso2:us-wi#fips:55057,55057,55,55,Juneau,767.1067,43.932835,-90.11398,Juneau County,county
+iso1:us#iso2:us-tn#fips:47151,47151,47,47,Scott,532.3186599999999,36.435234,-84.50352,Scott County,county
+iso1:us#iso2:us-sd#fips:46031,46031,46,46,Corson,2469.778,45.68567,-101.179665,Corson County,county
+iso1:us#iso2:us-sd#fips:46053,46053,46,46,Gregory,1014.98413,43.175144,-99.20659,Gregory County,county
+iso1:us#iso2:us-nc#fips:37181,37181,37,37,Vance,252.4088,36.365482,-78.40543000000001,Vance County,county
+iso1:us#iso2:us-ky#fips:21033,21033,21,21,Caldwell,344.80172999999996,37.148643,-87.87051,Caldwell County,county
+iso1:us#iso2:us-sc#fips:45011,45011,45,45,Barnwell,548.3976,33.26055,-81.43423,Barnwell County,county
+iso1:us#iso2:us-tn#fips:47039,47039,47,47,Decatur,333.88925,35.603138,-88.11029,Decatur County,county
+iso1:us#iso2:us-in#fips:18009,18009,18,18,Blackford,165.08722,40.47267,-85.32373,Blackford County,county
+iso1:us#iso2:us-al#fips:01055,1055,1,1,Etowah,535.1063,34.04764,-86.03426,Etowah County,county
+iso1:us#iso2:us-id#fips:16025,16025,16,16,Camas,1074.2708,43.502552,-114.77213,Camas County,county
+iso1:us#iso2:us-ks#fips:20155,20155,20,20,Reno,1255.3503,37.948184999999995,-98.07835,Reno County,county
+iso1:us#iso2:us-tn#fips:47119,47119,47,47,Maury,613.1596,35.615696,-87.07777,Maury County,county
+iso1:us#iso2:us-wy#fips:56015,56015,56,56,Goshen,2225.6887,42.089455,-104.35354,Goshen County,county
+iso1:us#iso2:us-wi#fips:55107,55107,55,55,Rusk,913.58435,45.472733000000005,-91.13674,Rusk County,county
+iso1:us#iso2:us-wi#fips:55133,55133,55,55,Waukesha,549.73956,43.018368,-88.30424000000001,Waukesha County,county
+iso1:us#iso2:us-ky#fips:21079,21079,21,21,Garrard,230.1065,37.63016,-84.54585,Garrard County,county
+iso1:us#iso2:us-ma#fips:25021,25021,25,25,Norfolk,396.12067,42.171738,-71.18111400000001,Norfolk County,county
+iso1:us#iso2:us-in#fips:18063,18063,18,18,Hendricks,406.90738,39.768963,-86.50990999999999,Hendricks County,county
+iso1:us#iso2:us-il#fips:17077,17077,17,17,Jackson,583.58997,37.786095,-89.38121,Jackson County,county
+iso1:us#iso2:us-sc#fips:45043,45043,45,45,Georgetown,813.9215,33.41753,-79.29633000000001,Georgetown County,county
+iso1:us#iso2:us-nd#fips:38041,38041,38,38,Hettinger,1132.2776,46.435703000000004,-102.45424,Hettinger County,county
+iso1:us#iso2:us-ut#fips:49019,49019,49,49,Grand,3672.8684,38.974327,-109.57345,Grand County,county
+iso1:us#iso2:us-ut#fips:49045,49045,49,49,Tooele,6942.182,40.467754,-113.12398,Tooele County,county
+iso1:us#iso2:us-va#fips:51650,51650,51,51,Hampton city,51.45988,37.047962,-76.29729499999999,Hampton city,county
+iso1:us#iso2:us-wi#fips:55011,55011,55,55,Buffalo,675.8135,44.38563,-91.76129,Buffalo County,county
+iso1:us#iso2:us-va#fips:51069,51069,51,51,Frederick,413.18273999999997,39.20366,-78.26383,Frederick County,county
+iso1:us#iso2:us-wv#fips:54041,54041,54,54,Lewis,386.9421,38.988876,-80.495476,Lewis County,county
+iso1:us#iso2:us-mn#fips:27119,27119,27,27,Polk,1971.1396,47.774254,-96.400024,Polk County,county
+iso1:us#iso2:us-mn#fips:27127,27127,27,27,Redwood,878.6028,44.403534,-95.25424,Redwood County,county
+iso1:us#iso2:us-tn#fips:47047,47047,47,47,Fayette,704.79926,35.196995,-89.4138,Fayette County,county
+iso1:us#iso2:us-as:#fips:60040,60040,60,60,Swains Island,0.93926597,-11.054436,-171.06902,Swains Island,county
+iso1:us#iso2:us-la#fips:22089,22089,22,22,St. Charles Parish,277.7603,29.905721999999997,-90.35786,St. Charles Parish,county
+iso1:us#iso2:us-ar#fips:05111,5111,5,5,Poinsett,758.388,35.568870000000004,-90.68111,Poinsett County,county
+iso1:us#iso2:us-fl#fips:12045,12045,12,12,Gulf,553.45807,29.907257,-85.25654,Gulf County,county
+iso1:us#iso2:us-tn#fips:47063,47063,47,47,Hamblen,161.19437,36.218395,-83.26607,Hamblen County,county
+iso1:us#iso2:us-al#fips:01021,1021,1,1,Chilton,692.87506,32.85405,-86.72661,Chilton County,county
+iso1:us#iso2:us-tx#fips:48351,48351,48,48,Newton,933.70886,30.786718,-93.73925,Newton County,county
+iso1:us#iso2:us-tx#fips:48219,48219,48,48,Hockley,908.4226699999999,33.60593,-102.3434,Hockley County,county
+iso1:us#iso2:us-ga#fips:13009,13009,13,13,Baldwin,258.7079,33.059490000000004,-83.255455,Baldwin County,county
+iso1:us#iso2:us-nc#fips:37175,37175,37,37,Transylvania,378.36612,35.210102,-82.816666,Transylvania County,county
+iso1:us#iso2:us-nc#fips:37171,37171,37,37,Surry,533.7604,36.415417,-80.68646,Surry County,county
+iso1:us#iso2:us-al#fips:01031,1031,1,1,Coffee,679.0092,31.402258000000003,-85.9896,Coffee County,county
+iso1:us#iso2:us-oh#fips:39149,39149,39,39,Shelby,407.70956,40.33668,-84.20414,Shelby County,county
+iso1:us#iso2:us-id#fips:16027,16027,16,16,Canyon,587.06714,43.625797,-116.70906000000001,Canyon County,county
+iso1:us#iso2:us-mt#fips:30019,30019,30,30,Daniels,1426.0648,48.79443,-105.54173999999999,Daniels County,county
+iso1:us#iso2:us-fl#fips:12073,12073,12,12,Leon,666.9127,30.45931,-84.2778,Leon County,county
+iso1:us#iso2:us-ok#fips:40119,40119,40,40,Payne,684.9244,36.079223999999996,-96.97525999999999,Payne County,county
+iso1:us#iso2:us-al#fips:01039,1039,1,1,Covington,1030.5935,31.243988,-86.44872,Covington County,county
+iso1:us#iso2:us-in#fips:18093,18093,18,18,Lawrence,449.19385,38.839813,-86.48782,Lawrence County,county
+iso1:us#iso2:us-ks#fips:20069,20069,20,20,Gray,868.8969,37.744514,-100.45170999999999,Gray County,county
+iso1:us#iso2:us-ky#fips:21045,21045,21,21,Casey,444.2536,37.32196,-84.92822,Casey County,county
+iso1:us#iso2:us-ky#fips:21169,21169,21,21,Metcalfe,289.6506,36.99243,-85.63345,Metcalfe County,county
+iso1:us#iso2:us-ky#fips:21207,21207,21,21,Russell,253.7011,36.990584999999996,-85.05495,Russell County,county
+iso1:us#iso2:us-la#fips:22011,22011,22,22,Beauregard Parish,1157.4019,30.645018,-93.34025600000001,Beauregard Parish,county
+iso1:us#iso2:us-me#fips:23025,23025,23,23,Somerset,3924.4163,45.503646999999994,-69.95611,Somerset County,county
+iso1:us#iso2:us-ok#fips:40025,40025,40,40,Cimarron,1834.8707,36.74839,-102.5177,Cimarron County,county
+iso1:us#iso2:us-ky#fips:21163,21163,21,21,Meade,305.45337,37.967476,-86.20085999999999,Meade County,county
+iso1:us#iso2:us-ky#fips:21179,21179,21,21,Nelson,417.53213999999997,37.80312,-85.465935,Nelson County,county
+iso1:us#iso2:us-ky#fips:21187,21187,21,21,Owen,351.11984,38.499393,-84.84159,Owen County,county
+iso1:us#iso2:us-mo#fips:29155,29155,29,29,Pemiscot,492.63297,36.209915,-89.78594,Pemiscot County,county
+iso1:us#iso2:us-ne#fips:31125,31125,31,31,Nance,441.61287999999996,41.402386,-97.99141,Nance County,county
+iso1:us#iso2:us-wi#fips:55078,55078,55,55,Menominee,357.62677,44.991302000000005,-88.66925,Menominee County,county
+iso1:us#iso2:us-tx#fips:48365,48365,48,48,Panola,811.38306,32.16398,-94.30515,Panola County,county
+iso1:us#iso2:us-ky#fips:21011,21011,21,21,Bath,278.80667,38.15225,-83.73764,Bath County,county
+iso1:us#iso2:us-tx#fips:48001,48001,48,48,Anderson,1062.667,31.84126,-95.66173,Anderson County,county
+iso1:us#iso2:us-va#fips:51033,51033,51,51,Caroline,527.6276,38.03032,-77.35235,Caroline County,county
+iso1:us#iso2:us-ia#fips:19167,19167,19,19,Sioux,767.9402,43.082645,-96.17801,Sioux County,county
+iso1:us#iso2:us-ca#fips:06021,6021,6,6,Glenn,1314.0122,39.602546999999994,-122.4017,Glenn County,county
+iso1:us#iso2:us-mo#fips:29510,29510,29,29,St. Louis city,61.745674,38.6357,-90.24458,St. Louis city,county
+iso1:us#iso2:us-ga#fips:13111,13111,13,13,Fannin,387.11813,34.866543,-84.31733,Fannin County,county
+iso1:us#iso2:us-sd#fips:46051,46051,46,46,Grant,681.46924,45.172638,-96.77226,Grant County,county
+iso1:us#iso2:us-sd#fips:46091,46091,46,46,Marshall,838.1498,45.737045,-97.58086999999999,Marshall County,county
+iso1:us#iso2:us-wa#fips:53067,53067,53,53,Thurston,722.5144,46.93582,-122.83015400000001,Thurston County,county
+iso1:us#iso2:us-ne#fips:31107,31107,31,31,Knox,1108.4808,42.634403000000006,-97.89135,Knox County,county
+iso1:us#iso2:us-nm#fips:35061,35061,35,35,Valencia,1066.7803,34.716840000000005,-106.80658000000001,Valencia County,county
+iso1:us#iso2:us-mt#fips:30079,30079,30,30,Prairie,1736.6617,46.812386,-105.50398999999999,Prairie County,county
+iso1:us#iso2:us-ia#fips:19005,19005,19,19,Allamakee,639.0655,43.274963,-91.38275,Allamakee County,county
+iso1:us#iso2:us-tx#fips:48061,48061,48,48,Cameron,891.6719,26.102922,-97.47896,Cameron County,county
+iso1:us#iso2:us-tx#fips:48339,48339,48,48,Montgomery,1042.3248,30.298801,-95.50295,Montgomery County,county
+iso1:us#iso2:us-co#fips:08071,8071,8,8,Las Animas,4773.1006,37.318832,-104.04411,Las Animas County,county
+iso1:us#iso2:us-tx#fips:48299,48299,48,48,Llano,934.0846,30.707584000000004,-98.68469,Llano County,county
+iso1:us#iso2:us-tx#fips:48319,48319,48,48,Mason,928.86755,30.703916999999997,-99.237305,Mason County,county
+iso1:us#iso2:us-nc#fips:37043,37043,37,37,Clay,214.99074,35.052997999999995,-83.752266,Clay County,county
+iso1:us#iso2:us-ny#fips:36071,36071,36,36,Orange,812.3428299999999,41.402409999999996,-74.30625,Orange County,county
+iso1:us#iso2:us-ny#fips:36093,36093,36,36,Schenectady,204.58806,42.81755,-74.04356,Schenectady County,county
+iso1:us#iso2:us-wv#fips:54059,54059,54,54,Mingo,423.15402,37.72116,-82.15899,Mingo County,county
+iso1:us#iso2:us-ks#fips:20197,20197,20,20,Wabaunsee,794.3630400000001,38.955154,-96.20125999999999,Wabaunsee County,county
+iso1:us#iso2:us-mn#fips:27055,27055,27,27,Houston,552.0622599999999,43.666990000000006,-91.50156,Houston County,county
+iso1:us#iso2:us-ky#fips:21181,21181,21,21,Nicholas,195.16805,38.338029999999996,-84.02622,Nicholas County,county
+iso1:us#iso2:us-ma#fips:25023,25023,25,25,Plymouth,658.60315,41.987194,-70.74194,Plymouth County,county
+iso1:us#iso2:us-ny:#fips:36005,36005,36,36,Bronx,42.05165,40.848713000000004,-73.852936,Bronx County,county
+iso1:us#iso2:us-nc#fips:37055,37055,37,37,Dare,383.2418,35.60627,-75.76754,Dare County,county
+iso1:us#iso2:us-oh#fips:39103,39103,39,39,Medina,421.47144000000003,41.116172999999996,-81.899765,Medina County,county
+iso1:us#iso2:us-pa#fips:42005,42005,42,42,Armstrong,653.21313,40.81238,-79.46413000000001,Armstrong County,county
+iso1:us#iso2:us-nj#fips:34001,34001,34,34,Atlantic,555.5337,39.469357,-74.63376,Atlantic County,county
+iso1:us#iso2:us-wi#fips:55071,55071,55,55,Manitowoc,589.3245,44.156136,-87.577354,Manitowoc County,county
+iso1:us#iso2:us-wi#fips:55029,55029,55,55,Door,481.97900000000004,45.09342,-87.04868,Door County,county
+iso1:us#iso2:us-nc#fips:37047,37047,37,37,Columbus,938.15295,34.2616,-78.63930500000001,Columbus County,county
+iso1:us#iso2:us-oh#fips:39053,39053,39,39,Gallia,466.54654000000005,38.817046999999995,-82.30174,Gallia County,county
+iso1:us#iso2:us-tx#fips:48441,48441,48,48,Taylor,915.5675,32.297127,-99.89043000000001,Taylor County,county
+iso1:us#iso2:us-va#fips:51570,51570,51,51,Colonial Heights city,7.519685000000001,37.261684,-77.396805,Colonial Heights city,county
+iso1:us#iso2:us-oh#fips:39031,39031,39,39,Coshocton,563.9784,40.29671,-81.93011,Coshocton County,county
+iso1:us#iso2:us-ne#fips:31135,31135,31,31,Perkins,883.3654,40.857647,-101.627464,Perkins County,county
+iso1:us#iso2:us-tx#fips:48205,48205,48,48,Hartley,1462.0006,35.840244,-102.61005,Hartley County,county
+iso1:us#iso2:us-co#fips:08049,8049,8,8,Grand,1846.509,40.113064,-106.11084,Grand County,county
+iso1:us#iso2:us-tx#fips:48249,48249,48,48,Jim Wells,865.19916,27.733515,-98.09081,Jim Wells County,county
+iso1:us#iso2:us-ia#fips:19189,19189,19,19,Winnebago,400.50272,43.378124,-93.743484,Winnebago County,county
+iso1:us#iso2:us-ca#fips:06079,6079,6,6,San Luis Obispo,3300.7290000000003,35.385222999999996,-120.44755,San Luis Obispo County,county
+iso1:us#iso2:us-al#fips:01067,1067,1,1,Henry,561.7694,31.516977,-85.239975,Henry County,county
+iso1:us#iso2:us-oh#fips:39175,39175,39,39,Wyandot,406.89304,40.839783000000004,-83.31368,Wyandot County,county
+iso1:us#iso2:us-tx#fips:48505,48505,48,48,Zapata,998.44635,26.996979999999997,-99.1826,Zapata County,county
+iso1:us#iso2:us-ga#fips:13177,13177,13,13,Lee,355.89444,31.818419,-84.14668,Lee County,county
+iso1:us#iso2:us-ky#fips:21019,21019,21,21,Boyd,159.87265,38.360003999999996,-82.681404,Boyd County,county
+iso1:us#iso2:us-mn#fips:27019,27019,27,27,Carver,354.20853,44.82132,-93.800095,Carver County,county
+iso1:us#iso2:us-ne#fips:31037,31037,31,31,Colfax,411.66083,41.57496,-97.08894000000001,Colfax County,county
+iso1:us#iso2:us-sc#fips:45025,45025,45,45,Chesterfield,799.0128,34.637015999999996,-80.159225,Chesterfield County,county
+iso1:us#iso2:us-tn#fips:47101,47101,47,47,Lewis,282.10152999999997,35.523243,-87.49699,Lewis County,county
+iso1:us#iso2:us-or#fips:41067,41067,41,41,Washington,724.2980299999999,45.553543,-123.09761999999999,Washington County,county
+iso1:us#iso2:us-va#fips:51810,51810,51,51,Virginia Beach city,244.7309,36.779984000000006,-76.02521,Virginia Beach city,county
+iso1:us#iso2:us-mt#fips:30057,30057,30,30,Madison,3588.2793,45.32529,-111.91378999999999,Madison County,county
+iso1:us#iso2:us-va#fips:51103,51103,51,51,Lancaster,133.30202,37.704840000000004,-76.41266999999999,Lancaster County,county
+iso1:us#iso2:us-mo#fips:29013,29013,29,29,Bates,836.7231400000001,38.257217,-94.33925,Bates County,county
+iso1:us#iso2:us-nh#fips:33001,33001,33,33,Belknap,401.8578,43.519108,-71.42537,Belknap County,county
+iso1:us#iso2:us-va#fips:51159,51159,51,51,Richmond,191.48439,37.942894,-76.73056,Richmond County,county
+iso1:us#iso2:us-ak#fips:02230,2230,2,2,Skagway Municipality,433.9477,59.56038,-135.33827,Skagway Municipality,county
+iso1:us#iso2:us-ak#fips:02105,2105,2,2,Hoonah-Angoon Census Area,6556.696,58.25346,-136.32072,Hoonah-Angoon Census Area,county
+iso1:us#iso2:us-wa#fips:53021,53021,53,53,Franklin,1241.6381,46.53458,-118.906944,Franklin County,county
+iso1:us#iso2:us-ia#fips:19093,19093,19,19,Ida,431.5224,42.39186,-95.50742,Ida County,county
+iso1:us#iso2:us-ks#fips:20173,20173,20,20,Sedgwick,996.96204,37.681046,-97.46105,Sedgwick County,county
+iso1:us#iso2:us-tx#fips:48453,48453,48,48,Travis,992.2665,30.239513,-97.69126999999999,Travis County,county
+iso1:us#iso2:us-fl#fips:12057,12057,12,12,Hillsborough,1021.95917,27.906607,-82.34971999999999,Hillsborough County,county
+iso1:us#iso2:us-nj#fips:34021,34021,34,34,Mercer,224.44795,40.2825,-74.70373000000001,Mercer County,county
+iso1:us#iso2:us-ne#fips:31023,31023,31,31,Butler,584.9209,41.226074,-97.13204,Butler County,county
+iso1:us#iso2:us-pa#fips:42129,42129,42,42,Westmoreland,1028.0756,40.31107,-79.46669,Westmoreland County,county
+iso1:us#iso2:us-fl#fips:12015,12015,12,12,Charlotte,681.13,26.868975,-81.94128,Charlotte County,county
+iso1:us#iso2:us-ia#fips:19029,19029,19,19,Cass,564.2776,41.333824,-94.933304,Cass County,county
+iso1:us#iso2:us-oh#fips:39107,39107,39,39,Mercer,462.45932,40.53533,-84.63206,Mercer County,county
+iso1:us#iso2:us-as:#fips:60030,60030,60,60,Rose Island,0.031697363,-14.536529999999999,-168.15129,Rose Island,county
+iso1:us#iso2:us-ky#fips:21115,21115,21,21,Johnson,261.97345,37.847755,-82.830124,Johnson County,county
+iso1:us#iso2:us-ri#fips:44003,44003,44,44,Kent,168.57086,41.674244,-71.580925,Kent County,county
+iso1:us#iso2:us-vt#fips:50025,50025,50,50,Windham,785.5353,42.995335,-72.721954,Windham County,county
+iso1:us#iso2:us-vt#fips:50019,50019,50,50,Orleans,693.59705,44.82844,-72.25163,Orleans County,county
+iso1:us#iso2:us-ks#fips:20085,20085,20,20,Jackson,656.2417,39.411144,-95.79449,Jackson County,county
+iso1:us#iso2:us-la#fips:22041,22041,22,22,Franklin Parish,624.61426,32.139076,-91.67237,Franklin Parish,county
+iso1:us#iso2:us-ms#fips:28155,28155,28,28,Webster,421.1592,33.61206,-89.28396,Webster County,county
+iso1:us#iso2:us-ma#fips:25011,25011,25,25,Franklin,699.2225,42.584503000000005,-72.59179,Franklin County,county
+iso1:us#iso2:us-ne#fips:31031,31031,31,31,Cherry,5960.411,42.571323,-101.04765,Cherry County,county
+iso1:us#iso2:us-mt#fips:30001,30001,30,30,Beaverhead,5542.875,45.13386,-112.89287,Beaverhead County,county
+iso1:us#iso2:us-mo#fips:29143,29143,29,29,New Madrid,674.8807400000001,36.59426,-89.65594499999999,New Madrid County,county
+iso1:us#iso2:us-ar#fips:05057,5057,5,5,Hempstead,727.5459,33.735954,-93.66435,Hempstead County,county
+iso1:us#iso2:us-mo#fips:29029,29029,29,29,Camden,656.0653,38.026527,-92.76533,Camden County,county
+iso1:us#iso2:us-va#fips:51117,51117,51,51,Mecklenburg,625.3309,36.687256,-78.36896,Mecklenburg County,county
+iso1:us#iso2:us-ky#fips:21233,21233,21,21,Webster,332.11017000000004,37.519459999999995,-87.68479,Webster County,county
+iso1:us#iso2:us-ok#fips:40047,40047,40,40,Garfield,1058.5433,36.378056,-97.78845,Garfield County,county
+iso1:us#iso2:us-wa#fips:53059,53059,53,53,Skamania,1658.3384,46.024784000000004,-121.95323,Skamania County,county
+iso1:us#iso2:us-mi#fips:26091,26091,26,26,Lenawee,749.6445,41.896023,-84.07435600000001,Lenawee County,county
+iso1:us#iso2:us-ga#fips:13123,13123,13,13,Gilmer,426.2276,34.690506,-84.45463000000001,Gilmer County,county
+iso1:us#iso2:us-mn#fips:27135,27135,27,27,Roseau,1671.6753,48.761066,-95.8215,Roseau County,county
+iso1:us#iso2:us-ms#fips:28089,28089,28,28,Madison,714.546,32.634370000000004,-90.03416,Madison County,county
+iso1:us#iso2:us-tx#fips:48227,48227,48,48,Howard,900.8221,32.30343,-101.43871999999999,Howard County,county
+iso1:us#iso2:us-wv#fips:54099,54099,54,54,Wayne,506.02367999999996,38.143642,-82.42267,Wayne County,county

--- a/can_tools/scrapers/base.py
+++ b/can_tools/scrapers/base.py
@@ -1,8 +1,9 @@
+from can_tools.models import Base
 import os
 import pickle
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
 import pandas as pd
 from sqlalchemy.engine.base import Engine
@@ -37,13 +38,8 @@ class DatasetBase(ABC):
         The type of data for this scraper. This is often set to "covid"
         by subclasses
 
-    pk : str
-        The primary key for the table named `table_name` -- For covid
-        data it will be
-        '("vintage", "dt", "location_id", "variable_id", "demographic_id")'
-
-    table_name: str
-        The name of the database table where this data should be inserted
+    table: Type[Base]
+        The SQLAlchemy base table where this data should be inserted
 
     location_type: Optional[str]
         Optional information used when a scraper only retrieves data about a
@@ -54,8 +50,7 @@ class DatasetBase(ABC):
 
     autodag: bool = True
     data_type: str = "general"
-    pk: str
-    table_name: str
+    table: Type[Base]
     location_type: Optional[str]
     base_path: Path
 

--- a/can_tools/scrapers/official/base.py
+++ b/can_tools/scrapers/official/base.py
@@ -1,7 +1,7 @@
 import uuid
 from abc import ABC
 from contextlib import closing
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import pandas as pd
 import requests
@@ -10,6 +10,8 @@ from sqlalchemy.orm.session import sessionmaker
 
 from can_tools.db_util import fast_append_to_sql
 from can_tools.models import (
+    Base,
+    CovidObservation,
     TemptableOfficialHasLocation,
     TemptableOfficialNoLocation,
     build_insert_from_temp,
@@ -24,10 +26,8 @@ class StateDashboard(DatasetBase, ABC):
     Attributes
     ----------
 
-    table_name: str = "covid_official"
-        Name of database table to insert into
-    pk: str = '("vintage", "dt", "location", "variable_id", "demographic_id")'
-        Primary key on database table
+    table: Type[Base] = CovidObservation
+        SQLAlchemy base table to insert into
     provider = "state"
         Provider here is state
     data_type: str = "covid"
@@ -39,8 +39,7 @@ class StateDashboard(DatasetBase, ABC):
 
     """
 
-    table_name: str = "covid_official"
-    pk: str = '("vintage", "dt", "location_id", "variable_id", "demographic_id")'
+    table: Type[Base] = CovidObservation
     provider = "state"
     data_type: str = "covid"
     has_location: bool

--- a/can_tools/scrapers/uscensus/geo.py
+++ b/can_tools/scrapers/uscensus/geo.py
@@ -1,6 +1,7 @@
 """
 Utilities for getting geographical information from US census Bureau
 """
+from can_tools.models import Location
 import geopandas as gpd
 import pandas as pd
 
@@ -139,8 +140,7 @@ class USGeoBaseAPI(InsertWithTempTableMixin, DatasetBaseNoDate):
         A string representing the PostgresQL primary key
     """
 
-    table_name = "locations"
-    pk = '("id")'
+    table = Location
     autodag = False
 
     def __init__(self, geo: str = "state", year: int = 2019):
@@ -173,6 +173,7 @@ class USGeoBaseAPI(InsertWithTempTableMixin, DatasetBaseNoDate):
         -------
 
         """
+        raise NotImplementedError()
         _sql_geo_insert = f"""
         INSERT INTO meta.{table_name} (location, location_type, state, name, area, latitude, longitude, fullname)
         SELECT tt.location, loct.id, tt.state, tt.name,


### PR DESCRIPTION
1. Add `provider_id` to `covid_observations` Primary Key
2. Remove `covid_official` and `covid_usafacts` tables. We only have `covid_observations` now and we can differentiate data from other sources via the `provider_id` column
3. Added an `id` column to the locations table. This is  a String that matches the `locationId` column from the CAN api
4. dropped `location` and `location type` from `covid_observations` in favor of new `Location.id` column
5. Removed `pk` attribute from DatasetBase -- this is now inferred by sqlalchemy for us
6. Changed from `table_name: str` to `table: Type[Base]` on DatasetBase

End result is that:

1. we only have one main covid observations table. The provider is part of the primary key so we will have potentially multiple observations for each (dt, location, variable, demographic), one for each provider. This should enable the features of querying/filtering based on a specific provider (e.g. all data from state dashboards, all data from cdc, etc.)
2. We now have the location_id column that lines up with what CAN uses.

cc @ghop02 @TomGoBravo @mikelehen 