### PR TITLE
Adjusted test_encounters to specimens based FAQs

### DIFF
--- a/can_tools/scrapers/official/TN/tn_state.py
+++ b/can_tools/scrapers/official/TN/tn_state.py
@@ -48,17 +48,17 @@ class TennesseeState(StateDashboard):
             "POS_TESTS": CMU(
                 category="pcr_tests_positive",
                 measurement="cumulative",
-                unit="test_encounters",
+                unit="specimens",
             ),
             "NEG_TESTS": CMU(
                 category="pcr_tests_negative",
                 measurement="cumulative",
-                unit="test_encounters",
+                unit="specimens",
             ),
             "TOTAL_TESTS": CMU(
                 category="pcr_tests_total",
                 measurement="cumulative",
-                unit="test_encounters",
+                unit="specimens",
             ),
         }
 
@@ -137,17 +137,17 @@ class TennesseeCounty(StateDashboard):
             "POS_TESTS": CMU(
                 category="pcr_tests_positive",
                 measurement="cumulative",
-                unit="test_encounters",
+                unit="specimens",
             ),
             "NEG_TESTS": CMU(
                 category="pcr_tests_negative",
                 measurement="cumulative",
-                unit="test_encounters",
+                unit="specimens",
             ),
             "TOTAL_TESTS": CMU(
                 category="pcr_tests_total",
                 measurement="cumulative",
-                unit="test_encounters",
+                unit="specimens",
             ),
             "NEW_DEATHS": CMU(category="deaths", measurement="new", unit="people"),
             "TOTAL_DEATHS": CMU(


### PR DESCRIPTION
Chase asked about this categorization of `test_encounters` vs `specimens`.  After further review, I found this information.

https://www.tn.gov/health/cedep/ncov/data/data-faqs.html
Under "What changes have been made to how TDH presents the COVID-19 data?" they do references the changes in the data on 6/12. "On the full data report, the numbers will be broken down into confirmed and probable cases and confirmed and probable deaths consistent with Centers for Disease Control and Prevention surveillance case definitions: wwwn.cdc.gov/nndss/conditions/coronavirus-disease-2019-covid-19/case-definition/2020/."

The CDC definition seems to state specimens, not test encounters.