### PR TITLE
Add 6 days to collection_week to indicate the last data point included.

### DIFF
--- a/can_tools/scrapers/official/federal/HHS/facility.py
+++ b/can_tools/scrapers/official/federal/HHS/facility.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from datetime import timedelta
 
 import pandas as pd
 import numpy as np
@@ -26,7 +27,9 @@ class HHSReportedPatientImpactHospitalCapacityFacility(HHSDataset):
         df.columns = [x.lower().strip() for x in df.columns]
 
         # Set date and fips code
-        df.loc[:, "dt"] = pd.to_datetime(df["collection_week"])
+        # NOTE: collection_week refers to the first day of the week, so add 6
+        # days to get the last day.
+        df.loc[:, "dt"] = pd.to_datetime(df["collection_week"]) + timedelta(days=6)
 
         # Filter out all of the columns without a fips code for now -- I
         # think that it is likely that we could reverse engineer these


### PR DESCRIPTION
@ghop02 pointed out that collection_week indicates the _start_ of the week.

Per the example on https://healthdata.gov/dataset/covid-19-reported-patient-impact-and-hospital-capacity-facility:

> For a given entry, the term “collection_week” signifies the start of the period that is aggregated. For example, a “collection_week” of 2020-11-20 means the average/sum/coverage of the elements captured from that given facility starting and including Friday, November 20, 2020, and ending and including reports for Thursday, November 26, 2020.

So I've added 6 days to the collection_week date.