### PR TITLE
CDC Vaccine Data

### DIFF
--- a/can_tools/bootstrap_data/covid_categories.csv
+++ b/can_tools/bootstrap_data/covid_categories.csv
@@ -60,3 +60,7 @@ vaccine,pfizer_vaccine_allocated
 vaccine,pfizer_vaccine_distributed
 vaccine,pfizer_vaccine_initiated
 vaccine,pfizer_vaccine_completed
+vaccine,total_vaccine_allocated
+vaccine,total_vaccine_distributed
+vaccine,total_vaccine_initiated
+vaccine,total_vaccine_completed

--- a/can_tools/bootstrap_data/covid_categories.csv
+++ b/can_tools/bootstrap_data/covid_categories.csv
@@ -52,3 +52,11 @@ test,reported_positivity
 hospital,critical_staff_shortage_yes
 hospital,critical_staff_shortage_no
 hospital,critical_staff_shortage_noreport
+vaccine,moderna_vaccine_allocated
+vaccine,moderna_vaccine_distributed
+vaccine,moderna_vaccine_initiated
+vaccine,moderna_vaccine_completed
+vaccine,pfizer_vaccine_allocated
+vaccine,pfizer_vaccine_distributed
+vaccine,pfizer_vaccine_initiated
+vaccine,pfizer_vaccine_completed

--- a/can_tools/bootstrap_data/covid_units.csv
+++ b/can_tools/bootstrap_data/covid_units.csv
@@ -8,3 +8,4 @@ unique_people
 unknown
 beds
 hospitals
+doses

--- a/can_tools/bootstrap_data/covid_variables.csv
+++ b/can_tools/bootstrap_data/covid_variables.csv
@@ -166,3 +166,11 @@ adult_icu_beds_in_use_covid,rolling_average_7_day,beds
 ventilators_available,current,people
 ventilators_in_use,current,people
 ventilators_capacity,current,people
+moderna_vaccine_allocated,cumulative,doses
+moderna_vaccine_distributed,cumulative,doses
+moderna_vaccine_initiated,cumulative,people
+moderna_vaccine_completed,cumulative,people
+pfizer_vaccine_allocated,cumulative,doses
+pfizer_vaccine_distributed,cumulative,doses
+pfizer_vaccine_initiated,cumulative,people
+pfizer_vaccine_completed,cumulative,people

--- a/can_tools/bootstrap_data/covid_variables.csv
+++ b/can_tools/bootstrap_data/covid_variables.csv
@@ -174,3 +174,7 @@ pfizer_vaccine_allocated,cumulative,doses
 pfizer_vaccine_distributed,cumulative,doses
 pfizer_vaccine_initiated,cumulative,people
 pfizer_vaccine_completed,cumulative,people
+total_vaccine_allocated,cumulative,doses
+total_vaccine_distributed,cumulative,doses
+total_vaccine_initiated,cumulative,people
+total_vaccine_completed,cumulative,people

--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -3,6 +3,7 @@ from can_tools.scrapers.official import (  # IllinoisDemographics,; IllinoisHist
     CaliforniaCasesDeaths,
     CaliforniaHospitals,
     CDCCovidDataTracker,
+    CDCStateVaccine,
     DCCases,
     DCDeaths,
     DCGeneral,

--- a/can_tools/scrapers/official/__init__.py
+++ b/can_tools/scrapers/official/__init__.py
@@ -3,7 +3,8 @@ from can_tools.scrapers.official.CA import CaliforniaCasesDeaths, CaliforniaHosp
 from can_tools.scrapers.official.DC import DCCases, DCGeneral, DCDeaths
 
 from can_tools.scrapers.official.federal import (
-    CDCCovidDataTracker, CDCStateVaccine,
+    CDCCovidDataTracker,
+    CDCStateVaccine,
     HHSReportedPatientImpactHospitalCapacityFacility,
     HHSReportedPatientImpactHospitalCapacityState,
 )

--- a/can_tools/scrapers/official/__init__.py
+++ b/can_tools/scrapers/official/__init__.py
@@ -3,7 +3,7 @@ from can_tools.scrapers.official.CA import CaliforniaCasesDeaths, CaliforniaHosp
 from can_tools.scrapers.official.DC import DCCases, DCGeneral, DCDeaths
 
 from can_tools.scrapers.official.federal import (
-    CDCCovidDataTracker,
+    CDCCovidDataTracker, CDCStateVaccine,
     HHSReportedPatientImpactHospitalCapacityFacility,
     HHSReportedPatientImpactHospitalCapacityState,
 )

--- a/can_tools/scrapers/official/federal/CDC/__init__.py
+++ b/can_tools/scrapers/official/federal/CDC/__init__.py
@@ -1,3 +1,6 @@
 from can_tools.scrapers.official.federal.CDC.cdc_coviddatatracker import (
     CDCCovidDataTracker,
 )
+from can_tools.scrapers.official.federal.CDC.cdc_state_vaccines import (
+    CDCStateVaccine
+)

--- a/can_tools/scrapers/official/federal/CDC/__init__.py
+++ b/can_tools/scrapers/official/federal/CDC/__init__.py
@@ -1,6 +1,4 @@
 from can_tools.scrapers.official.federal.CDC.cdc_coviddatatracker import (
     CDCCovidDataTracker,
 )
-from can_tools.scrapers.official.federal.CDC.cdc_state_vaccines import (
-    CDCStateVaccine
-)
+from can_tools.scrapers.official.federal.CDC.cdc_state_vaccines import CDCStateVaccine

--- a/can_tools/scrapers/official/federal/CDC/cdc_state_vaccines.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_state_vaccines.py
@@ -25,9 +25,7 @@ class CDCStateVaccine(FederalDashboard):
 
     def normalize(self, data):
         # Read data in
-        df = pd.DataFrame.from_records(
-            data["vaccination_data"]
-        )
+        df = pd.DataFrame.from_records(data["vaccination_data"])
 
         # Set date
         df["dt"] = pd.to_datetime(df["Date"])
@@ -41,16 +39,24 @@ class CDCStateVaccine(FederalDashboard):
 
         crename = {
             "Doses_Distributed": CMU(
-                category="total_vaccine_distributed", measurement="cumulative", unit="doses"
+                category="total_vaccine_distributed",
+                measurement="cumulative",
+                unit="doses",
             ),
             "Doses_Administered": CMU(
-                category="total_vaccine_initiated", measurement="cumulative", unit="people"
+                category="total_vaccine_initiated",
+                measurement="cumulative",
+                unit="people",
             ),
             "Administered_Moderna": CMU(
-                category="moderna_vaccine_initiated", measurement="cumulative", unit="people"
+                category="moderna_vaccine_initiated",
+                measurement="cumulative",
+                unit="people",
             ),
             "Administered_Pfizer": CMU(
-                category="pfizer_vaccine_initiated", measurement="cumulative", unit="people"
+                category="pfizer_vaccine_initiated",
+                measurement="cumulative",
+                unit="people",
             ),
         }
 

--- a/can_tools/scrapers/official/federal/CDC/cdc_state_vaccines.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_state_vaccines.py
@@ -1,0 +1,75 @@
+import random
+import requests
+
+import pandas as pd
+import us
+
+from can_tools.scrapers.base import CMU
+from can_tools.scrapers.official.base import FederalDashboard
+
+
+class CDCStateVaccine(FederalDashboard):
+    has_location = True
+    location_type = "state"
+    source = "https://covid.cdc.gov/covid-data-tracker/#vaccinations"
+    provider = "cdc"
+
+    def fetch(self, test=False):
+        fetcher_url = (
+            "https://covid.cdc.gov/covid-data-tracker/COVIDData/"
+            "getAjaxData?id=vaccination_data"
+        )
+        response = requests.get(fetcher_url)
+
+        return response.json()
+
+    def normalize(self, data):
+        # Read data in
+        df = pd.DataFrame.from_records(
+            data["vaccination_data"]
+        )
+
+        # Set date
+        df["dt"] = pd.to_datetime(df["Date"])
+
+        # Only keep states and set fips codes
+        state_abbr_list = [x.abbr for x in us.STATES]
+        df = df.loc[df["Location"].isin(state_abbr_list), :]
+        df.loc[:, "location"] = df["Location"].map(
+            lambda x: int(us.states.lookup(x).fips)
+        )
+
+        crename = {
+            "Doses_Distributed": CMU(
+                category="total_vaccine_distributed", measurement="cumulative", unit="doses"
+            ),
+            "Doses_Administered": CMU(
+                category="total_vaccine_initiated", measurement="cumulative", unit="people"
+            ),
+            "Administered_Moderna": CMU(
+                category="moderna_vaccine_initiated", measurement="cumulative", unit="people"
+            ),
+            "Administered_Pfizer": CMU(
+                category="pfizer_vaccine_initiated", measurement="cumulative", unit="people"
+            ),
+        }
+
+        # Reshape and add variable information
+        out = df.melt(id_vars=["dt", "location"], value_vars=crename.keys()).dropna()
+        out = self.extract_CMU(out, crename)
+        out["vintage"] = self._retrieve_vintage()
+
+        cols_2_keep = [
+            "vintage",
+            "dt",
+            "location",
+            "category",
+            "measurement",
+            "unit",
+            "age",
+            "race",
+            "ethnicity",
+            "sex",
+            "value",
+        ]
+        return out.loc[:, cols_2_keep]

--- a/can_tools/scrapers/official/federal/__init__.py
+++ b/can_tools/scrapers/official/federal/__init__.py
@@ -1,4 +1,5 @@
-from can_tools.scrapers.official.federal.CDC import CDCCovidDataTracker
+from can_tools.scrapers.official.federal.CDC import CDCCovidDataTracker, CDCStateVaccine
+
 from can_tools.scrapers.official.federal.HHS import (
     HHSReportedPatientImpactHospitalCapacityFacility,
     HHSReportedPatientImpactHospitalCapacityState,


### PR DESCRIPTION
Data from https://covid.cdc.gov/covid-data-tracker/#vaccinations

This PR is based on #75 -- In addition to the categories/variables included in that PR, it also adds `total_vaccines_{}` because the CDC data reports:

1. Doses_Distributed
2. Doses_Administered
3. Administered_Moderna
4. Administered_Pfizer

The next PR will cover:

* https://healthdata.gov/dataset/covid-19-vaccine-distribution-allocations-jurisdiction-moderna
* https://healthdata.gov/dataset/covid-19-vaccine-distribution-allocations-jurisdiction-pfizer

The column naming in these upcoming datasets is pretty annoying...
