### PR TITLE
CDC Testing Data: Add DC support

### DIFF
--- a/can_tools/scrapers/base.py
+++ b/can_tools/scrapers/base.py
@@ -1,12 +1,18 @@
 from can_tools.models import Base
+
 import os
 import pickle
+
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Type
 
 import pandas as pd
+import us
 from sqlalchemy.engine.base import Engine
+
+
+ALL_STATES_PLUS_DC = us.STATES + [us.states.DC]
 
 
 class CMU:

--- a/can_tools/scrapers/base.py
+++ b/can_tools/scrapers/base.py
@@ -12,6 +12,10 @@ import us
 from sqlalchemy.engine.base import Engine
 
 
+# `us` v2.0 removed DC from the `us.STATES` list, so we are creating
+# our own which includes DC. In v3.0, there will be an env option to
+# include `DC` in the `us.STATES` list and, if we upgrade, we should
+# activate that option and replace this with just `us.STATES`
 ALL_STATES_PLUS_DC = us.STATES + [us.states.DC]
 
 

--- a/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
@@ -30,7 +30,9 @@ class CDCCovidDataTracker(FederalDashboard):
                 random.sample(us.STATES, 3),
             )
         else:
-            urls = map(lambda x: fetcher_url.format(x.abbr.lower()), us.STATES)
+            urls = map(
+                lambda x: fetcher_url.format(x.abbr.lower()), us.STATES + [us.states.DC]
+            )
         responses = list(map(requests.get, urls))
         bad_idx = [i for (i, r) in enumerate(responses) if not r.ok]
         if len(bad_idx):

--- a/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
@@ -2,9 +2,8 @@ import random
 import requests
 
 import pandas as pd
-import us
 
-from can_tools.scrapers.base import CMU
+from can_tools.scrapers.base import CMU, ALL_STATES_PLUS_DC
 from can_tools.scrapers.official.base import FederalDashboard
 
 
@@ -27,12 +26,10 @@ class CDCCovidDataTracker(FederalDashboard):
             # When testing, choos random 3 states
             urls = map(
                 lambda x: fetcher_url.format(x.abbr.lower()),
-                random.sample(us.STATES, 3),
+                random.sample(ALL_STATES_PLUS_DC, 3),
             )
         else:
-            urls = map(
-                lambda x: fetcher_url.format(x.abbr.lower()), us.STATES + [us.states.DC]
-            )
+            urls = map(lambda x: fetcher_url.format(x.abbr.lower()), ALL_STATES_PLUS_DC)
         responses = list(map(requests.get, urls))
         bad_idx = [i for (i, r) in enumerate(responses) if not r.ok]
         if len(bad_idx):


### PR DESCRIPTION
We are using the `us` package v2 which removed DC from the `us.STATES` list (see https://github.com/unitedstates/python-us#200). In `us` v3, DC can be added to the `us.STATES` list by setting an env variable. We can revisit this update if we decide to upgrade.

We create a new variable `ALL_US_STATES_PLUS_DC` and store it in `can_tools/scrapers/base.py`. This variable is then referenced in the `CDCCovidDataTracker.fetch` method. We can update other scrapers in the future as we notice that they use `us.STATES` to iterate rather than `ALL_US_STATES_PLUS_DC`.

Resolves #81 