### PR TITLE
CDC: Update vaccine scraper to reflect the new json structure and new data

### DIFF
--- a/can_tools/bootstrap_data/covid_categories.csv
+++ b/can_tools/bootstrap_data/covid_categories.csv
@@ -64,3 +64,4 @@ vaccine,total_vaccine_allocated
 vaccine,total_vaccine_distributed
 vaccine,total_vaccine_initiated
 vaccine,total_vaccine_completed
+vaccine,total_vaccine_doses_administered

--- a/can_tools/bootstrap_data/covid_variables.csv
+++ b/can_tools/bootstrap_data/covid_variables.csv
@@ -178,3 +178,4 @@ total_vaccine_allocated,cumulative,doses
 total_vaccine_distributed,cumulative,doses
 total_vaccine_initiated,cumulative,people
 total_vaccine_completed,cumulative,people
+total_vaccine_doses_administered,cumulative,doses

--- a/can_tools/scrapers/official/federal/CDC/cdc_state_vaccines.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_state_vaccines.py
@@ -36,9 +36,6 @@ class CDCStateVaccine(FederalDashboard):
         df.loc[:, "location"] = df["Location"].map(
             lambda x: int(us.states.lookup(x).fips)
         )
-        df.loc[:, "Administered_Dose2"] = df.eval(
-            "Doses_Administered - Administered_Dose1"
-        )
 
         crename = {
             "Doses_Distributed": CMU(
@@ -51,10 +48,10 @@ class CDCStateVaccine(FederalDashboard):
                 measurement="cumulative",
                 unit="people",
             ),
-            "Administered_Dose2": CMU(
-                category="total_vaccine_completed",
+            "Doses_Administered": CMU(
+                category="total_vaccine_doses_administered",
                 measurement="cumulative",
-                unit="people",
+                unit="doses",
             ),
         }
 

--- a/can_tools/scrapers/official/federal/CDC/cdc_state_vaccines.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_state_vaccines.py
@@ -4,7 +4,7 @@ import requests
 import pandas as pd
 import us
 
-from can_tools.scrapers.base import CMU
+from can_tools.scrapers.base import CMU, ALL_STATES_PLUS_DC
 from can_tools.scrapers.official.base import FederalDashboard
 
 
@@ -31,10 +31,13 @@ class CDCStateVaccine(FederalDashboard):
         df["dt"] = pd.to_datetime(df["Date"])
 
         # Only keep states and set fips codes
-        state_abbr_list = [x.abbr for x in us.STATES]
+        state_abbr_list = [x.abbr for x in ALL_STATES_PLUS_DC]
         df = df.loc[df["Location"].isin(state_abbr_list), :]
         df.loc[:, "location"] = df["Location"].map(
             lambda x: int(us.states.lookup(x).fips)
+        )
+        df.loc[:, "Administered_Dose2"] = df.eval(
+            "Doses_Administered - Administered_Dose1"
         )
 
         crename = {
@@ -43,18 +46,13 @@ class CDCStateVaccine(FederalDashboard):
                 measurement="cumulative",
                 unit="doses",
             ),
-            "Doses_Administered": CMU(
+            "Administered_Dose1": CMU(
                 category="total_vaccine_initiated",
                 measurement="cumulative",
                 unit="people",
             ),
-            "Administered_Moderna": CMU(
-                category="moderna_vaccine_initiated",
-                measurement="cumulative",
-                unit="people",
-            ),
-            "Administered_Pfizer": CMU(
-                category="pfizer_vaccine_initiated",
+            "Administered_Dose2": CMU(
+                category="total_vaccine_completed",
                 measurement="cumulative",
                 unit="people",
             ),


### PR DESCRIPTION
@ghop02 @sglyon 

Chris noticed that the structure of the json has changed and now includes first doses and total doses. We're implicitly assuming that `dose 1 + dose 2 = total doses` and imputing `dose 2` values.

Additionally, rather than iterate on `us.STATES`, we use the new `ALL_STATES_PLUS_DC` variable