### PR TITLE
CDC Vaccine Data: Update to incorporate dose 2

### DIFF
--- a/can_tools/scrapers/official/federal/CDC/cdc_state_vaccines.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_state_vaccines.py
@@ -48,6 +48,11 @@ class CDCStateVaccine(FederalDashboard):
                 measurement="cumulative",
                 unit="people",
             ),
+            "Administered_Dose2": CMU(
+                category="total_vaccine_completed",
+                measurement="cumulative",
+                unit="people",
+            ),
             "Doses_Administered": CMU(
                 category="total_vaccine_doses_administered",
                 measurement="cumulative",


### PR DESCRIPTION
@mikelehen noticed that they've add the dose 2 data... We incorporate that in this PR.

@ghop02 @sglyon 