### PR TITLE
VT Vaccine County and State

### DIFF
--- a/can_tools/bootstrap_data/covid_variables.csv
+++ b/can_tools/bootstrap_data/covid_variables.csv
@@ -174,12 +174,14 @@ pfizer_vaccine_allocated,cumulative,doses
 pfizer_vaccine_distributed,cumulative,doses
 pfizer_vaccine_initiated,cumulative,people
 total_vaccine_initiated,new,people
+total_vaccine_initiated,new_7_day,people
 pfizer_vaccine_completed,cumulative,people
 total_vaccine_allocated,cumulative,doses
 total_vaccine_distributed,cumulative,doses
 total_vaccine_initiated,cumulative,people
 total_vaccine_completed,cumulative,people
 total_vaccine_completed,new,people
+total_vaccine_completed,new_7_day,people
 total_vaccine_doses_administered,cumulative,doses
 total_vaccine_doses_administered,new,doses
 pcr_tests_positive,rolling_average_14_day,percentage

--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -40,6 +40,8 @@ from can_tools.scrapers.official import (  # IllinoisDemographics,; IllinoisHist
     TexasStateVaccine,
     # TexasVaccineDemographics,
     TexasTests,
+    VermontCountyVaccine,
+    VermontStateVaccine,
     WisconsinCounties,
     WisconsinState,
 )

--- a/can_tools/scrapers/official/VT/__init__.py
+++ b/can_tools/scrapers/official/VT/__init__.py
@@ -1,0 +1,4 @@
+from can_tools.scrapers.official.VT.vt_vaccinations import (
+    VermontCountyVaccine,
+    VermontStateVaccine,
+)

--- a/can_tools/scrapers/official/VT/vt_vaccinations.py
+++ b/can_tools/scrapers/official/VT/vt_vaccinations.py
@@ -1,0 +1,214 @@
+import pandas as pd
+import us
+
+from can_tools.scrapers import CMU
+from can_tools.scrapers.official.base import ArcGIS
+
+pd.options.mode.chained_assignment = None  # Avoid unnessacary SettingWithCopy warning
+
+
+class VermontCountyVaccine(ArcGIS):
+    ARCGIS_ID = "YKJ5JtnaPQ2jDbX8"
+    has_location = False
+    location_type = "county"
+    state_fips = int(us.states.lookup("Vermont").fips)
+    source = "https://www.healthvermont.gov/covid-19/vaccine/covid-19-vaccine-dashboard"
+    var_columns = [
+        "dose_1_male",
+        "dose_1_female",
+        "dose_1_sex_unknown",
+        "dose_2_male",
+        "dose_2_female",
+        "dose_2_sex_unknown",
+    ]  # variables to track
+
+    def fetch(self):
+        return self.get_all_jsons("VT_COVID_Vaccine_Data", 0, "")
+
+    def normalize(self, data):
+        data = (
+            self.arcgis_jsons_to_df(data)
+            .fillna(0)
+            .rename(columns={"County": "location_name"})
+        )
+        data = self._get_clean_data(data)
+        newest_date = data["dt"].max()
+
+        """
+        get cumulative data
+        """
+        df = data.melt(
+            id_vars=["dt", "location_name"], value_vars=self.var_columns
+        ).dropna()
+
+        # sum total values by county for first and second dose
+        df1 = (
+            df.query('variable.str.contains("dose_1")')
+            .groupby("location_name", as_index=False)
+            .sum("value")
+        )
+        df1["category"] = "total_vaccine_initiated"
+        df2 = (
+            df.query('variable.str.contains("dose_2")')
+            .groupby("location_name", as_index=False)
+            .sum("value")
+        )
+        df2["category"] = "total_vaccine_completed"
+
+        # combine dfs and fill needed columns
+        df = pd.concat(
+            [
+                df1,
+                df2,
+            ],
+            ignore_index=True,
+        )
+        cumulative_df = self._populate_cols(df, newest_date)
+
+        """
+        get weekly snapshots
+        """
+        # create "total" 1st and 2nd dose columns by week
+        weekly_df = self._get_clean_data(data)
+        weekly_df["dose_1"] = (
+            weekly_df["dose_1_male"]
+            + weekly_df["dose_1_female"]
+            + weekly_df["dose_1_sex_unknown"]
+        )
+        weekly_df["dose_2"] = (
+            weekly_df["dose_2_male"]
+            + weekly_df["dose_2_female"]
+            + weekly_df["dose_2_sex_unknown"]
+        )
+
+        crename = {
+            "dose_1": CMU(
+                category="total_vaccine_initiated",
+                measurement="new_7_day",
+                unit="people",
+            ),
+            "dose_2": CMU(
+                category="total_vaccine_completed",
+                measurement="new_7_day",
+                unit="people",
+            ),
+            "dose_1_male": CMU(
+                category="total_vaccine_initiated",
+                measurement="new_7_day",
+                unit="people",
+                sex="male",
+            ),
+            "dose_2_male": CMU(
+                category="total_vaccine_completed",
+                measurement="new_7_day",
+                unit="people",
+                sex="male",
+            ),
+            "dose_1_female": CMU(
+                category="total_vaccine_initiated",
+                measurement="new_7_day",
+                unit="people",
+                sex="female",
+            ),
+            "dose_2_female": CMU(
+                category="total_vaccine_completed",
+                measurement="new_7_day",
+                unit="people",
+                sex="female",
+            ),
+            "dose_1_sex_unknown": CMU(
+                category="total_vaccine_initiated",
+                measurement="new_7_day",
+                unit="people",
+                sex="unknown",
+            ),
+            "dose_2_sex_unknown": CMU(
+                category="total_vaccine_completed",
+                measurement="new_7_day",
+                unit="people",
+                sex="unknown",
+            ),
+        }
+
+        weekly_df = weekly_df.melt(
+            id_vars=["location_name", "dt"], value_vars=crename.keys()
+        ).dropna()
+        weekly_df["value"] = weekly_df["value"].astype(int)
+        weekly_df["vintage"] = self._retrieve_vintage()
+
+        # Extract category information and add other variable context
+        weekly_df = self.extract_CMU(weekly_df, crename)
+        weekly_df = weekly_df.drop(columns={"variable"})
+
+        return pd.concat([cumulative_df, weekly_df], ignore_index=True)
+
+    def _get_clean_data(self, data):
+        """
+        clean data -- rename columns and reformat date column
+
+        accepts: pandas.Dataframe
+        returns: pandas.Dataframe
+        """
+        data.columns = [x.lower() for x in list(data)]
+        data = data.query("location_name != 'Unknown/Other'")
+        data["dt"] = (
+            data["dates"].str.split("-").str[0]
+        )  # keep first date (can change to second)
+        data["dt"] = pd.to_datetime(data["dt"], errors="coerce")
+        return data
+
+    def _populate_cols(self, data, dt):
+        """
+        create and populate necessary columns for put() function. format value to numeric
+
+        accepts: pandas.Dataframe
+        returns: pandas.Dataframe
+        """
+        df = data
+        df[["measurement", "unit", "age", "race", "ethnicity", "sex"]] = [
+            "cumulative",
+            "people",
+            "all",
+            "all",
+            "all",
+            "all",
+        ]  # add columns and values
+
+        df["dt"] = dt
+        df["vintage"] = self._retrieve_vintage()
+        df.loc[:, "value"] = pd.to_numeric(df["value"])
+        return df
+
+
+class VermontStateVaccine(VermontCountyVaccine):
+    has_location = True
+    location_type = "state"
+
+    def normalize(self, data):
+        data = (
+            self.arcgis_jsons_to_df(data)
+            .fillna(0)
+            .rename(columns={"County": "location_name"})
+        )
+        df = self._get_clean_data(data)
+        newest_date = df["dt"].max()
+
+        # transform to long -- keep only dose 1 and 2 for each sex
+        df = df.melt(
+            id_vars=["dt", "location_name"], value_vars=self.var_columns
+        ).dropna()
+
+        # get cumulative state values (sum all rows for each dose)
+        first_dose = df.loc[df["variable"].str.contains("dose_1"), "value"].sum()
+        second_dose = df.loc[df["variable"].str.contains("dose_2"), "value"].sum()
+
+        # combine values into a df and add necessary columns
+        d = [
+            {"value": first_dose, "category": "total_vaccine_initiated"},
+            {"value": second_dose, "category": "total_vaccine_completed"},
+        ]
+        df = pd.DataFrame(d)
+        df = self._populate_cols(df, newest_date)
+
+        df["location"] = self.state_fips
+        return df

--- a/can_tools/scrapers/official/__init__.py
+++ b/can_tools/scrapers/official/__init__.py
@@ -73,3 +73,5 @@ from can_tools.scrapers.official.CT import (
 )
 
 from can_tools.scrapers.official.OH import OhioVaccineCounty
+
+from can_tools.scrapers.official.VT import VermontCountyVaccine, VermontStateVaccine


### PR DESCRIPTION
Scrapers to collect data on `total_vaccine_initiated` and `total_vaccine_completed`.  

- [Data Source](https://services.arcgis.com/YKJ5JtnaPQ2jDbX8/arcgis/rest/services/VT_COVID_Vaccine_Data/FeatureServer/0)
- [Corresponding Dashboard](https://www.healthvermont.gov/covid-19/vaccine/covid-19-vaccine-dashboard)

### VermontCountyVaccine():
by county:
- cumulative data for `total_vaccine_initiated` and `total_vaccine_completed` 
- weekly data for `total_vaccine_initiated` and `total_vaccine_completed` by gender

### VermontStateVaccine():
state level:
- cumulative data for `total_vaccine_initiated` and `total_vaccine_completed`

### Notes:

- PowerBI dashboard updates more frequently than data portal (where I pulled the data from)
- Cumulative/summed data do not match that of the dashboard because of the less frequent updates, so I'm not sure how to validate/check that the sums are correct.
- Dates are provided in week spans (start and end date.) I extract the start of the week as the date, but am able to change this if needed 
