### PR TITLE
BUG: Fix MI and NC county names

### DIFF
--- a/can_tools/scrapers/official/MI/mi_vaccine.py
+++ b/can_tools/scrapers/official/MI/mi_vaccine.py
@@ -45,7 +45,7 @@ class MichiganVaccineCounty(StateDashboard):
                 unit="doses",
             ),
         }
-        not_counties = ["No County", "Detroit"]  # noqa
+        not_counties = ["No County", "Detroit", "Non-Michigan Resident"]  # noqa
 
         # need to sum over all the possible facility types for distribution
         df = (

--- a/can_tools/scrapers/official/NC/nc_vaccine.py
+++ b/can_tools/scrapers/official/NC/nc_vaccine.py
@@ -51,6 +51,11 @@ class NorthCarolinaVaccineCounty(StateDashboard):
             .loc[:, col_renamer.values()]
         )
 
+        # Fix names of counties...
+        df.loc[:, "location_name"] = (
+            df.loc[:, "location_name"].str.strip().replace({"Mcdowell": "McDowell"})
+        )
+
         # Drop missing
         df = (
             df.dropna()


### PR DESCRIPTION
MI is now reporting a "Non-Michigan Resident" value under counties and NC (1) added spaces after every county name and (2) changed McDowell to Mcdowell.

This PR fixes both errors introduced by changes to the dashboard.