### PR TITLE
Scraper for Montana County and State Vaccines

### DIFF
--- a/can_tools/bootstrap_data/covid_units.csv
+++ b/can_tools/bootstrap_data/covid_units.csv
@@ -1,5 +1,6 @@
 name
 people
+doses_per_1k
 people_per_100k
 percentage
 specimens

--- a/can_tools/bootstrap_data/covid_variables.csv
+++ b/can_tools/bootstrap_data/covid_variables.csv
@@ -184,6 +184,7 @@ total_vaccine_completed,new,people
 total_vaccine_completed,new_7_day,people
 total_vaccine_doses_administered,cumulative,doses
 total_vaccine_doses_administered,new,doses
+total_vaccine_doses_administered,cumulative,doses_per_1k
 pcr_tests_positive,rolling_average_14_day,percentage
 total_vaccine_initiated,current,percentage
 total_vaccine_completed,current,percentage

--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -26,6 +26,8 @@ from can_tools.scrapers.official import (  # IllinoisDemographics,; IllinoisHist
     MarylandCountyVaccines,
     MarylandState,
     MinnesotaCountyVaccines,
+    MontanaCountyVaccine,
+    MontanaStateVaccine,
     NewJerseyVaccineCounty,
     MichiganVaccineCounty,
     MissouriVaccineCounty,

--- a/can_tools/scrapers/official/MT/__init__.py
+++ b/can_tools/scrapers/official/MT/__init__.py
@@ -1,0 +1,4 @@
+from can_tools.scrapers.official.MT.mt_vaccinations import (
+    MontanaCountyVaccine,
+    MontanaStateVaccine,
+)

--- a/can_tools/scrapers/official/MT/mt_vaccinations.py
+++ b/can_tools/scrapers/official/MT/mt_vaccinations.py
@@ -1,0 +1,126 @@
+import pandas as pd
+import us
+
+from can_tools.scrapers import CMU
+from can_tools.scrapers.official.base import ArcGIS
+
+
+class MontanaCountyVaccine(ArcGIS):
+    ARCGIS_ID = "qnjIrwR8z5Izc0ij"
+    has_location = False
+    location_type = "county"
+    state_fips = int(us.states.lookup("Montana").fips)
+    source = "https://montana.maps.arcgis.com/apps/MapSeries/index.html?appid=7c34f3412536439491adcc2103421d4b"
+    crename = {
+        "Dose_1": CMU(
+            category="total_vaccine_initiated",
+            measurement="cumulative",
+            unit="people",
+        ),
+        "Dose_2": CMU(
+            category="total_vaccine_completed",
+            measurement="cumulative",
+            unit="people",
+        ),
+        "total_doses_admin": CMU(
+            category="total_vaccine_doses_administered",
+            measurement="cumulative",
+            unit="doses",
+        ),
+        "Doses_per_1000": CMU(
+            category="total_vaccine_doses_administered",
+            measurement="cumulative",
+            unit="doses_per_1k",
+        ),
+    }
+
+    def fetch(self):
+        return self.get_all_jsons("COVID_Vaccination_PRD_View", 0, "")
+
+    def normalize(self, data):
+        df = (
+            self.arcgis_jsons_to_df(data)
+            .fillna(0)
+            .rename(columns={"NAME": "location_name", "Date_Reported": "dt"})
+        )
+
+        df["location_name"] = df[
+            "location_name"
+        ].str.title()  # capitalize start of words
+
+        df["location_name"] = df["location_name"].replace(
+            {"Lewis & Clark": "Lewis and Clark", "Mccone": "McCone"}
+        )  # rename mismatching names
+
+        df["dt"] = pd.to_datetime(df["dt"], unit="ms").dt.date
+
+        df["total_doses_admin"] = (
+            df["Dose_1"] + df["Dose_2"]
+        )  # this matches the values in the dashboard
+
+        return self._transform_df(df)
+
+    def _transform_df(self, data):
+        """
+        transform pd.Dataframe from wide to long
+        add vintage timestamp
+        select columns to return
+        """
+        # specify if has FIPS or not
+        if self.has_location:
+            loc_col_type = "location"
+        elif not self.has_location:
+            loc_col_type = "location_name"
+
+        out = data.melt(
+            id_vars=["dt", loc_col_type], value_vars=self.crename.keys()
+        ).dropna()
+        out.loc[:, "value"] = pd.to_numeric(out["value"])
+        out = self.extract_CMU(out, self.crename)
+        out["vintage"] = self._retrieve_vintage()
+
+        cols_to_keep = [
+            "vintage",
+            "dt",
+            loc_col_type,
+            "category",
+            "measurement",
+            "unit",
+            "age",
+            "race",
+            "ethnicity",
+            "sex",
+            "value",
+        ]
+        return out.loc[:, cols_to_keep]
+
+
+class MontanaStateVaccine(MontanaCountyVaccine):
+    location_type = "state"
+    has_location = True
+    crename = {
+        "Total_Montanans_Immunized": CMU(
+            category="total_vaccine_completed",
+            measurement="cumulative",
+            unit="people",
+        ),
+        "Total_Doses_Administered": CMU(
+            category="total_vaccine_doses_administered",
+            measurement="cumulative",
+            unit="doses",
+        ),
+    }
+
+    def fetch(self):
+        return self.get_all_jsons("COVID_Vaccination_PRD_View", 1, "")
+
+    def normalize(self, data):
+        df = (
+            self.arcgis_jsons_to_df(data)
+            .fillna(0)
+            .rename(columns={"Report_Date": "dt"})
+        )
+        df["dt"] = pd.to_datetime(df["dt"], unit="ms").dt.date
+        df["location"] = self.state_fips
+
+        return self._transform_df(df)

--- a/can_tools/scrapers/official/__init__.py
+++ b/can_tools/scrapers/official/__init__.py
@@ -52,6 +52,8 @@ from can_tools.scrapers.official.MD import (
 )
 from can_tools.scrapers.official.MN import MinnesotaCountyVaccines
 
+from can_tools.scrapers.official.MT import MontanaCountyVaccine, MontanaStateVaccine
+
 # from can_tools.scrapers.official.MA import Massachusetts
 from can_tools.scrapers.official.NC import NorthCarolinaVaccineCounty
 from can_tools.scrapers.official.NJ import NewJerseyVaccineCounty


### PR DESCRIPTION
[dashboard](https://montana.maps.arcgis.com/apps/MapSeries/index.html?appid=7c34f3412536439491adcc2103421d4b)

[data souce](https://services.arcgis.com/qnjIrwR8z5Izc0ij/ArcGIS/rest/services/COVID_Vaccination_PRD_View/FeatureServer)

**`MontanaCountyVaccine()`:**

tracks: 
| _original variable_    | category                         | measurement   | unit         |
|----:|:---------------------------------|:--------------|:-------------|
|   _Dose_1_ | total_vaccine_initiated          | cumulative    | people       |
|  _Dose_2_ | total_vaccine_completed          | cumulative    | people       |
| _Dose_1 + Dose_2_ | total_vaccine_doses_administered | cumulative    | doses        |
| _Doses_per_1000_ | total_vaccine_doses_administered | cumulative    | doses_per_1k |

**`MontanaStateVaccine()`:**

tracks:
|  _original variable_  | category                         | measurement   | unit   |
|---:|:---------------------------------|:--------------|:-------|
|  _Total_Montanans_Immunized_ | total_vaccine_completed          | cumulative    | people |
| _Total_Doses_Administered_| total_vaccine_doses_administered | cumulative    | doses  |

**Notes:**

- For the county data the `total_vaccine_doses_administered`,`cumulative`,`doses` data is calculated by adding the _initiated_ and _completed_ columns together. These values match the `Total Doses Administered` numbers displayed on the dashboard. 

- I kept the vaccinations per 1000 people (I'm not sure if this data is wanted or not), and to do so created the unit `doses_per_1k` and the corresponding entry in `covid_variables.csv` 
- The sums of the county data (for `total_vaccine_doses_administered ` and `total_vaccine_completed`) do not match the given total statewide data. I suspect this might be due to doses being administered in Federal Entities (like prisons), but I wanted to flag this.