### PR TITLE
WIP: Fix scrapers

### DIFF
--- a/can_tools/__init__.py
+++ b/can_tools/__init__.py
@@ -36,7 +36,17 @@ def all_subclasses(cls):
 
 
 def non_abc_subclasses(cls):
-    return list(x for x in all_subclasses(cls) if not inspect.isabstract(x))
+    out = list(x for x in all_subclasses(cls) if not inspect.isabstract(x))
+
+    # need to specifically remove some classes :(
+    from can_tools.scrapers.official.base import TableauDashboard
+    from can_tools.scrapers.official.PA.pa_vaccines import (
+        PennsylvaniaVaccineDemographics,
+    )
+
+    bad = [TableauDashboard, PennsylvaniaVaccineDemographics]
+
+    return [x for x in out if x not in bad]
 
 
 ALL_SCRAPERS: List[Type[scrapers.DatasetBase]] = non_abc_subclasses(

--- a/can_tools/bootstrap_data/covid_variables.csv
+++ b/can_tools/bootstrap_data/covid_variables.csv
@@ -190,3 +190,4 @@ total_vaccine_doses_administered,new,doses
 pcr_tests_positive,rolling_average_14_day,percentage
 total_vaccine_initiated,current,percentage
 total_vaccine_completed,current,percentage
+janssen_vaccine_allocated,cumulative,doses

--- a/can_tools/scrapers/ctp.py
+++ b/can_tools/scrapers/ctp.py
@@ -107,7 +107,7 @@ class CovidTrackingProjectDemographics(FederalDashboard):
             # "Tests_Ethnicity_Unknown",
         }
         # Fill `#REF!` entries with NaN
-        data.Cases_Black = pd.to_numeric(data.Cases_Black, errors='coerce')
+        data.Cases_Black = pd.to_numeric(data.Cases_Black, errors="coerce")
 
         return (
             data.assign(

--- a/can_tools/scrapers/ctp.py
+++ b/can_tools/scrapers/ctp.py
@@ -106,6 +106,8 @@ class CovidTrackingProjectDemographics(FederalDashboard):
             # "Tests_Ethnicity_NonHispanic",
             # "Tests_Ethnicity_Unknown",
         }
+        # Fill `#REF!` entries with NaN
+        data.Cases_Black = pd.to_numeric(data.Cases_Black, errors='coerce')
 
         return (
             data.assign(

--- a/can_tools/scrapers/official/AZ/az_vaccine.py
+++ b/can_tools/scrapers/official/AZ/az_vaccine.py
@@ -50,6 +50,8 @@ class ArizonaVaccineCounty(StateDashboard):
             "pfizer_vaccine_allocated",
             "moderna_vaccine_allocated_new_doses",
             "moderna_vaccine_allocated",
+            "janssen_vaccine_new_doses",
+            "janssen_vaccine_allocated",
             "total_vaccine_allocated",
         ]
 
@@ -58,6 +60,7 @@ class ArizonaVaccineCounty(StateDashboard):
             "location_name",
             "pfizer_vaccine_allocated",
             "moderna_vaccine_allocated",
+            'janssen_vaccine_allocated',
             "total_vaccine_allocated",
         ]
 
@@ -75,6 +78,11 @@ class ArizonaVaccineCounty(StateDashboard):
                 category="pfizer_vaccine_allocated",
                 measurement="cumulative",
                 unit="doses",
+            ),
+            "janssen_vaccine_allocated": CMU(
+                category="janssen_vaccine_allocated",
+                measurement="cumulative",
+                unit="doses"
             ),
             "total_vaccine_allocated": CMU(
                 category="total_vaccine_allocated",

--- a/can_tools/scrapers/official/AZ/az_vaccine.py
+++ b/can_tools/scrapers/official/AZ/az_vaccine.py
@@ -60,7 +60,7 @@ class ArizonaVaccineCounty(StateDashboard):
             "location_name",
             "pfizer_vaccine_allocated",
             "moderna_vaccine_allocated",
-            'janssen_vaccine_allocated',
+            "janssen_vaccine_allocated",
             "total_vaccine_allocated",
         ]
 
@@ -82,7 +82,7 @@ class ArizonaVaccineCounty(StateDashboard):
             "janssen_vaccine_allocated": CMU(
                 category="janssen_vaccine_allocated",
                 measurement="cumulative",
-                unit="doses"
+                unit="doses",
             ),
             "total_vaccine_allocated": CMU(
                 category="total_vaccine_allocated",

--- a/can_tools/scrapers/official/AZ/az_vaccine.py
+++ b/can_tools/scrapers/official/AZ/az_vaccine.py
@@ -24,9 +24,9 @@ class ArizonaVaccineCounty(StateDashboard):
         return camelot.read_pdf(url, pages="2", flavor="stream")
 
     def normalize(self, data) -> pd.DataFrame:
-        # adding values to this array will cause all rows where location_name is 
+        # adding values to this array will cause all rows where location_name is
         # in this array to be removed
-        non_counties = ['Tribes']
+        non_counties = ["Tribes"]
         # Sanity check how many tables we got back
         if len(data) > 1:
             raise ValueError("more tables returned than expected value")

--- a/can_tools/scrapers/official/AZ/az_vaccine.py
+++ b/can_tools/scrapers/official/AZ/az_vaccine.py
@@ -24,6 +24,9 @@ class ArizonaVaccineCounty(StateDashboard):
         return camelot.read_pdf(url, pages="2", flavor="stream")
 
     def normalize(self, data) -> pd.DataFrame:
+        # adding values to this array will cause all rows where location_name is 
+        # in this array to be removed
+        non_counties = ['Tribes']
         # Sanity check how many tables we got back
         if len(data) > 1:
             raise ValueError("more tables returned than expected value")
@@ -93,7 +96,7 @@ class ArizonaVaccineCounty(StateDashboard):
         out["vintage"] = self._retrieve_vintage()
         out["dt"] = self._retrieve_dt("US/Arizona")
 
-        return out
+        return out.query("location_name not in @non_counties")
 
     def validate(self, df, df_hist) -> bool:
         "Quality is free, but only to those who are willing to pay heavily for it. - DeMarco and Lister"

--- a/can_tools/scrapers/official/CA/ca_vaccine.py
+++ b/can_tools/scrapers/official/CA/ca_vaccine.py
@@ -14,13 +14,18 @@ class CaliforniaVaccineCounty(TableauDashboard):
     source_name = "Official California State Government Website"
     state_fips = int(us.states.lookup("California").fips)
     location_type = "county"
-
+    source_url = (
+        "https://public.tableau.com/interactive/views/"
+        "COVID-19VaccineDashboardPublic/Vaccine"
+        "?:embed=y&:showVizHome=no&:display_count=y&:display_static_image=y"
+        "&:bootstrapWhenNotified=true&:language=en&:embed=y&:showVizHome=n&:apiID=host0"
+    )
     baseurl = "https://public.tableau.com"
 
     viewPath = "COVID-19VaccineDashboardPublic/Vaccine"
 
     cmus = {
-        "AGG(Total Doses Administered)-alias": CMU(
+        "SUM(Dose Administered)-alias": CMU(
             category="total_vaccine_doses_administered",
             measurement="cumulative",
             unit="doses",
@@ -30,7 +35,7 @@ class CaliforniaVaccineCounty(TableauDashboard):
     county_column = "County-value"
 
     def fetch(self) -> pd.DataFrame:
-        return self.get_tableau_view()["County Map"]
+        return self.get_tableau_view(self.source_url)["County Map"]
 
     def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
         # county names (converted to title case)

--- a/can_tools/scrapers/official/GA/ga_vaccines.py
+++ b/can_tools/scrapers/official/GA/ga_vaccines.py
@@ -23,13 +23,15 @@ class GeorgiaCountyVaccine(ArcGIS):
     )
     source_name = "Georgia Department of Public Health"
 
+    # TODO: Check the resource is correct
     def fetch(self):
-        return self.get_all_jsons("Georgia_DPH_COVID19_Vaccination_PUBLIC_v1", 4, 6)
+        return self.get_all_jsons(
+            "Georgia_DPH_COVID19_Vaccination_public_v2_VIEW", 7, 6
+        )
 
     def normalize(self, data):
         df = self.arcgis_jsons_to_df(data)
         df.columns = [c.lower() for c in df.columns]
-
         # Fix location names and drop state data
         df.loc[:, "location_name"] = (
             df["county_name"].str.title().str.replace("County", "").str.strip()
@@ -70,7 +72,6 @@ class GeorgiaCountyVaccine(ArcGIS):
         # Add date and vintage
         out["dt"] = self._retrieve_dt("US/Eastern")
         out["vintage"] = self._retrieve_vintage()
-
         cols_to_keep = [
             "vintage",
             "dt",

--- a/can_tools/scrapers/official/GA/ga_vaccines.py
+++ b/can_tools/scrapers/official/GA/ga_vaccines.py
@@ -23,7 +23,6 @@ class GeorgiaCountyVaccine(ArcGIS):
     )
     source_name = "Georgia Department of Public Health"
 
-    # TODO: Check the resource is correct
     def fetch(self):
         return self.get_all_jsons(
             "Georgia_DPH_COVID19_Vaccination_public_v2_VIEW", 7, 6

--- a/can_tools/scrapers/official/MN/mn_vaccine.py
+++ b/can_tools/scrapers/official/MN/mn_vaccine.py
@@ -20,11 +20,7 @@ class MinnesotaCountyVaccines(MicrosoftBIDashboard):
     source = "https://mn.gov/covid19/vaccine/data/index.jsp"
     source_name = "Minnesota Covid-19 Response"
     powerbi_url = "https://wabi-us-gov-iowa-api.analysis.usgovcloudapi.net"
-    powerbi_dashboard_link = (
-        "https://app.powerbigov.us/view?r=eyJrIjoiZDI0YzAwOTgtZDVmOS00"
-        "NTA3LTlmNjQtZTdkODNmYTAwZWJhIiwidCI6ImViMTRiMDQ2LTI0YzQtNDUxO"
-        "S04ZjI2LWI4OWMyMTU5ODI4YyJ9"
-    )
+    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiNDNjYTdhYmMtMzNlZi00MDM0LWI5NmEtODNkYWY0MmQzNmQyIiwidCI6ImViMTRiMDQ2LTI0YzQtNDUxOS04ZjI2LWI4OWMyMTU5ODI4YyJ9"
 
     def get_dashboard_iframe(self):
         fumn = {"src": self.powerbi_dashboard_link}

--- a/can_tools/scrapers/official/MO/mo_vaccine.py
+++ b/can_tools/scrapers/official/MO/mo_vaccine.py
@@ -18,16 +18,16 @@ class MissouriVaccineCounty(TableauDashboard):
     def normalize(self, data: pd.DataFrame) -> pd.DataFrame:
         _make_cmu = lambda c: CMU(category=c, measurement="cumulative", unit="people")
         cmus = {
-            "First COVID-19 Dose Administered": _make_cmu("total_vaccine_initiated"),
-            "Second COVID-19 Dose Administered": _make_cmu("total_vaccine_completed"),
+            "COVID-19 Vaccine Regimen Initiated": _make_cmu("total_vaccine_initiated"),
+            "COVID-19 Vaccine Regimen Completed": _make_cmu("total_vaccine_completed"),
         }
-        non_counties = ["St. Louis City"]  # noqa
+        non_counties = ["St. Louis City", "Kansas City", "Joplin"]  # noqa
         return (
             data.rename(
                 columns={
                     "Measure Values-alias": "value",
                     "Measure Names-alias": "variable",
-                    "County Name-value": "location_name",
+                    "Jurisdiction-value": "location_name",
                 }
             )
             .loc[:, ["value", "variable", "location_name"]]

--- a/can_tools/scrapers/official/NC/nc_vaccine.py
+++ b/can_tools/scrapers/official/NC/nc_vaccine.py
@@ -38,5 +38,6 @@ class NCVaccine(TableauDashboard):
 
     def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
         df = super().normalize(df)
+        df.location_name = df.location_name.str.strip() # Strip whitespace
         df.loc[df["location_name"] == "Mcdowell", "location_name"] = "McDowell"
         return df

--- a/can_tools/scrapers/official/NC/nc_vaccine.py
+++ b/can_tools/scrapers/official/NC/nc_vaccine.py
@@ -14,22 +14,20 @@ class NCVaccine(TableauDashboard):
     state_fips = int(us.states.lookup("North Carolina").fips)
     location_type = "county"
     baseurl = "https://public.tableau.com"
-    viewPath = (
-        "NCDHHS_COVID-19_Dashboard_Vaccinations/NCDHHS_DASHBOARD_PEOPLE_VACCINATIONS"
-    )
+    viewPath = "NCDHHS_COVID-19_Dashboard_Vaccinations/Summary"
 
-    data_tableau_table = "COUNTY MAP"
+    data_tableau_table = "County Map"
     location_name_col = "County -alias"
     timezone = "US/Eastern"
 
     # map wide form column names into CMUs
     cmus = {
-        "SUM(Dose 1 Administered)-alias": CMU(
+        "SUM(Partially Vaccinated)-alias": CMU(
             category="total_vaccine_initiated",
             measurement="cumulative",
             unit="people",
         ),
-        "SUM(Dose 2 Administered)-alias": CMU(
+        "SUM(Fully Vaccinated)-alias": CMU(
             category="total_vaccine_completed",
             measurement="cumulative",
             unit="people",
@@ -38,6 +36,8 @@ class NCVaccine(TableauDashboard):
 
     def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
         df = super().normalize(df)
-        df.location_name = df.location_name.str.strip()  # Strip whitespace
+        df.location_name = df.location_name.str.replace(
+            " County", ""
+        ).str.strip()  # Strip whitespace
         df.loc[df["location_name"] == "Mcdowell", "location_name"] = "McDowell"
         return df

--- a/can_tools/scrapers/official/NC/nc_vaccine.py
+++ b/can_tools/scrapers/official/NC/nc_vaccine.py
@@ -38,6 +38,6 @@ class NCVaccine(TableauDashboard):
 
     def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
         df = super().normalize(df)
-        df.location_name = df.location_name.str.strip() # Strip whitespace
+        df.location_name = df.location_name.str.strip()  # Strip whitespace
         df.loc[df["location_name"] == "Mcdowell", "location_name"] = "McDowell"
         return df

--- a/can_tools/scrapers/official/TX/texas_vaccine.py
+++ b/can_tools/scrapers/official/TX/texas_vaccine.py
@@ -68,9 +68,10 @@ class TexasCountyVaccine(TexasVaccineParent):
         # Read excel file and set date
         df = self.excel_to_dataframe(data, "By County")
         df = self._rename_and_reshape(df)
-
+        non_counties = ['Texas', 'Federal Pharmacy Retail Vaccination Program', 'Other']
         # Drop state data which we retrieve with another scraper
-        df = df.query("location_name != 'Texas'")
+        # Drop data where location_name is "Federal Pharmacy Retail Vaccination Program"
+        df = df.query("location_name not in @non_counties")
 
         cols_to_keep = [
             "vintage",

--- a/can_tools/scrapers/official/TX/texas_vaccine.py
+++ b/can_tools/scrapers/official/TX/texas_vaccine.py
@@ -17,7 +17,7 @@ from can_tools.scrapers.official.TX.tx_vaccine_crenames import (
 
 
 class TexasVaccineParent(StateDashboard, ABC):
-    state_fips = us.states.lookup("Texas").fips
+    state_fips = int(us.states.lookup("Texas").fips)
     source = "https://www.dshs.state.tx.us/coronavirus/immunize/vaccine.aspx"
     source_name = "Texas Department of State Health Services"
 
@@ -127,7 +127,7 @@ class TXVaccineCountyAge(TexasVaccineParent):
             measurement="cumulative",
             unit="doses",
         ),
-        "People Vaccinated with at least One Dose": CMU(
+        "People Vaccinated with at Least One Dose": CMU(
             category="total_vaccine_initiated",
             measurement="cumulative",
             unit="people",
@@ -187,7 +187,7 @@ class TXVaccineCountyAge(TexasVaccineParent):
                 columns={
                     "Age Group": "age",
                     "Race/Ethnicity": "race",
-                    "County Name": "location_name",
+                    "County": "location_name",
                 }
             )
             .melt(
@@ -198,6 +198,7 @@ class TXVaccineCountyAge(TexasVaccineParent):
             .pipe(self.extract_CMU, cmu=self.cmus, columns=self.cmu_columns)
             .pipe(lambda x: x.loc[~x["location_name"].isin(["*Other", "Total"]), :])
             .assign(vintage=self._retrieve_vintage())
+            .query("location_name != 'Other'")
         )
 
         return df

--- a/can_tools/scrapers/official/TX/texas_vaccine.py
+++ b/can_tools/scrapers/official/TX/texas_vaccine.py
@@ -68,7 +68,7 @@ class TexasCountyVaccine(TexasVaccineParent):
         # Read excel file and set date
         df = self.excel_to_dataframe(data, "By County")
         df = self._rename_and_reshape(df)
-        non_counties = ['Texas', 'Federal Pharmacy Retail Vaccination Program', 'Other']
+        non_counties = ["Texas", "Federal Pharmacy Retail Vaccination Program", "Other"]
         # Drop state data which we retrieve with another scraper
         # Drop data where location_name is "Federal Pharmacy Retail Vaccination Program"
         df = df.query("location_name not in @non_counties")

--- a/can_tools/scrapers/official/TX/texas_vaccine.py
+++ b/can_tools/scrapers/official/TX/texas_vaccine.py
@@ -127,7 +127,7 @@ class TXVaccineCountyAge(TexasVaccineParent):
             measurement="cumulative",
             unit="doses",
         ),
-        "People Vaccinated with at Least One Dose": CMU(
+        "People Vaccinated with at least One Dose": CMU(
             category="total_vaccine_initiated",
             measurement="cumulative",
             unit="people",

--- a/can_tools/scrapers/official/VA/va_vaccine.py
+++ b/can_tools/scrapers/official/VA/va_vaccine.py
@@ -26,9 +26,7 @@ class VirginiaVaccine(TableauDashboard):
         rows = [
             (
                 data["Vaccine One Dose"]["SUM(At Least One Dose)-alias"].iloc[0],
-                data["Vaccine Fully Vacinated"][
-                    "SUM(Fully Vaccinated)-alias"
-                ].iloc[0],
+                data["Vaccine Fully Vacinated"]["SUM(Fully Vaccinated)-alias"].iloc[0],
                 data["Vaccine Total Doses"]["SUM(Vaccine Count)-alias"].iloc[0],
                 self.state_fips,
                 "Virginia",

--- a/can_tools/scrapers/official/VA/va_vaccine.py
+++ b/can_tools/scrapers/official/VA/va_vaccine.py
@@ -25,9 +25,9 @@ class VirginiaVaccine(TableauDashboard):
     def normalize(self, data) -> pd.DataFrame:
         rows = [
             (
-                data["Vaccine One Dose (3)"]["SUM(Vaccine Count)-alias"].iloc[0],
-                data["Vaccine Fully Vacinated (2)"][
-                    "SUM(Fully Vaccinated (1))-alias"
+                data["Vaccine One Dose"]["SUM(At Least One Dose)-alias"].iloc[0],
+                data["Vaccine Fully Vacinated"][
+                    "SUM(Fully Vaccinated)-alias"
                 ].iloc[0],
                 data["Vaccine Total Doses"]["SUM(Vaccine Count)-alias"].iloc[0],
                 self.state_fips,
@@ -47,7 +47,7 @@ class VirginiaVaccine(TableauDashboard):
 
         county_df = data["Doses Administered by Administration FIPS"].rename(
             columns={
-                "SUM(Fully Vaccinated (1))-alias": "totalHadSecondDose",
+                "SUM(Fully Vaccinated)-alias": "totalHadSecondDose",
                 "SUM(Vaccine Count)-alias": "totalDoses",
                 "Recipient FIPS-alias": "location",
                 "ATTR(CityCounty)-alias": "location_name",

--- a/can_tools/scrapers/official/base.py
+++ b/can_tools/scrapers/official/base.py
@@ -834,10 +834,6 @@ class TableauMapClick(StateDashboard, ABC):
 class MicrosoftBIDashboard(StateDashboard, ABC):
     powerbi_url: str
 
-    def __init__(self, *a, **kw):
-        super(MicrosoftBIDashboard, self).__init__(*a, **kw)
-        self._sess = None
-
     @property
     def sess(self):
         if self._sess is not None:

--- a/can_tools/scrapers/official/base.py
+++ b/can_tools/scrapers/official/base.py
@@ -548,12 +548,14 @@ class TableauDashboard(StateDashboard, ABC):
             .drop(["variable"], axis=1)
         )
 
-    def get_tableau_view(self):
+    def get_tableau_view(self, url=None):
         def onAlias(it, value, cstring):
             return value[it] if (it >= 0) else cstring["dataValues"][abs(it) - 1]
 
         req = requests_retry_session()
         fullURL = self.baseurl + "/views/" + self.viewPath
+        if url is not None:
+            fullURL = url
         if self.filterFunctionName is not None:
             params = ":language=en&:display_count=y&:origin=viz_share_link&:embed=y&:showVizHome=n&:jsdebug=y&"
             params += self.filterFunctionName + "=" + self.filterFunctionValue

--- a/can_tools/scrapers/official/federal/HHS/facility.py
+++ b/can_tools/scrapers/official/federal/HHS/facility.py
@@ -66,6 +66,11 @@ class HHSReportedPatientImpactHospitalCapacityFacility(HHSDataset):
                     # ended up in after the split...
                     # https://en.wikipedia.org/wiki/Cordova,_Alaska
                     2080: 2261,
+                    # Source of change: https://www.cdc.gov/nchs/nvss/bridged_race/county_geography-_changes2015.pdf
+                    # page 6
+                    # Virginia, 2013: Bedford (independent) city (FIPS 51515) was changed to
+                    # town status and added to Bedford County (FIPS 51019) effective July 1st, 2013
+                    51515: 51019
                 }
             )
         )

--- a/can_tools/scrapers/official/federal/HHS/facility.py
+++ b/can_tools/scrapers/official/federal/HHS/facility.py
@@ -70,7 +70,7 @@ class HHSReportedPatientImpactHospitalCapacityFacility(HHSDataset):
                     # page 6
                     # Virginia, 2013: Bedford (independent) city (FIPS 51515) was changed to
                     # town status and added to Bedford County (FIPS 51019) effective July 1st, 2013
-                    51515: 51019
+                    51515: 51019,
                 }
             )
         )


### PR DESCRIPTION
Fixes the following scrapers that broke:

- [x] TXVaccineCountyRace
   - Couple problems. `state_fips` was returning a string. `County Name` is now just `County`. And there are some rows with "Other" as the county name
- [x] TXVaccineCountyAge
    - Same as `TXVaccineCountyRace`
- [x] NCCountyVaccine
    - This scraper doesn't exist. It's under `NCVaccine`. Removed the DAG
- [x] NCVaccine
   - Only problem was trailing whitespace at the end of the county names. Trimmed off whitespace and works
- [x] PennsylvaniaVaccineDemographics
     - This class isn't exported by `scrapers/official/__init__.py`. All the other demographic specific scrapers are running fine. Should this DAG be deleted?
     - Deleted the DAG
- [x] MinnesotaCountyVaccines
   - PowerBi dashboard. @cc7768 should be solving a problem related to PowerBi dashboards
   - Fixed by updating the dashboard url
   - The site has a captcha and prevents the automatic retrieval of the current key. Need to update the url everytime the key changes (about once a week)
- [x] TexasCountyVaccine
    - Some rows had non-country `location_name`'s. Fixed by removing rows that were not a valid county
- [x] CaliforniaVaccineCounty
    - looks like the URL used doesn't point exactly to the dashboard
    - fixed by editing TableuBase class and allowing a URL override
- [ ] WYCountyVaccinations [disabled on frontend]
    - The initial request for the data is returning an error. The error's `reasonStr` is `PREFETCH_VALIDATION`
- [ ] WYStateVaccinations
    - Same as `WYCountyVaccinations`
- [x] GeorgiaCountyVaccine
    - The correct resource on the ArcGIS server seems to have moved. I found the [matching one](https://services6.arcgis.com/t7DA9BjRElflTVpw/ArcGIS/rest/services/Georgia_DPH_COVID19_Vaccination_public_v2_VIEW/FeatureServer/7). There are two different datasets, one with an `ADM` name and another with `RES`. `ADM` isn't returning data, but `RES` is. I'm not sure what the original one was. Maybe @cc7768 can clarify
- [x] VirginiaVaccine (https://trello.com/c/QqObNrn8/1054-vaccine-data-dropped-in-va-because-data-stale)
    - Remote column names changed. Updated code to use new column names
- [x] ArizonaVaccineCounty
  - County columns had `Tribes` as one of the counties. Fixed by removing all rows with `location_name == 'Tribes`
- [x] CovidTrackingProjectDemographics
    - Some of the entries in the `Cases_Black` column were `#REF!`. `normalize` couldn't parse these. Fixed by coercing `to_numeric` on that column. `#REF!` entries are now `NaN`
- [x] MissouriVaccineCounty
   - Column names had changed. Updated column names to match remote data
- [x] HHSReportedPatientImpactHospitalCapacityFacility
    - Bedford City, VA was changed to a town and included in the county fips in 2013. For some reason reports still have the old City FIPS. Fixed by replacing the old City FIPS with the corresponding county FIPS it belongs to (edited) 

