### PR TITLE
change GA county arcgis resource

### DIFF
--- a/can_tools/scrapers/official/GA/ga_vaccines.py
+++ b/can_tools/scrapers/official/GA/ga_vaccines.py
@@ -25,7 +25,7 @@ class GeorgiaCountyVaccine(ArcGIS):
 
     def fetch(self):
         return self.get_all_jsons(
-            "Georgia_DPH_COVID19_Vaccination_public_v2_VIEW", 7, 6
+            "Georgia_DPH_COVID19_Vaccination_public_v2_VIEW", 6, 6
         )
 
     def normalize(self, data):


### PR DESCRIPTION
Original fix in PR #151 changed the ArcGIS resource for Georgia county. The ArcGIS server had updated the names and locations of the specific features, and the one that was originally used wasn't returning any data. 

This PR now changes back to the original resource as it is now returning data.

