### PR TITLE
Switch to Stable Endpoint

### DIFF
--- a/can_tools/scrapers/official/federal/HHS/common.py
+++ b/can_tools/scrapers/official/federal/HHS/common.py
@@ -17,7 +17,7 @@ class HHSDataset(FederalDashboard, ABC):
     def dataset_details(self, decoder="utf-8-sig"):
         # Download page html and turn into soup
         dsid = self.dsid
-        url = f"https://healthdata.gov/api/3/action/package_show?id={dsid}"
+        url = f"https://legacy.healthdata.gov/api/3/action/package_show?id={dsid}"
         res = requests.get(url)
 
         # Get the data link

--- a/can_tools/scrapers/official/federal/HHS/facility.py
+++ b/can_tools/scrapers/official/federal/HHS/facility.py
@@ -13,7 +13,7 @@ class HHSReportedPatientImpactHospitalCapacityFacility(HHSDataset):
     has_location = True
     location_type = "multiple"
     source = (
-        "https://healthdata.gov/dataset/"
+        "https://legacy.healthdata.gov/dataset/"
         "covid-19-reported-patient-impact-and-hospital-capacity-facility"
     )
     dsid = "d475cc4e-83cd-4c16-be57-9105f300e0bc"

--- a/can_tools/scrapers/official/federal/HHS/hhs_state.py
+++ b/can_tools/scrapers/official/federal/HHS/hhs_state.py
@@ -11,7 +11,7 @@ class HHSReportedPatientImpactHospitalCapacityState(HHSDataset):
     has_location = True
     location_type = "state"
     source = (
-        "https://healthdata.gov/dataset/"
+        "https://legacy.healthdata.gov/dataset/"
         "covid-19-reported-patient-impact-and-hospital-capacity-state-timeseries/"
     )
     dsid = "83b4a668-9321-4d8c-bc4f-2bef66c49050"


### PR DESCRIPTION
Step 1 is to switch to the stable, but soon to be deprecated endpoint. https://trello.com/c/yL8laHTs/1014-transition-hhs-data-to-new-socrata-links