### PR TITLE
FIX: TXVaccineCountyAge, TXVaccineCountyRace, CASanDiegoVaccine

### DIFF
--- a/can_tools/scrapers/official/CA/counties/sandiego_vaccine.py
+++ b/can_tools/scrapers/official/CA/counties/sandiego_vaccine.py
@@ -139,6 +139,9 @@ class CASanDiegoVaccine(ArcGIS):
             "AdministeredDoses",
         ]
         total_temp = df.query("(Category in @total_cols) & (variable == 'Count_')")
+        total_temp["Join_Name"] = total_temp.Join_Name.replace(
+            {"Doses administered": "AdministeredDoses"}
+        )
         total_df = self.extract_CMU(
             total_temp, total_crename, var_name="Join_Name"
         ).drop(["Category", "Join_Name", "variable"], axis="columns")

--- a/can_tools/scrapers/official/TX/texas_vaccine.py
+++ b/can_tools/scrapers/official/TX/texas_vaccine.py
@@ -68,7 +68,7 @@ class TexasCountyVaccine(TexasVaccineParent):
         # Read excel file and set date
         df = self.excel_to_dataframe(data, "By County")
         df = self._rename_and_reshape(df)
-        non_counties = ["Texas", "Federal Pharmacy Retail Vaccination Program", "Other"]
+        non_counties = ["Texas", "Federal Pharmacy Retail Vaccination Program", "Other", "Grand Total"]
         # Drop state data which we retrieve with another scraper
         # Drop data where location_name is "Federal Pharmacy Retail Vaccination Program"
         df = df.query("location_name not in @non_counties")
@@ -181,13 +181,14 @@ class TXVaccineCountyAge(TexasVaccineParent):
 
     def normalize(self, data) -> pd.DataFrame:
         # Read in data, set location, and drop totals
+        non_counties = ['Other', 'Grand Total']
         df = (
             self.excel_to_dataframe(data, self.sheet_name)
             .rename(
                 columns={
                     "Age Group": "age",
                     "Race/Ethnicity": "race",
-                    "County": "location_name",
+                    "County Name": "location_name",
                 }
             )
             .melt(
@@ -198,7 +199,7 @@ class TXVaccineCountyAge(TexasVaccineParent):
             .pipe(self.extract_CMU, cmu=self.cmus, columns=self.cmu_columns)
             .pipe(lambda x: x.loc[~x["location_name"].isin(["*Other", "Total"]), :])
             .assign(vintage=self._retrieve_vintage())
-            .query("location_name != 'Other'")
+            .query("location_name not in @non_counties")
             .dropna(subset=["value"])
         )
 

--- a/can_tools/scrapers/official/TX/texas_vaccine.py
+++ b/can_tools/scrapers/official/TX/texas_vaccine.py
@@ -68,7 +68,12 @@ class TexasCountyVaccine(TexasVaccineParent):
         # Read excel file and set date
         df = self.excel_to_dataframe(data, "By County")
         df = self._rename_and_reshape(df)
-        non_counties = ["Texas", "Federal Pharmacy Retail Vaccination Program", "Other", "Grand Total"]
+        non_counties = [
+            "Texas",
+            "Federal Pharmacy Retail Vaccination Program",
+            "Other",
+            "Grand Total",
+        ]
         # Drop state data which we retrieve with another scraper
         # Drop data where location_name is "Federal Pharmacy Retail Vaccination Program"
         df = df.query("location_name not in @non_counties")
@@ -181,7 +186,7 @@ class TXVaccineCountyAge(TexasVaccineParent):
 
     def normalize(self, data) -> pd.DataFrame:
         # Read in data, set location, and drop totals
-        non_counties = ['Other', 'Grand Total']
+        non_counties = ["Other", "Grand Total"]
         df = (
             self.excel_to_dataframe(data, self.sheet_name)
             .rename(

--- a/can_tools/scrapers/official/TX/texas_vaccine.py
+++ b/can_tools/scrapers/official/TX/texas_vaccine.py
@@ -30,13 +30,9 @@ class TexasVaccineParent(StateDashboard, ABC):
 
     def excel_to_dataframe(self, data, sheet) -> pd.DataFrame:
         # Read data from excel file and parse specified sheet
-        data = pd.ExcelFile(io.BytesIO(data.content))
-        df = data.parse(sheet, na_values="--")
-
-        # Set date to yesterday
-        df["dt"] = self._retrieve_dtm1d("US/Eastern")
-
-        return df
+        return pd.read_excel(
+            data.content, sheet_name=sheet, engine="openpyxl", na_values="--"
+        ).assign(dt=self._retrieve_dtm1d("US/Eastern"))
 
 
 class TexasCountyVaccine(TexasVaccineParent):
@@ -66,7 +62,7 @@ class TexasCountyVaccine(TexasVaccineParent):
 
     def normalize(self, data) -> pd.DataFrame:
         # Read excel file and set date
-        df = self.excel_to_dataframe(data, "By County")
+        df = self.excel_to_dataframe(data, "By County", engine="")
         df = self._rename_and_reshape(df)
         non_counties = [
             "Texas",


### PR DESCRIPTION
*TXVaccineCountyAge/Race*
Column `County` in excel data returned by server changed to `County Name`.

`Grand Total` was a `County Name` and caused problems with `d.put`. Fixed by filtering out rows with `County Name == 'Grand Total'`


*CASanDiegoVaccine*
2021-03-11 and 2021-03-12 had incorrect names for total number of doses administered. Fixed by renaming these entries to the correct name.
