### PR TITLE
FIX: CaliforniaHospitals. change record id

### DIFF
--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -4,7 +4,6 @@ from can_tools.scrapers.official import (  # IllinoisDemographics,; IllinoisHist
     ArizonaMaricopaVaccine,
     ArizonaVaccineCounty,
     CASanDiegoVaccine,
-    CaliforniaCasesDeaths,
     CaliforniaHospitals,
     CaliforniaTesting,
     CaliforniaVaccineCounty,

--- a/can_tools/scrapers/official/CA/__init__.py
+++ b/can_tools/scrapers/official/CA/__init__.py
@@ -1,5 +1,4 @@
 from can_tools.scrapers.official.CA.ca_state import (
-    CaliforniaCasesDeaths,
     CaliforniaHospitals,
 )
 

--- a/can_tools/scrapers/official/CA/ca_state.py
+++ b/can_tools/scrapers/official/CA/ca_state.py
@@ -6,19 +6,23 @@ import us
 from can_tools.scrapers.base import CMU
 from can_tools.scrapers.official.base import StateQueryAPI
 
+# https://data.chhs.ca.gov/api/3/action/datastore_search?resource_id=046cdd2b-31e5-4d34-9ed3-b48cdbc4be7a&limit=5
+# https://data.ca.gov/api/3/action/datastore_search?resource_id=0545b878-90a8-4b26-a16a-84978354f1a3&limit=5
 
+# https://data.chhs.ca.gov/api/3/action/datastore_search?resource_id=046cdd2b-31e5-4d34-9ed3-b48cdbc4be7a&limit=5
 class CaliforniaCasesDeaths(StateQueryAPI):
     """
     Fetch county level covid data from California state dashbaord
     """
 
-    apiurl = "https://data.ca.gov/api/3/action/datastore_search"
+    apiurl = "https://data.chhs.ca.gov/api/3/action/datastore_search"
+    # apiurl = "https://data.ca.gov/api/3/action/datastore_search"
     source = "https://covid19.ca.gov/state-dashboard"
     source_name = "Official California State Government Website"
     state_fips = int(us.states.lookup("California").fips)
     has_location = False
     location_type = "county"
-    resource_id = "926fd08f-cc91-4828-af38-bd45de97f8c3"
+    resource_id = "046cdd2b-31e5-4d34-9ed3-b48cdbc4be7a"
 
     def fetch(self) -> Any:
         return self.raw_from_api(self.resource_id, limit=1000)
@@ -84,14 +88,15 @@ class CaliforniaCasesDeaths(StateQueryAPI):
         out["vintage"] = self._retrieve_vintage()
 
         # Drop the information that we won't be keeping track of
-        loc_not_keep = ["Out Of Country", "Unassigned"]
+        loc_not_keep = ["Out Of Country", "Unassigned", "Unknown"]
         out = out.loc[~out["location_name"].isin(loc_not_keep), :]
 
         return out
 
 
 class CaliforniaHospitals(CaliforniaCasesDeaths):
-    resource_id = "42d33765-20fd-44b8-a978-b083b7542225"
+    resource_id = "0d9be83b-5027-41ff-97b2-6ca70238d778"
+    apiurl = "https://data.ca.gov/api/3/action/datastore_search"
 
     def pre_normalize(self, data) -> pd.DataFrame:
         """

--- a/can_tools/scrapers/official/CA/ca_state.py
+++ b/can_tools/scrapers/official/CA/ca_state.py
@@ -5,98 +5,17 @@ import us
 
 from can_tools.scrapers.base import CMU
 from can_tools.scrapers.official.base import StateQueryAPI
-
-# https://data.chhs.ca.gov/api/3/action/datastore_search?resource_id=046cdd2b-31e5-4d34-9ed3-b48cdbc4be7a&limit=5
-# https://data.ca.gov/api/3/action/datastore_search?resource_id=0545b878-90a8-4b26-a16a-84978354f1a3&limit=5
-
-# https://data.chhs.ca.gov/api/3/action/datastore_search?resource_id=046cdd2b-31e5-4d34-9ed3-b48cdbc4be7a&limit=5
-class CaliforniaCasesDeaths(StateQueryAPI):
-    """
-    Fetch county level covid data from California state dashbaord
-    """
-
-    apiurl = "https://data.chhs.ca.gov/api/3/action/datastore_search"
-    # apiurl = "https://data.ca.gov/api/3/action/datastore_search"
-    source = "https://covid19.ca.gov/state-dashboard"
-    source_name = "Official California State Government Website"
+class CaliforniaHospitals(StateQueryAPI):
+    resource_id = "0d9be83b-5027-41ff-97b2-6ca70238d778"
+    apiurl = "https://data.ca.gov/api/3/action/datastore_search"
     state_fips = int(us.states.lookup("California").fips)
-    has_location = False
+    source_name = "Official California State Government Website"
+    source = "https://covid19.ca.gov/state-dashboard"
     location_type = "county"
-    resource_id = "046cdd2b-31e5-4d34-9ed3-b48cdbc4be7a"
+    has_location = False
 
     def fetch(self) -> Any:
         return self.raw_from_api(self.resource_id, limit=1000)
-
-    def pre_normalize(self, data) -> pd.DataFrame:
-        """
-        Normalizes the list of json objects that corresponds with case
-        and death data
-
-        Parameters
-        ----------
-        data : List
-            A list of json elements
-
-        Returns
-        -------
-        df : pd.DataFrame
-            A DataFrame with the normalized data
-        """
-        # Map current column names to CMU elements
-        crename = {
-            "newcountconfirmed": CMU(
-                category="cases", measurement="new", unit="people"
-            ),
-            "totalcountconfirmed": CMU(
-                category="cases", measurement="cumulative", unit="people"
-            ),
-            "newcountdeaths": CMU(category="deaths", measurement="new", unit="people"),
-            "totalcountdeaths": CMU(
-                category="deaths", measurement="cumulative", unit="people"
-            ),
-        }
-
-        # Read in data and convert to long format
-        df = self.data_from_raw(data).rename(columns={"county": "location_name"})
-        df["dt"] = pd.to_datetime(df["date"])
-
-        # Move things into long format
-        df = df.melt(
-            id_vars=["location_name", "dt"], value_vars=crename.keys()
-        ).dropna()
-
-        # Determine the category of each observation
-        df = self.extract_CMU(df, crename)
-
-        cols_to_keep = [
-            "dt",
-            "location_name",
-            "category",
-            "measurement",
-            "unit",
-            "age",
-            "race",
-            "ethnicity",
-            "sex",
-            "value",
-        ]
-        return df.loc[:, cols_to_keep]
-
-    def normalize(self, data) -> pd.DataFrame:
-        # Normalize case/death and hospital data
-        out = self.pre_normalize(data)
-        out["vintage"] = self._retrieve_vintage()
-
-        # Drop the information that we won't be keeping track of
-        loc_not_keep = ["Out Of Country", "Unassigned", "Unknown"]
-        out = out.loc[~out["location_name"].isin(loc_not_keep), :]
-
-        return out
-
-
-class CaliforniaHospitals(CaliforniaCasesDeaths):
-    resource_id = "0d9be83b-5027-41ff-97b2-6ca70238d778"
-    apiurl = "https://data.ca.gov/api/3/action/datastore_search"
 
     def pre_normalize(self, data) -> pd.DataFrame:
         """
@@ -163,3 +82,14 @@ class CaliforniaHospitals(CaliforniaCasesDeaths):
         ]
 
         return out.loc[:, cols_to_keep]
+
+    def normalize(self, data) -> pd.DataFrame:
+        # Normalize case/death and hospital data
+        out = self.pre_normalize(data)
+        out["vintage"] = self._retrieve_vintage()
+
+        # Drop the information that we won't be keeping track of
+        loc_not_keep = ["Out Of Country", "Unassigned", "Unknown"]
+        out = out.loc[~out["location_name"].isin(loc_not_keep), :]
+
+        return out

--- a/can_tools/scrapers/official/CA/ca_state.py
+++ b/can_tools/scrapers/official/CA/ca_state.py
@@ -5,6 +5,8 @@ import us
 
 from can_tools.scrapers.base import CMU
 from can_tools.scrapers.official.base import StateQueryAPI
+
+
 class CaliforniaHospitals(StateQueryAPI):
     resource_id = "0d9be83b-5027-41ff-97b2-6ca70238d778"
     apiurl = "https://data.ca.gov/api/3/action/datastore_search"

--- a/can_tools/scrapers/official/__init__.py
+++ b/can_tools/scrapers/official/__init__.py
@@ -5,7 +5,6 @@ from can_tools.scrapers.official.AZ import (
 )
 
 from can_tools.scrapers.official.CA import (
-    CaliforniaCasesDeaths,
     CaliforniaHospitals,
     CASanDiegoVaccine,
     CaliforniaTesting,


### PR DESCRIPTION
The `CaliforniaHospitals` scraper was using an old resource id to request the data from the California open data API. Updated the resourced id to fix