### PR TITLE
CA Vaccine Scraper updated tableau - fix scraper

### DIFF
--- a/can_tools/scrapers/official/CA/ca_vaccine.py
+++ b/can_tools/scrapers/official/CA/ca_vaccine.py
@@ -1,6 +1,3 @@
-src = "https://public.tableau.com/views/COVID-19VaccineDashboardPublic/Vaccine?:embed=y&:showVizHome=no&:host_url=https://public.tableau.com/&:embed_code_version=3&:tabs=no&:toolbar=yes&:animate_transition=yes&:display_static_image=no&:display_spinner=no&:display_overlay=yes&:display_count=yes&:language=en&publish=yes&:loadOrderID=0"
-
-
 import pandas as pd
 import us
 
@@ -14,15 +11,17 @@ class CaliforniaVaccineCounty(TableauDashboard):
     source_name = "Official California State Government Website"
     state_fips = int(us.states.lookup("California").fips)
     location_type = "county"
+
     source_url = (
-        "https://public.tableau.com/interactive/views/"
-        "COVID-19VaccineDashboardPublic/Vaccine"
-        "?:embed=y&:showVizHome=no&:display_count=y&:display_static_image=y"
-        "&:bootstrapWhenNotified=true&:language=en&:embed=y&:showVizHome=n&:apiID=host0"
+        "https://public.tableau.com/views/COVID-19VaccineDashboardPublicv2/Vaccine?"
+        ":embed=y&:showVizHome=no&:host_url=https://public.tableau.com/&:embed_code_version=3"
+        "&:tabs=no&:toolbar=yes&:animate_transition=yes&:display_static_image=no"
+        "&:display_spinner=no&:display_overlay=yes&:display_count=yes"
+        "&:language=en&publish=yes&:loadOrderID=0"
     )
     baseurl = "https://public.tableau.com"
 
-    viewPath = "COVID-19VaccineDashboardPublic/Vaccine"
+    viewPath = "COVID-19VaccineDashboardPublicv2/Vaccine"
 
     cmus = {
         "SUM(Dose Administered)-alias": CMU(
@@ -32,10 +31,10 @@ class CaliforniaVaccineCounty(TableauDashboard):
         ),
     }
 
-    county_column = "County-value"
+    county_column = "County-alias"
 
     def fetch(self) -> pd.DataFrame:
-        return self.get_tableau_view(self.source_url)["County Map"]
+        return self.get_tableau_view(self.source_url)["County Admin Map"]
 
     def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
         # county names (converted to title case)


### PR DESCRIPTION
Looks like CA updated their county vaccine scraper (no new variables yet) but the new path has updated data