### PR TITLE
Cdc scraper single state

### DIFF
--- a/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
@@ -35,7 +35,6 @@ class CDCCovidDataTracker(FederalDashboard):
     }
 
     def __init__(self, *args, state=None, **kwargs):
-        state = "DC"
         self.state = us.states.lookup(state) if state else None
         super().__init__(*args, **kwargs)
 

--- a/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
@@ -1,5 +1,6 @@
-import random
+import pathlib
 import requests
+import us
 
 import pandas as pd
 
@@ -14,7 +15,40 @@ class CDCCovidDataTracker(FederalDashboard):
     source_name = "Centers for Disease Control and Prevention"
     provider = "cdc"
 
-    def fetch(self, test=False):
+    variables = {
+        "new_cases_7_day_rolling_average": CMU(
+            category="cases", measurement="rolling_average_7_day", unit="people"
+        ),
+        "new_deaths_7_day_rolling_average": CMU(
+            category="deaths", measurement="rolling_average_7_day", unit="people"
+        ),
+        "percent_new_test_results_reported_positive_7_day_rolling_average": CMU(
+            category="pcr_tests_positive",
+            measurement="rolling_average_7_day",
+            unit="percentage",
+        ),
+        "new_test_results_reported_7_day_rolling_average": CMU(
+            category="pcr_tests_total",
+            measurement="rolling_average_7_day",
+            unit="specimens",  # TODO: Need to ensure this is actually specimens!
+        ),
+    }
+
+    def __init__(self, *args, state=None, **kwargs):
+        state = "DC"
+        self.state = us.states.lookup(state) if state else None
+        super().__init__(*args, **kwargs)
+
+    def _filepath(self, raw: bool) -> pathlib.Path:
+        # Overriding _filepath to support saving individual files for each state
+        path = super()._filepath(raw)
+        if not self.state:
+            return path
+
+        root = path.parent / f"{self.state.abbr}.{path.name}"
+        return root
+
+    def fetch(self):
         # reset exceptions
         self.exceptions = []
         fetcher_url = (
@@ -22,16 +56,15 @@ class CDCCovidDataTracker(FederalDashboard):
             "getAjaxData?id=integrated_county_timeseries_state_{}_external"
         )
 
-        # Iterate through the states collecting the time-series data
-        if test:
-            # When testing, choos random 3 states
-            urls = map(
-                lambda x: fetcher_url.format(x.abbr.lower()),
-                random.sample(ALL_STATES_PLUS_DC, 3),
-            )
+        if self.state:
+            states = [self.state]
         else:
-            urls = map(lambda x: fetcher_url.format(x.abbr.lower()), ALL_STATES_PLUS_DC)
-        responses = list(map(requests.get, urls))
+            states = ALL_STATES_PLUS_DC
+
+        urls = [fetcher_url.format(state.abbr.lower()) for state in states]
+
+        responses = [requests.get(url) for url in urls]
+
         bad_idx = [i for (i, r) in enumerate(responses) if not r.ok]
         if len(bad_idx):
             bad_urls = "\n".join([urls[i] for i in bad_idx])
@@ -46,48 +79,11 @@ class CDCCovidDataTracker(FederalDashboard):
             [pd.DataFrame.from_records(x[data_key]) for x in data],
             axis=0,
             ignore_index=True,
-        ).rename(columns={"fips_code": "location"})
+        )
 
-        # Set datetime to the end of report window -- We'll be reporting
-        # backwards looking windows. "date" and "report_date_window" are
-        # the same value as of 2020-11-21
-        df["dt"] = pd.to_datetime(df["date"])
+        df = self._rename_or_add_date_and_location(
+            df, location_column="fips_code", date_column="date"
+        )
 
-        crename = {
-            "new_cases_7_day_rolling_average": CMU(
-                category="cases", measurement="rolling_average_7_day", unit="people"
-            ),
-            "new_deaths_7_day_rolling_average": CMU(
-                category="deaths", measurement="rolling_average_7_day", unit="people"
-            ),
-            "percent_new_test_results_reported_positive_7_day_rolling_average": CMU(
-                category="pcr_tests_positive",
-                measurement="rolling_average_7_day",
-                unit="percentage",
-            ),
-            "new_test_results_reported_7_day_rolling_average": CMU(
-                category="pcr_tests_total",
-                measurement="rolling_average_7_day",
-                unit="specimens",  # TODO: Need to ensure this is actually specimens!
-            ),
-        }
-
-        # Reshape and add variable information
-        out = df.melt(id_vars=["dt", "location"], value_vars=crename.keys()).dropna()
-        out = self.extract_CMU(out, crename)
-        out["vintage"] = self._retrieve_vintage()
-
-        cols_2_keep = [
-            "vintage",
-            "dt",
-            "location",
-            "category",
-            "measurement",
-            "unit",
-            "age",
-            "race",
-            "ethnicity",
-            "sex",
-            "value",
-        ]
-        return out.loc[:, cols_2_keep]
+        df = self._reshape_variables(df, self.variables)
+        return df

--- a/services/prefect/flows/generated_flows.py
+++ b/services/prefect/flows/generated_flows.py
@@ -5,19 +5,21 @@ import pandas as pd
 import sqlalchemy as sa
 from can_tools import ALL_SCRAPERS
 from can_tools.scrapers.base import DatasetBase
-
+from can_tools.scrapers.base import ALL_STATES_PLUS_DC
+from can_tools.scrapers import CDCCovidDataTracker
 import prefect
 from prefect import Flow, task
 from prefect.schedules import CronSchedule
 from prefect.tasks.secrets import EnvVarSecret
+from prefect.tasks.prefect.flow_run import StartFlowRun
 
 
 @task
-def create_scraper(cls: Type[DatasetBase]) -> DatasetBase:
+def create_scraper(cls: Type[DatasetBase], **kwargs) -> DatasetBase:
     logger = prefect.context.get("logger")
     dt = prefect.context.get("scheduled_start_time")
     logger.info("Creating class {} with dt = {}".format(cls, dt))
-    return cls(execution_dt=dt)
+    return cls(execution_dt=dt, **kwargs)
 
 
 @task(max_retries=3, retry_delay=timedelta(minutes=1))
@@ -93,8 +95,58 @@ def create_flow_for_scraper(ix: int, d: Type[DatasetBase]):
     return flow
 
 
-for ix, cls in enumerate(ALL_SCRAPERS):
-    if not cls.autodag:
-        continue
-    flow = create_flow_for_scraper(ix, cls)
+def create_cdc_single_state_flow():
+    with Flow(CDCCovidDataTracker.__name__) as flow:
+        state = prefect.Parameter("state")
+        connstr = EnvVarSecret("COVID_DB_CONN_URI")
+        sentry_dsn = EnvVarSecret("SENTRY_DSN")
+        sentry_sdk_task = initialize_sentry(sentry_dsn)
+
+        d = create_scraper(CDCCovidDataTracker, state=state)
+        fetched = fetch(d)
+        normalized = normalize(d)
+        validated = validate(d)
+        done = put(d, connstr)
+
+        d.set_upstream(sentry_sdk_task)
+        normalized.set_upstream(fetched)
+        validated.set_upstream(normalized)
+        done.set_upstream(validated)
+
+    return flow
+
+
+def create_cdc_all_states_flow():
+    """Creates a flow that runs the CDC data update on all states."""
+    sched = CronSchedule("17 */4 * * *")
+
+    flow = Flow("CDCAllStatesDataUpdate", sched)
+    for state in ALL_STATES_PLUS_DC:
+        task = StartFlowRun(
+            flow_name=CDCCovidDataTracker.__name__,
+            project_name="can-scrape",
+            wait=True,
+            parameters={"state": state.abbr},
+        )
+        flow.add_task(task)
+
+    return flow
+
+
+def init_flows():
+    for ix, cls in enumerate(ALL_SCRAPERS):
+        if not cls.autodag:
+            continue
+        if cls == CDCCovidDataTracker:
+            flow = create_cdc_single_state_flow()
+        else:
+            flow = create_flow_for_scraper(ix, cls)
+        flow.register(project_name="can-scrape")
+
+    # Create additional flow that runs the CDC Data updater
+    flow = create_cdc_all_states_flow()
     flow.register(project_name="can-scrape")
+
+
+if __name__ == "__main__":
+    init_flows()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -55,16 +55,13 @@ def test_datasets(cls):
     execution_date = (pd.Timestamp.today() - pd.Timedelta("1 days")).strftime(
         "%Y-%m-%d"
     )
-    d = cls(execution_date)
-
-    slow_scrapers = [CDCCovidDataTracker]
-    if cls in slow_scrapers:
-        # Certain scrapers take too long so we added a "test" argument
-        # that allows `fetch` to only return a subset of data to speed
-        # up the fetch process
-        raw = d.fetch(test=True)
+    if cls == CDCCovidDataTracker:
+        d = cls(execution_date, state="CA")
     else:
-        raw = d.fetch()
+        d = cls(execution_date)
+
+    raw = d.fetch()
+
     assert raw is not None
     clean = d.normalize(raw)
     assert isinstance(clean, pd.DataFrame)


### PR DESCRIPTION
Modifies the CDC scraper to be able to run for a single state rather than having to run on all of them.

This creates a new prefect flow which kicks off a bunch of single state CDC scraper runs. Hopefully it makes our database a bit happier