### PR TITLE
fixes for Texas vaccine demographic scrapers

### DIFF
--- a/can_tools/scrapers/official/TX/texas_vaccine.py
+++ b/can_tools/scrapers/official/TX/texas_vaccine.py
@@ -129,7 +129,7 @@ class TXVaccineCountyAge(TexasVaccineParent):
             measurement="cumulative",
             unit="doses",
         ),
-        "People Vaccinated with at least One Dose": CMU(
+        "People Vaccinated  ": CMU(
             category="total_vaccine_initiated",
             measurement="cumulative",
             unit="people",
@@ -190,7 +190,7 @@ class TXVaccineCountyAge(TexasVaccineParent):
                 columns={
                     "Age Group": "age",
                     "Race/Ethnicity": "race",
-                    "County Name": "location_name",
+                    "County": "location_name",
                 }
             )
             .melt(


### PR DESCRIPTION
Small changes to column/key names.

`People Vaccinated  ` appears to be people vaccinated with at least one shot, but I could not find a proper/formal definition. 