### PR TITLE
FIX: Data doesn't represent J&J vaccine accurately

### DIFF
--- a/can_tools/scrapers/official/FL/fl_vaccine.py
+++ b/can_tools/scrapers/official/FL/fl_vaccine.py
@@ -24,7 +24,6 @@ class FloridaCountyVaccine(StateDashboard):
         for el in data:
             dfs.append(self._truncate_data(el.df))
         df = pd.concat(dfs)
-
         # # Ignore data from unknown region (no fips code) and fix naming convention for problem counties, and total state vals
         df = df.query(
             "location_name != 'Unknown' &"
@@ -46,11 +45,12 @@ class FloridaCountyVaccine(StateDashboard):
         )
 
         crename = {
-            "first_dose_new": CMU(
-                category="total_vaccine_initiated",
-                measurement="new",
-                unit="people",
-            ),
+            # # Removing this as it doesn't count the doses of J&J
+            # "first_dose_new": CMU(
+            #     category="total_vaccine_initiated",
+            #     measurement="new",
+            #     unit="people",
+            # ),
             "series_complete_new": CMU(
                 category="total_vaccine_completed",
                 measurement="new",
@@ -61,11 +61,12 @@ class FloridaCountyVaccine(StateDashboard):
                 measurement="new",
                 unit="doses",
             ),
-            "first_dose_total": CMU(
-                category="total_vaccine_initiated",
-                measurement="cumulative",
-                unit="people",
-            ),
+            # Removing this as it doesn't count the doses of J&J
+            # "first_dose_total": CMU(
+            #     category="total_vaccine_initiated",
+            #     measurement="cumulative",
+            #     unit="people",
+            # ),
             "series_complete_total": CMU(
                 category="total_vaccine_completed",
                 measurement="cumulative",

--- a/can_tools/scrapers/official/ME/me_vaccines.py
+++ b/can_tools/scrapers/official/ME/me_vaccines.py
@@ -144,7 +144,6 @@ class MaineCountyVaccines(MicrosoftBIDashboard):
 
         # Dump records into a DataFrame
         df = pd.DataFrame.from_records(data_rows, columns=row_names)
-
         # Title case and remove the word county
         df["location_name"] = df["county"].str.replace("County, ME", "").str.strip()
 
@@ -162,21 +161,13 @@ class MaineCountyVaccines(MicrosoftBIDashboard):
                 measurement="cumulative",
                 unit="doses",
             ),
-            "total_vaccine_initiated": CMU(
-                category="total_vaccine_initiated",
-                measurement="cumulative",
-                unit="people",
-            ),
+           
             "total_vaccine_completed": CMU(
                 category="total_vaccine_completed",
                 measurement="cumulative",
                 unit="people",
             ),
-            "total_vaccine_initiated_percent": CMU(
-                category="total_vaccine_initiated",
-                measurement="current",
-                unit="percentage",
-            ),
+           
             "total_vaccine_completed_percent": CMU(
                 category="total_vaccine_completed",
                 measurement="current",


### PR DESCRIPTION
Some of the data providers don't report the J&J vaccine following our definition. They only include the J&J vaccine counts in their second dose column. 

This pull request simply removes the `total_vaccine_initiated` column until either we can figure out how to separate the J&J dose counts from other vaccines, or the data provider changes the way they report.