### PR TITLE
FIX: Fix, NCVacccine, IowaCountyVaccine, MontataCountyVaccine, CTCountyVaccine, Pennsylvania

### DIFF
--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -36,6 +36,7 @@ from can_tools.scrapers.official.federal.HHS.hhs_state import (
 from can_tools.scrapers.official.FL.fl_vaccine import FloridaCountyVaccine
 from can_tools.scrapers.official.GA.ga_vaccines import GeorgiaCountyVaccine
 from can_tools.scrapers.official.HI.hi_county import HawaiiVaccineCounty
+
 # from can_tools.scrapers.official.IL import IllinoisDemographics, IllinoisHistorical
 from can_tools.scrapers.official.IA.ia_vaccine_county import IowaCountyVaccine
 from can_tools.scrapers.official.IL.il_vaccine import (

--- a/can_tools/scrapers/official/CT/ct_vaccine.py
+++ b/can_tools/scrapers/official/CT/ct_vaccine.py
@@ -27,7 +27,12 @@ class CTCountyVaccine(SODA, DatasetBase):
         data = data.rename(
             columns={"date": "dt", "county_of_residence": "location_name"}
         )
-        unwanted_loc = ["Total", "Address pending validation", "Residence out of state", "Resident out of state"]
+        unwanted_loc = [
+            "Total",
+            "Address pending validation",
+            "Residence out of state",
+            "Resident out of state",
+        ]
         data = data.query("location_name not in @unwanted_loc")
 
         crename = {

--- a/can_tools/scrapers/official/CT/ct_vaccine.py
+++ b/can_tools/scrapers/official/CT/ct_vaccine.py
@@ -27,7 +27,7 @@ class CTCountyVaccine(SODA, DatasetBase):
         data = data.rename(
             columns={"date": "dt", "county_of_residence": "location_name"}
         )
-        unwanted_loc = ["Total", "Address pending validation", "Residence out of state"]
+        unwanted_loc = ["Total", "Address pending validation", "Residence out of state", "Resident out of state"]
         data = data.query("location_name not in @unwanted_loc")
 
         crename = {

--- a/can_tools/scrapers/official/HI/hi_county.py
+++ b/can_tools/scrapers/official/HI/hi_county.py
@@ -24,18 +24,13 @@ class HawaiiVaccineCounty(TableauDashboard):
     state_fips = int(us.states.lookup("Hawaii").fips)
     # https://public.tableau.com/shared/H33ZZ9HCC?:display_count=y&:origin=viz_share_link&:embed=y
     # Hawai'i https://public.tableau.com/shared/7TCBHC568?:display_count=y&:origin=viz_share_link&:embed=y
-    filterFunctionName = "[sqlproxy.0td6cgz0bpiy7x131qvze0jvbqr1].[none:County:nk]" # this is the name of the user action, not the filter function name. doesn't work
+    filterFunctionName = "[sqlproxy.0td6cgz0bpiy7x131qvze0jvbqr1].[none:County:nk]"  # this is the name of the user action, not the filter function name. doesn't work
     baseurl = "https://public.tableau.com"
     viewPath = "HawaiiCOVID-19-VaccinationDashboard/VACCINESBYCOUNTY"
     # baseurl = "https://public.tableau.com/shared/"
     # viewPath = "7TCBHC568"
-    counties = [
-            'Maui',
-            'Hawaii',
-            'Honolulu',
-            'Kauai'
-        ]
-    
+    counties = ["Maui", "Hawaii", "Honolulu", "Kauai"]
+
     def fetch(self):
 
         results = {}
@@ -49,44 +44,44 @@ class HawaiiVaccineCounty(TableauDashboard):
         dfs = []
         for county in self.counties:
 
-            df = data[county]['Cumulative Persons']
+            df = data[county]["Cumulative Persons"]
             df.columns = [
-                'total_vaccine_initiated',
-                'alias',
-                'total_vaccine_completed',
+                "total_vaccine_initiated",
+                "alias",
+                "total_vaccine_completed",
                 "total_vaccines_administered",
                 "sum_daily_count",
                 "measure_name",
                 "dt",
-                "date"
+                "date",
             ]
 
-            df['location_name'] = county
+            df["location_name"] = county
             df.dt = pd.to_datetime(df.dt)
             dfs.append(df)
 
         df = pd.concat(dfs)
         crename = {
             "total_vaccine_initiated": CMU(
-                category='total_vaccine_initiated',
-                measurement='cumulative',
-                unit='people'
+                category="total_vaccine_initiated",
+                measurement="cumulative",
+                unit="people",
             ),
             "total_vaccine_completed": CMU(
                 category="total_vaccine_completed",
                 measurement="cumulative",
-                unit="people"
+                unit="people",
             ),
             "sum_daily_count": CMU(
                 category="total_vaccine_doses_administered",
                 measurement="cumulative",
-                unit="doses"
-            )
+                unit="doses",
+            ),
         }
 
-        out = df.melt(id_vars=['location_name', 'dt'], value_vars=crename.keys())
+        out = df.melt(id_vars=["location_name", "dt"], value_vars=crename.keys())
         out = self.extract_CMU(out, crename)
-        out['vintage'] = self._retrieve_vintage()
+        out["vintage"] = self._retrieve_vintage()
         cols_to_keep = [
             "vintage",
             "dt",

--- a/can_tools/scrapers/official/IA/ia_vaccine_county.py
+++ b/can_tools/scrapers/official/IA/ia_vaccine_county.py
@@ -6,6 +6,7 @@ from io import StringIO
 from can_tools.scrapers.official.base import StateDashboard, CMU
 from can_tools.scrapers import variables
 
+
 class IowaCountyVaccine(StateDashboard):
     has_location = False
     location_type = "county"
@@ -17,53 +18,61 @@ class IowaCountyVaccine(StateDashboard):
     card_id = "1179017552"
     csv_link = "https://public.domo.com/embed/pages/1wB9j/cards/1179017552/export"
     # Don't know if this will need to be renewed...
-    # If it does, to get this token: 
+    # If it does, to get this token:
     # 1) open the dashboard_link in a browser
     # 2) Scroll down to the table titled Vaccine Series by County of Vaccine Provider (about 2/3 down)
     # 3) Hover over the table in the top right corner, a button should appear
     # 4) Inspect the Network tab in the browser, then click the link
     # 5) The token will be in the request headers under 'x-domo-embed-token`
-    token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjUyNjM5Mzc0IiwibmJ" \
-            "mIjoxNjE3MDIzNzY3LCJpc3MiOiJhcGlHYXRld2F5IiwiZW1iIjpbIntcInRva2VuXCI" \
-            "6XCIxd0I5alwiLFwibGlua1R5cGVcIjpcIlNFQVJDSEFCTEVcIixcInBlcm1pc3Npb25" \
-            "zXCI6W1wiUkVBRFwiXX0iXSwiZXhwIjoxNjE3MDUyNTc3LCJpYXQiOjE2MTcwMjM3Nzc" \
-            "sImp0aSI6IjhiMjkwZTdiLTIyOGItNDk1ZS1hZWM4LTk4MzU4ZmY1MGQ1MSJ9.fLonEP" \
-            "lF81TuGI5UlVI4CAYAbkO3rk3HTv-vyvSNWbY"
-    
+    token = (
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjUyNjM5Mzc0IiwibmJ"
+        "mIjoxNjE3MDIzNzY3LCJpc3MiOiJhcGlHYXRld2F5IiwiZW1iIjpbIntcInRva2VuXCI"
+        "6XCIxd0I5alwiLFwibGlua1R5cGVcIjpcIlNFQVJDSEFCTEVcIixcInBlcm1pc3Npb25"
+        "zXCI6W1wiUkVBRFwiXX0iXSwiZXhwIjoxNjE3MDUyNTc3LCJpYXQiOjE2MTcwMjM3Nzc"
+        "sImp0aSI6IjhiMjkwZTdiLTIyOGItNDk1ZS1hZWM4LTk4MzU4ZmY1MGQ1MSJ9.fLonEP"
+        "lF81TuGI5UlVI4CAYAbkO3rk3HTv-vyvSNWbY"
+    )
 
     variables = {
-            "total_vaccine_initiated": variables.INITIATING_VACCINATIONS_ALL,
-            "total_vaccine_completed": variables.FULLY_VACCINATED_ALL,
-            "total_administered": variables.TOTAL_DOSES_ADMINISTERED_ALL
-        }
+        "total_vaccine_initiated": variables.INITIATING_VACCINATIONS_ALL,
+        "total_vaccine_completed": variables.FULLY_VACCINATED_ALL,
+        "total_administered": variables.TOTAL_DOSES_ADMINISTERED_ALL,
+    }
+
     def fetch(self):
-        headers = {
-            'x-domo-embed-token': self.token
-        }
-        res = requests.post(self.csv_link, {
-            "request": json.dumps({
-                "fileName": "Vaccine Series by County of Vaccine Provider.csv",
-                "accept": "text/csv",
-                "type": "file"
-            })
-        }, headers=headers)
+        headers = {"x-domo-embed-token": self.token}
+        res = requests.post(
+            self.csv_link,
+            {
+                "request": json.dumps(
+                    {
+                        "fileName": "Vaccine Series by County of Vaccine Provider.csv",
+                        "accept": "text/csv",
+                        "type": "file",
+                    }
+                )
+            },
+            headers=headers,
+        )
         data = StringIO(res.text)
         return pd.read_csv(data)
 
     def normalize(self, data):
-        df = data.rename(columns={
-            "Two-Dose Series Initiated": "total_vaccine_initiated",
-            "Two-Dose Series Completed": "total_vaccine_completed",
-            "Single-Dose Series Completed": "single_complete",
-            "Total Doses Administered": "total_administered"
-        })
+        df = data.rename(
+            columns={
+                "Two-Dose Series Initiated": "total_vaccine_initiated",
+                "Two-Dose Series Completed": "total_vaccine_completed",
+                "Single-Dose Series Completed": "single_complete",
+                "Total Doses Administered": "total_administered",
+            }
+        )
 
         df = self._rename_or_add_date_and_location(
             df,
             location_name_column="County",
             timezone="US/Central",
             apply_title_case=True,
-            location_names_to_drop=['Out of State']
+            location_names_to_drop=["Out of State"],
         )
         # Count single dose vaccine as both initiated and completed
         df.total_vaccine_initiated += df.total_vaccine_completed + df.single_complete

--- a/can_tools/scrapers/official/IA/ia_vaccine_county.py
+++ b/can_tools/scrapers/official/IA/ia_vaccine_county.py
@@ -24,11 +24,12 @@ class IowaCountyVaccine(StateDashboard):
     # 4) Inspect the Network tab in the browser, then click the link
     # 5) The token will be in the request headers under 'x-domo-embed-token`
     token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjUyNjM5Mzc0IiwibmJ" \
-            "mIjoxNjE2NzYyOTUyLCJpc3MiOiJhcGlHYXRld2F5IiwiZW1iIjpbIntcInRva2VuXCI6" \
-            "XCIxd0I5alwiLFwibGlua1R5cGVcIjpcIlNFQVJDSEFCTEVcIixcInBlcm1pc3Npb25zXCI" \
-            "6W1wiUkVBRFwiXX0iXSwiZXhwIjoxNjE2NzkxNzYyLCJpYXQiOjE2MTY3NjI5NjIsImp0aSI6" \
-            "IjdkODBhN2YwLWZmZjEtNDc2Yi1iNGQ3LThlOTRiOWFlYzJiMiJ9.Fn5GPyRJZal_b28wA2tS" \
-            "HUBZxJv-QsbBlngmSlvmbfw"
+            "mIjoxNjE3MDIzNzY3LCJpc3MiOiJhcGlHYXRld2F5IiwiZW1iIjpbIntcInRva2VuXCI" \
+            "6XCIxd0I5alwiLFwibGlua1R5cGVcIjpcIlNFQVJDSEFCTEVcIixcInBlcm1pc3Npb25" \
+            "zXCI6W1wiUkVBRFwiXX0iXSwiZXhwIjoxNjE3MDUyNTc3LCJpYXQiOjE2MTcwMjM3Nzc" \
+            "sImp0aSI6IjhiMjkwZTdiLTIyOGItNDk1ZS1hZWM4LTk4MzU4ZmY1MGQ1MSJ9.fLonEP" \
+            "lF81TuGI5UlVI4CAYAbkO3rk3HTv-vyvSNWbY"
+    
 
     variables = {
             "total_vaccine_initiated": variables.INITIATING_VACCINATIONS_ALL,
@@ -37,7 +38,7 @@ class IowaCountyVaccine(StateDashboard):
         }
     def fetch(self):
         headers = {
-            'x-domo-embed-token': self.token,
+            'x-domo-embed-token': self.token
         }
         res = requests.post(self.csv_link, {
             "request": json.dumps({

--- a/can_tools/scrapers/official/MT/mt_vaccinations.py
+++ b/can_tools/scrapers/official/MT/mt_vaccinations.py
@@ -7,7 +7,7 @@ from can_tools.scrapers.official.base import ArcGIS
 
 class MontanaCountyVaccine(ArcGIS):
     ARCGIS_ID = "qnjIrwR8z5Izc0ij"
-    has_location = False
+    has_location = True
     location_type = "county"
     state_fips = int(us.states.lookup("Montana").fips)
     source = "https://montana.maps.arcgis.com/apps/MapSeries/index.html?appid=7c34f3412536439491adcc2103421d4b"
@@ -32,12 +32,12 @@ class MontanaCountyVaccine(ArcGIS):
         df = (
             self.arcgis_jsons_to_df(data)
             .fillna(0)
-            .rename(columns={"NAME": "location_name", "Date_Reported": "dt"})
+            .rename(columns={"ALLFIPS": "location", "Date_Reported": "dt"})
         )
 
         # Capitalize start of words and replace wrong names
-        df.loc[:, "location_name"] = (
-            df.loc[:, "location_name"]
+        df.loc[:, "location"] = (
+            df.loc[:, "location"]
             .str.title()
             .replace({"Lewis & Clark": "Lewis and Clark", "Mccone": "McCone"})
         )

--- a/can_tools/scrapers/official/NC/nc_vaccine.py
+++ b/can_tools/scrapers/official/NC/nc_vaccine.py
@@ -22,8 +22,8 @@ class NCVaccine(TableauDashboard):
 
     # map wide form column names into CMUs
     cmus = {
-        "SUM(Partially Vaccinated)-alias": variables.INITIATING_VACCINATIONS_ALL,
-        "SUM(Fully Vaccinated)-alias": variables.FULLY_VACCINATED_ALL,
+        "AGG(Calc.Tooltip Partially Vaccinated)-alias": variables.INITIATING_VACCINATIONS_ALL,
+        "AGG(Calc.Tooltip Fully Vaccinated)-alias": variables.FULLY_VACCINATED_ALL,
     }
 
     def normalize(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/can_tools/scrapers/official/PA/pa_vaccines.py
+++ b/can_tools/scrapers/official/PA/pa_vaccines.py
@@ -17,7 +17,8 @@ class PennsylvaniaCountyVaccines(MicrosoftBIDashboard):
     location_type = "county"
     state_fips = int(us.states.lookup("Pennsylvania").fips)
 
-    source = "https://www.health.pa.gov/topics/disease/coronavirus/Vaccine/Pages/Vaccine.aspx"
+    source = "https://www.health.pa.gov/topics/disease/coronavirus/Vaccine/Pages/Dashboard.aspx"
+
     source_name = "Pennsylvania Department of Health"
     powerbi_url = "https://wabi-us-gov-iowa-api.analysis.usgovcloudapi.net"
 

--- a/can_tools/scrapers/official/PA/pa_vaccines.py
+++ b/can_tools/scrapers/official/PA/pa_vaccines.py
@@ -181,7 +181,9 @@ class PennsylvaniaVaccineDemographics(MicrosoftBIDashboard, ABC):
     location_type = ""
     state_fips = int(us.states.lookup("Pennsylvania").fips)
 
-    source = "https://www.health.pa.gov/topics/disease/coronavirus/Vaccine/Pages/Vaccine.aspx"
+    # source = "https://www.health.pa.gov/topics/disease/coronavirus/Vaccine/Pages/Vaccine.aspx"
+    source = "https://www.health.pa.gov/topics/disease/coronavirus/Vaccine/Pages/Dashboard.aspx"
+
     source_name = "Pennsylvania Department of Health"
     powerbi_url = "https://wabi-us-gov-iowa-api.analysis.usgovcloudapi.net"
 


### PR DESCRIPTION
NCVaccine:
* updated column names

IowaCountyVaccine:
* updated token

MontanaCountyVaccine:
* the names of the counties were incorrect. The data includes the fips numbers so I changed the scraper to use those instead

CTCountyVaccine:
* Removed non-county entry in data

Pennsylvania Scrapers:
* updated source 