### PR TITLE
fix/update DC demographic vaccine scraper

### DIFF
--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -18,7 +18,7 @@ from can_tools.scrapers.official.CA.counties.sandiego_vaccine import CASanDiegoV
 from can_tools.scrapers.official.CT.ct_vaccine import CTCountyVaccine
 from can_tools.scrapers.official.DC.dc_cases import DCCases
 from can_tools.scrapers.official.DC.dc_deaths import DCDeaths
-from can_tools.scrapers.official.DC.dc_vaccines import DCVaccineSex
+from can_tools.scrapers.official.DC.dc_vaccines import DCVaccineRace
 from can_tools.scrapers.official.DE.de_vaccine import DelawareStateVaccine
 from can_tools.scrapers.official.federal.CDC.cdc_coviddatatracker import (
     CDCCovidDataTracker,

--- a/can_tools/scrapers/official/DC/dc_vaccines.py
+++ b/can_tools/scrapers/official/DC/dc_vaccines.py
@@ -42,11 +42,16 @@ class DCVaccineRace(TableauDashboard):
                 "Cross-alias",
             }
         )
+        df["demo_val"] = df["demo_val"].str.lower()
+
+        # check to ensure that the scraper is still returning data by race
+        if not all(x in list(df["demo_val"].unique()) for x in ["white", "black"]):
+            raise ValueError("scraper is not returning race data")
 
         # sum the partially and fully vaccinated entries to match definition
         # to avoid pivoting to wide then back to long I selected each corresponding entry to sum
         q = 'variable == "{v} VACCINATED" and demo_val == "{d}"'
-        for d in ["BLACK", "WHITE", "OTHER"]:
+        for d in ["black", "white", "other"]:
             initiated_value = int(
                 df.query(q.format(v="PARTIALLY", d=d))["value"]
             ) + int(df.query(q.format(v="FULLY", d=d))["value"])
@@ -58,7 +63,7 @@ class DCVaccineRace(TableauDashboard):
         )
 
         out = df.assign(
-            race=df["demo_val"].str.lower(),
+            race=df["demo_val"],
             value=df["value"].astype(int),
             vintage=self._retrieve_vintage(),
             dt=self._get_date(),


### PR DESCRIPTION
temporarily updated scraper to match the data that the dashboard returns, (changed from Sex data to Race data)

Also, the previous _partially vaccinated_ data did not include people who had completed their series. This should fix this by summing the partially vaccinated people with fully vaccinated to match the `total_vaccine_initiated` definition. Sorry I didn't catch that earlier.

Added a check that should stop the scraper from running if the demographic changes (eg, if it switches back to data by sex)