### PR TITLE
fix Nevada vaccine scraper

### DIFF
--- a/can_tools/scrapers/official/NV/nv_vaccines.py
+++ b/can_tools/scrapers/official/NV/nv_vaccines.py
@@ -84,7 +84,7 @@ class NevadaCountyVaccines(MicrosoftBIDashboard):
                                     "From": self.construct_from(
                                         [
                                             ("c", "Counties", 0),
-                                            ("s", "Sheet1", 0),
+                                            ("s", "Vaccinations by Patient County", 0),
                                         ]
                                     ),
                                     "Select": self.construct_select(


### PR DESCRIPTION
Table to pull vaccine data was renamed from `Sheet 1` to `Vaccinations by Patient County` causing the fetch method to fail

one line change to fix this