### PR TITLE
Switch cdc testing column

### DIFF
--- a/can_tools/scrapers/official/DC/dc_vaccines.py
+++ b/can_tools/scrapers/official/DC/dc_vaccines.py
@@ -110,7 +110,7 @@ class DCVaccineRace(TableauDashboard):
         return out
 
 
-class DCVaccine(DCVaccineSex):
+class DCVaccine(DCVaccineRace):
     has_location = True
     source = "https://coronavirus.dc.gov/data/vaccination"
     source_name = "DC Health"

--- a/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
@@ -22,7 +22,7 @@ class CDCCovidDataTracker(FederalDashboard):
         "new_deaths_7_day_rolling_average": CMU(
             category="deaths", measurement="rolling_average_7_day", unit="people"
         ),
-        "percent_new_test_results_reported_positive_7_day_rolling_average": CMU(
+        "percent_positive_7_day": CMU(
             category="pcr_tests_positive",
             measurement="rolling_average_7_day",
             unit="percentage",


### PR DESCRIPTION
We would like to build a snapshot using this other cdc testing variable - I think it is more consistent and is the one used on the CDC webpage I believe.  

Also it looks like there was an import error - I know our unit tests are always failing but we should probalby figure out a better way to either a) make the unit tests less reliable on succeeding or b) be able to run a subset of the unit tests on build that are deterministic