### PR TITLE
Create main flow that runs all scrapers

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -123,7 +123,7 @@ nbconvert==6.0.7
 nbformat==5.0.8
 nest-asyncio==1.4.2
 notebook==6.1.5
-numpy==1.19.4
+numpy==1.20.2
 packaging==20.4
 pandas==1.1.4
 pandocfilters==1.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ BeautifulSoup4==4.9.3
 black==20.8b
 beautifulsoup4==4.9.3
 geopandas==0.8.1
-numpy==1.20.1
+numpy==1.20.2
 pandas==1.2.3
 psycopg2-binary==2.8.6
 pyppeteer==0.2.2

--- a/services/prefect/flows/update_api_view.py
+++ b/services/prefect/flows/update_api_view.py
@@ -2,7 +2,7 @@ from contextlib import closing
 from datetime import timedelta
 import os
 import pathlib
-
+from prefect import triggers
 import pandas as pd
 import prefect
 import sqlalchemy as sa
@@ -30,7 +30,12 @@ def export_to_csv(connstr: str):
     return True
 
 
-@task(max_retries=3, retry_delay=timedelta(minutes=1), nout=2)
+@task(
+    max_retries=3,
+    retry_delay=timedelta(minutes=1),
+    nout=2,
+    trigger=triggers.all_finished,
+)
 def create_parquet(_success):
     ts = prefect.context.scheduled_start_time
     dt_str = pd.to_datetime(ts).strftime("%Y-%m-%dT%H")


### PR DESCRIPTION
This creates a single flow that runs all of the scrapers - I think it'll make it easier to see when data was updated and what scrapers are failing instead of having to rely on prefect failed task uis.  Also, it gives a bit more of a sequence: run all scrapers -> update parquet file. 

Right now i dont' think this parallelized.  My thinking is that it doesn't matter too much, but if the total run takes more than 3 hours I think we can look into fixing that