### PR TITLE
Update South Dakota Vaccine Scraper

### DIFF
--- a/can_tools/bootstrap_data/covid_variables.csv
+++ b/can_tools/bootstrap_data/covid_variables.csv
@@ -180,6 +180,7 @@ total_vaccine_initiated,new,people
 total_vaccine_initiated,new,doses
 total_vaccine_initiated,new_7_day,people
 pfizer_vaccine_completed,cumulative,people
+janssen_vaccine_completed,cumulative,people
 total_vaccine_allocated,cumulative,doses
 total_vaccine_distributed,cumulative,doses
 total_vaccine_initiated,cumulative,people

--- a/can_tools/scrapers/official/SD/sd_vaccines.py
+++ b/can_tools/scrapers/official/SD/sd_vaccines.py
@@ -48,8 +48,8 @@ class SDVaccineCounty(MicrosoftBIDashboard):
         "janssen_series": CMU(
             category="janssen_vaccine_completed",
             measurement="cumulative",
-            unit="people"
-        )
+            unit="people",
+        ),
     }
 
     def construct_body(self, resource_key, ds_id, model_id, report_id, counties):

--- a/can_tools/scrapers/official/SD/sd_vaccines.py
+++ b/can_tools/scrapers/official/SD/sd_vaccines.py
@@ -25,6 +25,31 @@ class SDVaccineCounty(MicrosoftBIDashboard):
         "total_vaccine_initiated": variables.INITIATING_VACCINATIONS_ALL,
         "total_vaccine_doses_administered": variables.TOTAL_DOSES_ADMINISTERED_ALL,
         "total_vaccine_completed": variables.FULLY_VACCINATED_ALL,
+        "moderna_1_dose": CMU(
+            category="moderna_vaccine_initiated",
+            measurement="cumulative",
+            unit="people",
+        ),
+        "pfizer_1_dose": CMU(
+            category="pfizer_vaccine_initiated",
+            measurement="cumulative",
+            unit="people",
+        ),
+        "moderna_complete": CMU(
+            category="moderna_vaccine_completed",
+            measurement="cumulative",
+            unit="people",
+        ),
+        "pfizer_complete": CMU(
+            category="pfizer_vaccine_completed",
+            measurement="cumulative",
+            unit="people",
+        ),
+        "janssen_series": CMU(
+            category="janssen_vaccine_completed",
+            measurement="cumulative",
+            unit="people"
+        )
     }
 
     def construct_body(self, resource_key, ds_id, model_id, report_id, counties):

--- a/can_tools/scrapers/official/SD/sd_vaccines.py
+++ b/can_tools/scrapers/official/SD/sd_vaccines.py
@@ -192,10 +192,7 @@ class SDVaccineCounty(MicrosoftBIDashboard):
         for chunk in resjson:
             foo = chunk["results"][0]["result"]["data"]
             d = foo["dsr"]["DS"][0]["PH"][1]["DM1"]
-            data.append(d)
-
-        # flatten our data list of lists to one list (eg: [[1,2],[3,4]] -> [1,2,3,4])
-        data = [j for i in data for j in i]
+            data.extend(d)
 
         # make the mappings manually
         col_mapping = {


### PR DESCRIPTION
Updates the SDVaccineCounty scraper to collect `total_vaccine_initiated`,`total_vaccine_completed`, and `total_vaccine_doses_administered`, and first/second dose data by manufacturer.

I could not find a neat solution to #199, in that I still don't know why the request limits the number of responses to 12 or 13 counties. To circumvent this issue I broke up the fetch into 6 separate requests, returning data for 11 counties in each. Then I combined the results. If anyone knows of a fix/a more efficient way to approach this please let me know, but this should work correctly.

One question: If we collect manufacturer/dose specific data, do we want to collect/return that data? Or do we only care about the standard initiated/completed/administered?