### PR TITLE
Revert "Revert cdc test positivity change"

### DIFF
--- a/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
@@ -22,7 +22,7 @@ class CDCCovidDataTracker(FederalDashboard):
         "new_deaths_7_day_rolling_average": CMU(
             category="deaths", measurement="rolling_average_7_day", unit="people"
         ),
-        "percent_new_test_results_reported_positive_7_day_rolling_average": CMU(
+        "percent_positive_7_day": CMU(
             category="pcr_tests_positive",
             measurement="rolling_average_7_day",
             unit="percentage",


### PR DESCRIPTION
Reverts covid-projections/can-scrapers#210.

We've reevaluated the CDC dashboard and it seems that while they're not using percent_positive_7_day for their chart, they do use (the second to last data point from) it for the current test positivity value.  We are going to reach out to CDC to see if we can get clarity on the two columns, but for now we're feeling more comfortable moving forward with the percent_positive_7_day column.