### PR TITLE
FIX: Philadelphia County Vaccine

### DIFF
--- a/can_tools/scrapers/official/PA/pa_vaccines.py
+++ b/can_tools/scrapers/official/PA/pa_vaccines.py
@@ -171,8 +171,8 @@ class PennsylvaniaCountyVaccines(MicrosoftBIDashboard):
 
         res = out.loc[:, cols_to_keep]
 
-        # This scraper reports incorrect values for Philadelhpia county
-        # The PhiladelhpiaVaccine scraper now handles it's data
+        # This scraper reports incorrect values for Philadelphia county
+        # The PhiladelphiaVaccine scraper now handles it's data
         # Remove all Philadelphia county rows
         return res.loc[res.location_name != "Philadelphia"]
 
@@ -417,10 +417,10 @@ class PennsylvaniaVaccineDemographics(MicrosoftBIDashboard, ABC):
         categories.remove(self.demographic)
         res = self.normalize_postprocess(df, categories, crename)
 
-        # This scraper reports incorrect values for Philadelhpia county
-        # The PhiladelhpiaVaccine scraper now handles it's data
+        # This scraper reports incorrect values for Philadelphia county
+        # The PhiladelphiaVaccine scraper now handles it's data
         # Remove all Philadelphia county rows
-        return res.loc[df.location_name != "Philadelphia"]
+        return res.loc[res.location_name != "Philadelphia"]
 
 
 class PennsylvaniaVaccineAge(PennsylvaniaVaccineDemographics):

--- a/can_tools/scrapers/official/PA/pa_vaccines.py
+++ b/can_tools/scrapers/official/PA/pa_vaccines.py
@@ -169,7 +169,12 @@ class PennsylvaniaCountyVaccines(MicrosoftBIDashboard):
             "value",
         ]
 
-        return out.loc[:, cols_to_keep]
+        res = out.loc[:, cols_to_keep]
+
+        # This scraper reports incorrect values for Philadelhpia county
+        # The PhiladelhpiaVaccine scraper now handles it's data
+        # Remove all Philadelphia county rows
+        return res.loc[res.location_name != "Philadelphia"]
 
 
 class PennsylvaniaVaccineDemographics(MicrosoftBIDashboard, ABC):
@@ -318,8 +323,10 @@ class PennsylvaniaVaccineDemographics(MicrosoftBIDashboard, ABC):
         out["vintage"] = self._retrieve_vintage()
         out.loc[:, "location_type"] = "county"
         out.loc[:, "location_type"] = out.loc[:, "location_type"].where(
-            out.loc[:, "location_name"] != "Pennsylvania", "state"
+            out.loc[:, "location_name"] != "Pennsylvania",
+            "state",
         )
+
         cols_to_keep = [
             "vintage",
             "dt",
@@ -408,7 +415,12 @@ class PennsylvaniaVaccineDemographics(MicrosoftBIDashboard, ABC):
             "ethnicity",
         ]
         categories.remove(self.demographic)
-        return self.normalize_postprocess(df, categories, crename)
+        res = self.normalize_postprocess(df, categories, crename)
+
+        # This scraper reports incorrect values for Philadelhpia county
+        # The PhiladelhpiaVaccine scraper now handles it's data
+        # Remove all Philadelphia county rows
+        return res.loc[df.location_name != "Philadelphia"]
 
 
 class PennsylvaniaVaccineAge(PennsylvaniaVaccineDemographics):

--- a/can_tools/scrapers/official/PA/pa_vaccines.py
+++ b/can_tools/scrapers/official/PA/pa_vaccines.py
@@ -169,12 +169,7 @@ class PennsylvaniaCountyVaccines(MicrosoftBIDashboard):
             "value",
         ]
 
-        res = out.loc[:, cols_to_keep]
-
-        # This scraper reports incorrect values for Philadelphia county
-        # The PhiladelphiaVaccine scraper now handles it's data
-        # Remove all Philadelphia county rows
-        return res.loc[res.location_name != "Philadelphia"]
+        return out.loc[:, cols_to_keep]
 
 
 class PennsylvaniaVaccineDemographics(MicrosoftBIDashboard, ABC):
@@ -415,12 +410,7 @@ class PennsylvaniaVaccineDemographics(MicrosoftBIDashboard, ABC):
             "ethnicity",
         ]
         categories.remove(self.demographic)
-        res = self.normalize_postprocess(df, categories, crename)
-
-        # This scraper reports incorrect values for Philadelphia county
-        # The PhiladelphiaVaccine scraper now handles it's data
-        # Remove all Philadelphia county rows
-        return res.loc[res.location_name != "Philadelphia"]
+        return self.normalize_postprocess(df, categories, crename)
 
 
 class PennsylvaniaVaccineAge(PennsylvaniaVaccineDemographics):

--- a/can_tools/scrapers/official/PA/philadelhpia_vaccine.py
+++ b/can_tools/scrapers/official/PA/philadelhpia_vaccine.py
@@ -1,11 +1,11 @@
 import pandas as pd
 from us import states
 import sqlalchemy as sa
-from can_tools.scrapers.official.base import StateDashboard
+from can_tools.scrapers.official.base import CountyDashboard
 from can_tools.scrapers import variables, CMU
 
 
-class PhiladelphaVaccine(StateDashboard):
+class PhiladelphaVaccine(CountyDashboard):
     state_fips = int(states.lookup("Pennsylvania").fips)
     has_location = True
     location_type = "county"


### PR DESCRIPTION
I believe the fix introduced in #239 was getting overwritten by the state scraper. This removes the rows the `PennsylvaniaCountyVaccines` scraper gets for Philadelphia county as they are handled by the `PhiladelphaVaccine` scraper.