### PR TITLE
scrape territories

### DIFF
--- a/can_tools/scrapers/base.py
+++ b/can_tools/scrapers/base.py
@@ -20,6 +20,7 @@ from can_tools.models import Base
 # include `DC` in the `us.STATES` list and, if we upgrade, we should
 # activate that option and replace this with just `us.STATES`
 ALL_STATES_PLUS_DC = us.STATES + [us.states.DC]
+ALL_STATES_PLUS_TERRITORIES = us.states.STATES_AND_TERRITORIES + [us.states.DC]
 
 
 class CMU:

--- a/can_tools/scrapers/official/federal/CDC/cdc_vaccines.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_vaccines.py
@@ -5,7 +5,7 @@ import requests
 import us
 
 from can_tools.scrapers import variables
-from can_tools.scrapers.base import ALL_STATES_PLUS_DC, CMU
+from can_tools.scrapers.base import ALL_STATES_PLUS_TERRITORIES, CMU
 from can_tools.scrapers.official.base import FederalDashboard
 
 
@@ -39,7 +39,7 @@ class CDCStateVaccine(FederalDashboard):
         return response.json()
 
     def _filter_rows(self, df):
-        state_abbr_list = [x.abbr for x in ALL_STATES_PLUS_DC]
+        state_abbr_list = [x.abbr for x in ALL_STATES_PLUS_TERRITORIES]
         return df.loc[df["Location"].isin(state_abbr_list), :]
 
     def normalize(self, data):


### PR DESCRIPTION
This simple change adds a few more states to the scraper:

```
In [31]: d = CDCStateVaccine()

In [32]: df = d.fetch_normalize()

In [33]: [(x, x.fips) for x in us.states.TERRITORIES + [us.states.DC]]
Out[33]: 
[(<State:American Samoa>, '60'),
 (<State:Guam>, '66'),
 (<State:Northern Mariana Islands>, '69'),
 (<State:Puerto Rico>, '72'),
 (<State:Virgin Islands>, '78'),
 (<State:District of Columbia>, '11')]

In [34]: df.query("location >= 60").location.unique()
Out[34]: array([60, 66, 69, 72])
```