### PR TITLE
Fix Minnesota, Mississippi vaccine scrapers

### DIFF
--- a/can_tools/scrapers/official/MN/mn_vaccine.py
+++ b/can_tools/scrapers/official/MN/mn_vaccine.py
@@ -20,7 +20,10 @@ class MinnesotaCountyVaccines(MicrosoftBIDashboard):
     source = "https://mn.gov/covid19/vaccine/data/index.jsp"
     source_name = "Minnesota Covid-19 Response"
     powerbi_url = "https://wabi-us-gov-iowa-api.analysis.usgovcloudapi.net"
-    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiN2EwNjAyMTQtOTc5NS00NjJmLTg0YjctNjI2ZDIwMGM0NzYxIiwidCI6ImViMTRiMDQ2LTI0YzQtNDUxOS04ZjI2LWI4OWMyMTU5ODI4YyJ9"
+
+    # get the iframe link manually to bypass captcha
+    # this will need to be updated periodically -- find the iframe in the page source html 
+    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiMDRmOTJiZWUtMjk0Ni00ZDI4LTg4YzMtODk0ZDIwMTgxMjhjIiwidCI6ImViMTRiMDQ2LTI0YzQtNDUxOS04ZjI2LWI4OWMyMTU5ODI4YyJ9"
 
     def get_dashboard_iframe(self):
         fumn = {"src": self.powerbi_dashboard_link}

--- a/can_tools/scrapers/official/MN/mn_vaccine.py
+++ b/can_tools/scrapers/official/MN/mn_vaccine.py
@@ -22,7 +22,7 @@ class MinnesotaCountyVaccines(MicrosoftBIDashboard):
     powerbi_url = "https://wabi-us-gov-iowa-api.analysis.usgovcloudapi.net"
 
     # get the iframe link manually to bypass captcha
-    # this will need to be updated periodically -- find the iframe in the page source html 
+    # this will need to be updated periodically -- find the iframe in the page source html
     powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiMDRmOTJiZWUtMjk0Ni00ZDI4LTg4YzMtODk0ZDIwMTgxMjhjIiwidCI6ImViMTRiMDQ2LTI0YzQtNDUxOS04ZjI2LWI4OWMyMTU5ODI4YyJ9"
 
     def get_dashboard_iframe(self):

--- a/can_tools/scrapers/official/MS/ms_vaccine.py
+++ b/can_tools/scrapers/official/MS/ms_vaccine.py
@@ -39,7 +39,8 @@ class MSCountyVaccine(StateDashboard):
     def normalize(self, raw):
         # Clean up dataframe from PDF.
         data = raw[1].df
-        header = data.iloc[4, :].reset_index(drop=True)
+        # find header
+        header = data.loc[data.iloc[:, 0] == 'County of Residence'].iloc[0]
         data = data.iloc[5:, :].reset_index(drop=True)
         data.columns = header.to_list()
 

--- a/can_tools/scrapers/official/MS/ms_vaccine.py
+++ b/can_tools/scrapers/official/MS/ms_vaccine.py
@@ -40,8 +40,10 @@ class MSCountyVaccine(StateDashboard):
         # Clean up dataframe from PDF.
         data = raw[1].df
         # find header
-        header = data.loc[data.iloc[:, 0] == "County of Residence"].iloc[0]
-        data = data.iloc[5:, :].reset_index(drop=True)
+        header_loc = data.index[data.iloc[:, 0] == "County of Residence"].values[0]
+        header = data.loc[[header_loc]].iloc[0]
+        # grab all data from after the header
+        data = data.iloc[header_loc + 1 :, :].reset_index(drop=True)
         data.columns = header.to_list()
 
         data = self._rename_or_add_date_and_location(

--- a/can_tools/scrapers/official/MS/ms_vaccine.py
+++ b/can_tools/scrapers/official/MS/ms_vaccine.py
@@ -40,7 +40,7 @@ class MSCountyVaccine(StateDashboard):
         # Clean up dataframe from PDF.
         data = raw[1].df
         # find header
-        header = data.loc[data.iloc[:, 0] == 'County of Residence'].iloc[0]
+        header = data.loc[data.iloc[:, 0] == "County of Residence"].iloc[0]
         data = data.iloc[5:, :].reset_index(drop=True)
         data.columns = header.to_list()
 

--- a/can_tools/scrapers/official/OR/or_vaccine.py
+++ b/can_tools/scrapers/official/OR/or_vaccine.py
@@ -28,7 +28,7 @@ class OregonVaccineCounty(TableauDashboard):
     cmus = {
         "SUM(People Count)-alias": variables.INITIATING_VACCINATIONS_ALL,
         "SUM(Vaccinated)-alias": variables.FULLY_VACCINATED_ALL,
-        "SUM(Administrations)-alias":variables.TOTAL_DOSES_ADMINISTERED_ALL,
+        "SUM(Administrations)-alias": variables.TOTAL_DOSES_ADMINISTERED_ALL,
     }
 
     location_name_col = "AGG(County People Count Label)-alias"
@@ -55,13 +55,15 @@ class OregonVaccineCounty(TableauDashboard):
         # get init / complete table
         df = pd.concat([d[0] for d in data.values()])
         # get all doses table
-        doses = pd.concat([d[1] for d in data.values()])[['SUM(Administrations)-alias','AGG(County People Count Label)-alias']]
+        doses = pd.concat([d[1] for d in data.values()])[
+            ["SUM(Administrations)-alias", "AGG(County People Count Label)-alias"]
+        ]
         # append total_doses column to main df via join
         df = pd.merge(df, doses, on=self.location_name_col, how="left")
-        
+
         df["location_name"] = df[self.location_name_col].str.title()
         # parse out data columns
-        
+
         value_cols = list(set(df.columns) & set(self.cmus.keys()))
         assert len(value_cols) == len(self.cmus)
 

--- a/can_tools/scrapers/official/OR/or_vaccine.py
+++ b/can_tools/scrapers/official/OR/or_vaccine.py
@@ -22,4 +22,3 @@ class OregonVaccineCounty(TableauDashboard):
     data_tableau_table = "County Map Per Capita new"
     location_name_col = "Recip Address County-alias"
     timezone = "US/Pacific"
-    

--- a/can_tools/scrapers/official/OR/or_vaccine.py
+++ b/can_tools/scrapers/official/OR/or_vaccine.py
@@ -1,18 +1,7 @@
 import us
-from bs4 import BeautifulSoup
-import re
-import json
-import os
-import pandas as pd
-import requests
 
 from can_tools.scrapers import variables
-from can_tools.scrapers.official.base import (
-    TableauDashboard,
-    TableauMapClick,
-)
-
-from can_tools.scrapers.util import requests_retry_session
+from can_tools.scrapers.official.base import TableauDashboard
 
 
 class OregonVaccineCounty(TableauDashboard):
@@ -26,59 +15,11 @@ class OregonVaccineCounty(TableauDashboard):
     viewPath = "OregonCOVID-19VaccinationTrends/OregonCountyVaccinationTrends"
 
     cmus = {
-        "SUM(People Count)-alias": variables.INITIATING_VACCINATIONS_ALL,
-        "SUM(Vaccinated)-alias": variables.FULLY_VACCINATED_ALL,
-        "SUM(Administrations)-alias": variables.TOTAL_DOSES_ADMINISTERED_ALL,
+        "SUM(Metric - Total People)-alias": variables.INITIATING_VACCINATIONS_ALL,
+        "SUM(Metric - Fully Vaccinated)-alias": variables.FULLY_VACCINATED_ALL,
     }
 
-    location_name_col = "AGG(County People Count Label)-alias"
+    data_tableau_table = "County Map Per Capita new"
+    location_name_col = "Recip Address County-alias"
     timezone = "US/Pacific"
-    filterFunctionName = "[federated.0t5ugmz0hnw7q719jeh0615iizas].[none:county:nk]"
-
-    def fetch(self):
-        path = os.path.dirname(__file__) + "/../../../bootstrap_data/locations.csv"
-        counties = list(
-            pd.read_csv(path).query(f"state == 41 and location != 41")["name"]
-        )
-
-        results = {}
-        for county in counties:
-            print("making request for: ", county)
-            self.filterFunctionValue = county
-            tables = self.get_tableau_view()
-            results[county] = [
-                tables.get(key) for key in ["Cty In Progress", "Cty All Doses"]
-            ]
-        return results
-
-    def normalize(self, data: pd.DataFrame) -> pd.DataFrame:
-        # get init / complete table
-        df = pd.concat([d[0] for d in data.values()])
-        # get all doses table
-        doses = pd.concat([d[1] for d in data.values()])[
-            ["SUM(Administrations)-alias", "AGG(County People Count Label)-alias"]
-        ]
-        # append total_doses column to main df via join
-        df = pd.merge(df, doses, on=self.location_name_col, how="left")
-
-        df["location_name"] = df[self.location_name_col].str.title()
-        # parse out data columns
-
-        value_cols = list(set(df.columns) & set(self.cmus.keys()))
-        assert len(value_cols) == len(self.cmus)
-
-        out = (
-            df.melt(id_vars=["location_name"], value_vars=value_cols)
-            .dropna()
-            .assign(
-                dt=self._retrieve_dt(self.timezone),
-                vintage=self._retrieve_vintage(),
-                value=lambda x: pd.to_numeric(
-                    x["value"].astype(str).str.replace(",", ""),
-                ),
-            )
-            .pipe(self.extract_CMU, cmu=self.cmus)
-            .drop(["variable"], axis=1)
-        )
-        out["location_name"] = out["location_name"].str.replace("In ", "")
-        return out
+    

--- a/can_tools/scrapers/official/OR/or_vaccine.py
+++ b/can_tools/scrapers/official/OR/or_vaccine.py
@@ -1,8 +1,18 @@
 import us
+from bs4 import BeautifulSoup
+import re
+import json
+import os
+import pandas as pd
+import requests
 
 from can_tools.scrapers import variables
-from can_tools.scrapers.official.base import TableauDashboard
+from can_tools.scrapers.official.base import (
+    TableauDashboard,
+    TableauMapClick,
+)
 
+from can_tools.scrapers.util import requests_retry_session
 
 class OregonVaccineCounty(TableauDashboard):
     has_location = False
@@ -15,10 +25,58 @@ class OregonVaccineCounty(TableauDashboard):
     viewPath = "OregonCOVID-19VaccinationTrends/OregonCountyVaccinationTrends"
 
     cmus = {
-        "SUM(Metric - Total People)-alias": variables.INITIATING_VACCINATIONS_ALL,
-        "SUM(Metric - Fully Vaccinated)-alias": variables.FULLY_VACCINATED_ALL,
+        "SUM(In Progress)-alias": variables.INITIATING_VACCINATIONS_ALL,
+        "SUM(Vaccinated)-alias": variables.FULLY_VACCINATED_ALL,
     }
 
-    data_tableau_table = "County Map Per Capita new"
-    location_name_col = "Recip Address County-alias"
+    location_name_col = "AGG(County People Count Label)-alias"
     timezone = "US/Pacific"
+    filterFunctionName = '[federated.0t5ugmz0hnw7q719jeh0615iizas].[none:county:nk]'
+
+    def fetch(self):
+        path = os.path.dirname(__file__) + "/../../../bootstrap_data/locations.csv"
+        counties = list(
+            pd.read_csv(path).query(f"state == 41 and location != 41")["name"]
+        )
+
+        results = {}
+        for county in counties:
+            print('making request for: ', county)
+            self.filterFunctionValue = county
+            tables = self.get_tableau_view()
+            results[county] = [tables.get(key) for key in ['Cty In Progress', 'Cty All Doses']]
+        return results
+
+
+    def normalize(self, data: pd.DataFrame) -> pd.DataFrame:
+        # concat both tables separately
+        progress = pd.concat([d[0] for d in data.values()]) 
+        doses = pd.concat([d[1] for d in data.values()])[['AGG(County People Count Label)-alias', 'SUM(Doses Johnson)-alias']]
+        # append J&J doses to first table via join
+        df = pd.merge(progress, doses, on=self.location_name_col, how="left") 
+
+        # combine (1 of 2 dose) + (jj) to get initiated
+        df['SUM(In Progress)-alias'] += df['SUM(Doses Johnson)-alias']
+        df["location_name"] = df[self.location_name_col].str.title()
+
+        # parse out data columns
+        value_cols = list(set(df.columns) & set(self.cmus.keys()))
+        assert len(value_cols) == len(self.cmus)
+
+        out =  (
+            df.melt(id_vars=["location_name"], value_vars=value_cols)
+            .dropna()
+            .assign(
+                dt=self._retrieve_dt(self.timezone),
+                vintage=self._retrieve_vintage(),
+                value=lambda x: pd.to_numeric(
+                    x["value"].astype(str).str.replace(",", ""),
+                ),
+            )
+            .pipe(self.extract_CMU, cmu=self.cmus)
+            .drop(["variable"], axis=1)
+        )
+        out['location_name'] = out['location_name'].str.replace("In ", "")
+        return out              
+
+    


### PR DESCRIPTION
<del>Oregon:</del>

<del>They've moved their tables around it looks like. I've added a filter function to access each county. </del>

<del>The below value/variable (people initiated) is what I'm tracking as `total_vaccine_initiated`, and just want to make sure this is correct. </del>

Moved the Oregon changes to a new PR (#263) as it's effectively a new scraper

---
**Minnesota:**

If I recall correctly (correct me if I'm not), we have to manually grab the iframe because there's a captcha on the dashboard. I've updated the iframe so it works again. Should I look into a way to bypass the captcha? Or has that been done and it doesn't seem feasible?

---
**Mississippi**:

update the headers pulled from the PDF
