### PR TITLE
add total vaccine initiated values for Maricopa county

### DIFF
--- a/can_tools/scrapers/official/AZ/counties/maricopa_vaccine.py
+++ b/can_tools/scrapers/official/AZ/counties/maricopa_vaccine.py
@@ -4,6 +4,7 @@ import re
 import pandas as pd
 import json
 from bs4 import BeautifulSoup as bs
+from typing import Dict, Tuple
 from can_tools.scrapers.official.base import CountyDashboard
 from can_tools.scrapers import variables
 
@@ -17,7 +18,7 @@ class ArizonaMaricopaVaccine(CountyDashboard):
     variables = {
         "total_doses_administered": variables.TOTAL_DOSES_ADMINISTERED_ALL,
         "total_vaccine_completed": variables.FULLY_VACCINATED_ALL,
-        "1_dose_pf_mod": variables.INITIATING_VACCINATIONS_ALL,
+        "total_vaccine_initiated": variables.INITIATING_VACCINATIONS_ALL,
     }
 
     def _get_url(self, src_data: requests.models.Response) -> str:
@@ -31,15 +32,10 @@ class ArizonaMaricopaVaccine(CountyDashboard):
         url = re.findall(r"https://.*", redirect["content"])[0]
         return url
 
-    def fetch(self) -> requests.models.Response:
-        init_url = "https://datawrapper.dwcdn.net/Y9bAu/3/"
-        return requests.get(init_url)
-
-    def normalize(self, data) -> pd.DataFrame:
-        # get the url of the dashboard
-        url = self._get_url(data)
-
-        # make request to the dashboard itself
+    def _get_json(self, url: str) -> list:
+        """
+        extract the json containing the data from a script on the card
+        """
         page = requests.get(url)
         soup = bs(page.text, "lxml")
 
@@ -55,29 +51,46 @@ class ArizonaMaricopaVaccine(CountyDashboard):
         )
 
         # get only relevent data from this JSON
-        records = json.loads(raw_json)["data"]["changes"]
-        records = [r for r in records if r["column"] == 1]
+        return json.loads(raw_json)["data"]["changes"]
 
-        # dump into df
-        df = pd.DataFrame.from_records(records)
-        df = (
-            df.assign(
-                dt=pd.to_datetime(df["time"], unit="ms").dt.date,
-                value=df["value"].str.replace("r", "").astype(int),
-                variable=df["row"].replace(
-                    {
-                        1: "total_doses_administered",
-                        2: "1_dose_pf_mod",
-                        3: "total_vaccine_completed",
-                        4: "unknown_dose",
-                    }
-                ),
-                location_name="Maricopa",
-                vintage=self._retrieve_vintage(),
-            )
-            .drop(columns={"row", "column", "time", "ignored", "previous"})
-            .query('variable not in ["unknown_dose", "1_dose_pf_mod"]')
-        )
+    def fetch(self) -> Tuple[requests.models.Response]:
+        # data are stored in two different cards, so fetch both
+        url = "https://datawrapper.dwcdn.net/Y9bAu/3/"
+        initiated_url = "https://datawrapper.dwcdn.net/ECVzt/7/"
+        return requests.get(url), requests.get(initiated_url)
+
+    def normalize(self, data) -> pd.DataFrame:
+        # get the real urls of both cards
+        url = self._get_url(data[0])
+        init_url = self._get_url(data[1])
+
+        # extract the json/data from both cards
+        records = self._get_json(url)
+        records_init = self._get_json(init_url)
+
+        # only keep records that correspond to a data definition (vaccine initiated, doses admin, etc..)
+        records = [r for r in records if r["column"] == 1 and r["row"] in [1, 3]]
+        records_init = [r for r in records_init if r["column"] == 1 and r["row"] == 1]
+
+        # rename initiated values, as both dicts have "1" as a row value
+        for r in records_init:
+            r["row"] = "total_vaccine_initiated"
+
+        # dump rows into df
+        rows = records + records_init
+        df = pd.DataFrame.from_records(rows)
+        df = df.assign(
+            dt=pd.to_datetime(df["time"], unit="ms").dt.date,
+            value=df["value"].str.replace("r", "").astype(int),
+            variable=df["row"].replace(
+                {
+                    1: "total_doses_administered",
+                    3: "total_vaccine_completed",
+                }
+            ),
+            location_name="Maricopa",
+            vintage=self._retrieve_vintage(),
+        ).drop(columns={"row", "column", "time", "ignored", "previous"})
 
         out = self.extract_CMU(df, self.variables)
 


### PR DESCRIPTION
the county surfaces "_Number of Maricopa Residents Who Are Vaccinated with ≥1 Dose_" in a different dashboard/card than the `total_vaccine_doses_admin` and `total_vaccine_completed` data,

This updates the scraper to get data from both cards, adding (`total_vaccine_initiated`, `cumulative`. `people`) to the scraper.

initiated data card is here: https://datawrapper.dwcdn.net/ECVzt/7/