### PR TITLE
add age and sex demographic scrapers for NY counties

### DIFF
--- a/can_tools/bootstrap_data/covid_demographics.csv
+++ b/can_tools/bootstrap_data/covid_demographics.csv
@@ -4,6 +4,7 @@ all,all,all,all
 0-5,all,all,all
 0-10,all,all,all
 0-17,all,all,all
+0-15,all,all,all
 0-19,all,all,all
 0-20,all,all,all
 5-17,all,all,all
@@ -18,6 +19,7 @@ all,all,all,all
 15-19,all,all,all
 16-17,all,all,all
 16-19,all,all,all
+16-25,all,all,all
 16-19,all,all,female
 16-19,all,all,male
 16-19,all,all,unknown
@@ -41,6 +43,7 @@ all,all,all,all
 25-29,all,all,all
 25-34,all,all,all
 25-49,all,all,all
+26-34,all,all,all
 30-34,all,all,all
 30-39,all,all,all
 30-39,all,all,female

--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -105,7 +105,11 @@ from can_tools.scrapers.official.NE.ne_vaccines import (
 from can_tools.scrapers.official.NJ.nj_vaccine import NewJerseyVaccineCounty
 from can_tools.scrapers.official.NM.nm_vaccine import NewMexicoVaccineCounty
 from can_tools.scrapers.official.NV.nv_vaccines import NevadaCountyVaccines
-from can_tools.scrapers.official.NY.ny_vaccine import NewYorkVaccineCounty
+from can_tools.scrapers.official.NY.ny_vaccine import (
+    NewYorkVaccineCounty,
+    NewYorkVaccineCountyAge,
+    NewYorkVaccineCountySex,
+)
 from can_tools.scrapers.official.OH.oh_vaccine import OhioVaccineCounty
 from can_tools.scrapers.official.OH.oh_vaccine_demographics import (
     OHVaccineCountyRace,

--- a/can_tools/scrapers/official/NY/ny_vaccine.py
+++ b/can_tools/scrapers/official/NY/ny_vaccine.py
@@ -3,11 +3,8 @@ import pandas as pd
 import os
 
 from can_tools.scrapers import variables
-from can_tools.scrapers.official.base import (
-    TableauDashboard,
-    TableauMapClick,
-)
-from can_tools.scrapers.util import requests_retry_session
+from can_tools.scrapers.official.base import TableauDashboard
+from typing import List
 
 
 class NewYorkVaccineCounty(TableauDashboard):
@@ -43,7 +40,7 @@ class NewYorkVaccineCountyAge(NewYorkVaccineCounty):
         "People with completed Vaccine Series": variables.FULLY_VACCINATED_ALL,
     }
 
-    def fetch(self):
+    def fetch(self) -> List[pd.DataFrame]:
         path = os.path.dirname(__file__) + "/../../../bootstrap_data/locations.csv"
         counties = list(
             pd.read_csv(path).query(f"state == 36 and location != 36")["name"]
@@ -67,7 +64,7 @@ class NewYorkVaccineCountyAge(NewYorkVaccineCounty):
 
         return results
 
-    def normalize(self, data):
+    def normalize(self, data: List[pd.DataFrame]) -> pd.DataFrame:
         df = pd.concat(data)
         df = (
             df.rename(


### PR DESCRIPTION
tracks `total_vaccine_initiated/completed` for `age` and `sex` demographics. 

[age dashboard](https://covid19tracker.health.ny.gov/views/Gender_Age_Public/VaccinationbyAge?%3Asize=1200%2C23&%3Aembed=y&%3AshowVizHome=n&%3Atabs=n&%3Atoolbar=n&%3Adevice=desktop&%3AapiID=host3#navType=255&navSrc=Parse)
[sex dashboard](https://covid19tracker.health.ny.gov/views/Gender_Age_Public/VaccinationbyGender?:size=1200,23&:embed=y&:showVizHome=n&:bootstrapWhenNotified=y&:tabs=n&:toolbar=n&:device=desktop&:apiID=host4#navType=255&navSrc=Parse)