### PR TITLE
allow for multiple re-directs in Maricopa Vaccine County

### DIFF
--- a/can_tools/scrapers/official/AZ/counties/maricopa_vaccine.py
+++ b/can_tools/scrapers/official/AZ/counties/maricopa_vaccine.py
@@ -40,8 +40,16 @@ class ArizonaMaricopaVaccine(CountyDashboard):
         soup = bs(page.text, "lxml")
 
         # extract the and format script that contains the data/JSON
-        raw_data = soup.find_all("script")[1]
-        raw_data = str(raw_data).replace("\\", "")
+        raw_data = soup.find_all("script")
+
+        # if the page must re-direct more than once, find the next re-direct url 
+        # re-call fn until found end page
+        if len(raw_data) == 0:
+            new_data = requests.get(url)
+            new_url = self._get_url(new_data)
+            return self._get_json(new_url)
+
+        raw_data = str(raw_data[1]).replace("\\", "")
 
         # extract relevent json from string
         raw_json = (

--- a/can_tools/scrapers/official/AZ/counties/maricopa_vaccine.py
+++ b/can_tools/scrapers/official/AZ/counties/maricopa_vaccine.py
@@ -45,8 +45,7 @@ class ArizonaMaricopaVaccine(CountyDashboard):
         # if the page must re-direct more than once, find the next re-direct url 
         # re-call fn until found end page
         if len(raw_data) == 0:
-            new_data = requests.get(url)
-            new_url = self._get_url(new_data)
+            new_url = self._get_url(page)
             return self._get_json(new_url)
 
         raw_data = str(raw_data[1]).replace("\\", "")

--- a/can_tools/scrapers/official/AZ/counties/maricopa_vaccine.py
+++ b/can_tools/scrapers/official/AZ/counties/maricopa_vaccine.py
@@ -42,7 +42,7 @@ class ArizonaMaricopaVaccine(CountyDashboard):
         # extract the and format script that contains the data/JSON
         raw_data = soup.find_all("script")
 
-        # if the page must re-direct more than once, find the next re-direct url 
+        # if the page must re-direct more than once, find the next re-direct url
         # re-call fn until found end page
         if len(raw_data) == 0:
             new_url = self._get_url(page)


### PR DESCRIPTION
If a data card requires multiple re-directs to reach the final URL, the scraper currently fails (I was assuming it would only ever re-direct once, but on the new data it requires two.)

This adds the ability to re-direct as many times as needed, by calling the `_get_json()` function until a valid URL is found. 

This should be safe (never infinitely repeat) as if there's a bad URL/landing page, the `_get_url()` method should break, stopping any sort of loop. But, let me know if there are concerns about this. 

 