### PR TITLE
add sex, age county demographic scrapers for Minnesota

### DIFF
--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -85,7 +85,11 @@ from can_tools.scrapers.official.MI.mi_vaccine import (
     MichiganVaccineCounty,
     MichiganVaccineCountyDemographics,
 )
-from can_tools.scrapers.official.MN.mn_vaccine import MinnesotaCountyVaccines
+from can_tools.scrapers.official.MN.mn_vaccine import (
+    MinnesotaCountyVaccines,
+    MinnesotaCountyAgeVaccines,
+    MinnesotaCountySexVaccines,
+)
 from can_tools.scrapers.official.MO.mo_vaccine import MissouriVaccineCounty
 from can_tools.scrapers.official.MS.ms_vaccine import MSCountyVaccine
 from can_tools.scrapers.official.MT.mt_vaccinations import (

--- a/can_tools/scrapers/official/MN/mn_vaccine.py
+++ b/can_tools/scrapers/official/MN/mn_vaccine.py
@@ -2,10 +2,12 @@ from typing import Any
 
 import pandas as pd
 import us
+import os
 
-from can_tools.scrapers import CMU
+from can_tools.scrapers import CMU, variables
 from can_tools.scrapers.official.base import MicrosoftBIDashboard
 from can_tools.scrapers.util import flatten_dict
+from can_tools.scrapers import variables as v
 
 
 class MinnesotaCountyVaccines(MicrosoftBIDashboard):
@@ -24,7 +26,7 @@ class MinnesotaCountyVaccines(MicrosoftBIDashboard):
     # get the iframe link manually to bypass captcha
     # this will need to be updated periodically -- find the iframe in the page source html
 
-    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiZGZjYWQ3NWMtMjQyMS00NzQ2LWIzMmQtNDQ0MGZkZjY5OGUzIiwidCI6ImViMTRiMDQ2LTI0YzQtNDUxOS04ZjI2LWI4OWMyMTU5ODI4YyJ9"
+    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiMzc4MGIwN2EtOGE3Zi00NWU5LTg5ZGYtY2YzYjc1MzI1ZjIwIiwidCI6ImViMTRiMDQ2LTI0YzQtNDUxOS04ZjI2LWI4OWMyMTU5ODI4YyJ9"
 
     def get_dashboard_iframe(self):
         fumn = {"src": self.powerbi_dashboard_link}
@@ -193,3 +195,278 @@ class MinnesotaCountyVaccines(MicrosoftBIDashboard):
         ]
 
         return out.loc[:, cols_to_keep].dropna()
+
+
+class MinnesotaCountyAgeVaccines(MinnesotaCountyVaccines):
+
+    demographic = "age"
+    col_mapping = {
+        "G0": "location_name",
+        "M_1_DM3_{demo}_C_1": "initiating",
+        "M_1_DM3_{demo}_C_2": "completing",
+    }
+    # use these keys to fill in the keys for each dose type
+    demographic_key = {
+        "0": "12-15",
+        "1": "16-17",
+        "2": "18-49",
+        "3": "50-64",
+        "4": "65_plus",
+    }
+    variables = {
+        "initiating": v.INITIATING_VACCINATIONS_ALL,
+        "completing": v.FULLY_VACCINATED_ALL,
+    }
+
+    def construct_body(self, resource_key, ds_id, model_id, report_id, county):
+
+        "Build body request"
+        body = {}
+
+        body["version"] = "1.0.0"
+        body["cancelQueries"] = []
+        body["modelId"] = model_id
+
+        where_clause = [
+            {
+                "Condition": {
+                    "In": {
+                        "Expressions": [
+                            {
+                                "Column": {
+                                    "Expression": {"SourceRef": {"Source": "m"}},
+                                    "Property": "County",
+                                }
+                            }
+                        ],
+                        "Values": [[{"Literal": {"Value": f"'{county}'"}}]],
+                    }
+                },
+            },
+        ]
+
+        body["queries"] = [
+            {
+                "Query": {
+                    "Commands": [
+                        {
+                            "SemanticQueryDataShapeCommand": {
+                                "Query": {
+                                    "Version": 2,
+                                    "From": self.construct_from(
+                                        [
+                                            # From
+                                            ("d", "dashboarddata", 0),
+                                            ("_", "_Measures_Used", 0),
+                                            ("a", "Age group POP", 0),
+                                            ("m", "MODEL_Joined_Counties", 0),
+                                        ]
+                                    ),
+                                    "Select": self.construct_select(
+                                        [
+                                            # Selects
+                                            ("m", "County", "county"),
+                                            (
+                                                "d",
+                                                "age",
+                                                "demo",
+                                            ),
+                                        ],
+                                        [
+                                            # Aggregations
+                                        ],
+                                        [
+                                            # Measures
+                                            ("_", "casesincomplete", "incomplete"),
+                                            ("_", "CasesCompleted", "complete"),
+                                        ],
+                                    ),
+                                    "Where": where_clause,
+                                }
+                            }
+                        }
+                    ]
+                },
+                "QueryId": "",
+                "ApplicationContext": self.construct_application_context(
+                    ds_id, report_id
+                ),
+            }
+        ]
+        return body
+
+    def fetch(self):
+        # Get general information
+        self._setup_sess()
+        dashboard_frame = self.get_dashboard_iframe()
+        resource_key = self.get_resource_key(dashboard_frame)
+        ds_id, model_id, report_id = self.get_model_data(resource_key)
+
+        # Get the post url
+        url = self.powerbi_query_url()
+
+        # Build post headers
+        headers = self.construct_headers(resource_key)
+
+        counties = list(
+            pd.read_csv(
+                os.path.dirname(__file__) + "/../../../bootstrap_data/locations.csv"
+            ).query("state == @self.state_fips and name != 'Minnesota'")["name"]
+        )
+
+        jsons = []
+        """
+        make one call per county to ensure that all the data is received
+        """
+        for county in counties:
+            print("making request for: ", county)
+            body = self.construct_body(resource_key, ds_id, model_id, report_id, county)
+            res = self.sess.post(url, json=body, headers=headers)
+            jsons.append(res.json())
+        return jsons
+
+    def normalize(self, resjson: dict) -> pd.DataFrame:
+        data = []
+        for chunk in resjson:
+            foo = chunk["results"][0]["result"]["data"]
+            d = foo["dsr"]["DS"][0]["PH"][1]["DM1"]
+            data.extend(d)
+
+        # Iterate through all of the rows and store relevant data
+        data_rows = []
+        for record in data:
+            flat_record = flatten_dict(record)
+            # print(flat_record)
+
+            for demo_key, demo in self.demographic_key.items():
+                row = {}
+                row[self.demographic] = demo
+                for k in list(self.col_mapping.keys()):
+                    k_formatted = k.format(demo=demo_key)
+                    flat_record_key = [
+                        frk for frk in flat_record.keys() if k_formatted in frk
+                    ]
+                    if len(flat_record_key) > 0:
+                        row[self.col_mapping[k]] = flat_record[flat_record_key[0]]
+                data_rows.append(row)
+
+        # combine into dataframe
+        df = pd.DataFrame.from_records(data_rows)
+        out = self._reshape_variables(
+            df,
+            self.variables,
+            id_vars=[self.demographic],
+            skip_columns=[self.demographic],
+        )
+
+        return out.assign(
+            location_name=lambda x: x["location_name"].str.title(),
+            dt=self._retrieve_dtm1d("US/Eastern"),
+            vintage=self._retrieve_vintage(),
+        ).replace(
+            {
+                "Mcleod": "McLeod",
+                "Lac Qui Parle": "Lac qui Parle",
+                "Lake Of The Woods": "Lake of the Woods",
+            }
+        )
+
+
+class MinnesotaCountySexVaccines(MinnesotaCountyAgeVaccines):
+    demographic = "sex"
+    # use these keys to fill in the keys for each dose type
+    demographic_key = {"0": "female", "1": "male", "2": "unknown"}
+
+    def construct_body(self, resource_key, ds_id, model_id, report_id, county):
+
+        "Build body request"
+        body = {}
+
+        body["version"] = "1.0.0"
+        body["cancelQueries"] = []
+        body["modelId"] = model_id
+
+        where_clause = [
+            {
+                "Condition": {
+                    "In": {
+                        "Expressions": [
+                            {
+                                "Column": {
+                                    "Expression": {"SourceRef": {"Source": "m"}},
+                                    "Property": "County",
+                                }
+                            }
+                        ],
+                        "Values": [[{"Literal": {"Value": f"'{county}'"}}]],
+                    }
+                }
+            },
+            {
+                "Condition": {
+                    "Not": {
+                        "Expression": {
+                            "In": {
+                                "Expressions": [
+                                    {
+                                        "Column": {
+                                            "Expression": {
+                                                "SourceRef": {"Source": "d"}
+                                            },
+                                            "Property": "gender",
+                                        }
+                                    }
+                                ],
+                                "Values": [[{"Literal": {"Value": "'Other'"}}]],
+                            }
+                        }
+                    }
+                }
+            },
+        ]
+
+        body["queries"] = [
+            {
+                "Query": {
+                    "Commands": [
+                        {
+                            "SemanticQueryDataShapeCommand": {
+                                "Query": {
+                                    "Version": 2,
+                                    "From": self.construct_from(
+                                        [
+                                            # From
+                                            ("d", "dashboarddata", 0),
+                                            ("_", "_Measures_Used", 0),
+                                            ("a", "Age group POP", 0),
+                                            ("m", "MODEL_Joined_Counties", 0),
+                                        ]
+                                    ),
+                                    "Select": self.construct_select(
+                                        [
+                                            # Selects
+                                            ("m", "County", "county"),
+                                            ("d","gender","demo"),
+                                        ],
+                                        [
+                                            # Aggregations
+                                        ],
+                                        [
+                                            # Measures
+                                            ("_", "casesincomplete", "incomplete"),
+                                            ("_", "CasesCompleted", "complete"),
+                                        ],
+                                    ),
+                                    "Where": where_clause,
+                                }
+                            }
+                        }
+                    ]
+                },
+                "QueryId": "",
+                "ApplicationContext": self.construct_application_context(
+                    ds_id, report_id
+                ),
+            }
+        ]
+        return body


### PR DESCRIPTION
tracks `total_vaccine_initiated/completed` for age and sex by county. 

Some counties reported `other` values for sex, (along with `male`, `female` and `unknown`) but most did not. Of those that did collect it most had values <50, with the max being Hennepin county (where Minneapolis is) at 150. I did not collect this as it would have required making changes to how the JSON is parsed, but, if need be I can work to include it.  