### PR TITLE
add race demographic scraper for WA counties

### DIFF
--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -159,7 +159,10 @@ from can_tools.scrapers.official.VT.vt_vaccinations import (
     VermontCountyVaccine,
     VermontStateVaccine,
 )
-from can_tools.scrapers.official.WA.wa_vaccine import WashingtonVaccine
+from can_tools.scrapers.official.WA.wa_vaccine import (
+    WashingtonVaccine,
+    WashingtonVaccineCountyRace,
+)
 from can_tools.scrapers.official.WI.wi_county_vaccine import WisconsinVaccineCounty
 from can_tools.scrapers.official.WI.wi_demographic_vaccine import (
     WisconsinVaccineStateAge,

--- a/can_tools/scrapers/official/WA/wa_vaccine.py
+++ b/can_tools/scrapers/official/WA/wa_vaccine.py
@@ -2,10 +2,12 @@ import asyncio
 
 import pandas as pd
 import us
+import os
 
 from can_tools.scrapers import variables
-from can_tools.scrapers.official.base import StateDashboard
+from can_tools.scrapers.official.base import StateDashboard, MicrosoftBIDashboard
 from can_tools.scrapers.puppet import with_page
+from can_tools.scrapers.util import flatten_dict
 
 
 class WashingtonVaccine(StateDashboard):
@@ -47,3 +49,233 @@ class WashingtonVaccine(StateDashboard):
             .pipe(self.extract_CMU, cmu=self.variables)
             .drop(["variable"], axis="columns")
         )
+
+
+class WashingtonVaccineCountyRace(MicrosoftBIDashboard):
+    has_location = False
+    location_type = "county"
+    state_fips = int(us.states.lookup("Washington").fips)
+    source_name = "Washington State Department of Health"
+
+    source = "https://www.doh.wa.gov/Emergencies/COVID19/DataDashboard"
+    powerbi_url = "https://wabi-us-gov-virginia-api.analysis.usgovcloudapi.net"
+    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiYTkxNGE1NWYtMjk4Ni00MmVhLTkxNGEtOTM4NmYyZGMxZWM5IiwidCI6IjExZDBlMjE3LTI2NGUtNDAwYS04YmEwLTU3ZGNjMTI3ZDcyZCJ9"
+
+    variables = {
+        "initiated": variables.INITIATING_VACCINATIONS_ALL,
+        "completed": variables.FULLY_VACCINATED_ALL,
+    }
+    col_mapping = {
+        "G0": "location_name",
+        "M_1_DM3_{demo}_C_1": "initiated",
+        "M_1_DM3_{demo}_C_2": "completed",
+    }
+    demographic_key = {
+        "1": "unknown",
+        "2": "white",
+        "3": "asian",
+        "4": "other",
+        "5": "hispanic",
+        "6": "black",
+        "7": "ai_an",
+        "8": "pacific_islander",
+    }
+
+    def get_dashboard_iframe(self):
+        fumn = {"src": self.powerbi_dashboard_link}
+        return fumn
+
+    def construct_body(self, resource_key, ds_id, model_id, report_id, county):
+        "Build body request"
+        body = {}
+
+        # Set version
+        body["version"] = "1.0.0"
+        body["cancelQueries"] = []
+        body["modelId"] = model_id
+
+        where_clause = [
+            {
+                "Condition": {
+                    "Not": {
+                        "Expression": {
+                            "In": {
+                                "Expressions": [
+                                    {
+                                        "Column": {
+                                            "Expression": {
+                                                "SourceRef": {"Source": "r1"}
+                                            },
+                                            "Property": "Race",
+                                        }
+                                    }
+                                ],
+                                "Values": [
+                                    [{"Literal": {"Value": "'Total Number'"}}],
+                                    [
+                                        {
+                                            "Literal": {
+                                                "Value": "'Total with Race/Ethnicity Available'"
+                                            }
+                                        }
+                                    ],
+                                ],
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "Condition": {
+                    "In": {
+                        "Expressions": [
+                            {
+                                "Column": {
+                                    "Expression": {"SourceRef": {"Source": "_"}},
+                                    "Property": "NAME",
+                                }
+                            }
+                        ],
+                        "Values": [[{"Literal": {"Value": f"'{county} County'"}}]],
+                    }
+                }
+            },
+        ]
+
+        body["queries"] = [
+            {
+                "Query": {
+                    "Commands": [
+                        {
+                            "SemanticQueryDataShapeCommand": {
+                                "Query": {
+                                    "Version": 2,
+                                    "From": self.construct_from(
+                                        [
+                                            # From
+                                            ("r1", "Race Table View CombinedOther", 0),
+                                            ("_", "_counties_US_only", 0),
+                                        ]
+                                    ),
+                                    "Select": self.construct_select(
+                                        [
+                                            # Selects
+                                            ("_", "NAME", "county"),
+                                            ("r1", "Race", "race"),
+                                        ],
+                                        [
+                                            # Aggregations
+                                        ],
+                                        [
+                                            # Measures
+                                            (
+                                                "r1",
+                                                "VaccCountInitRaceCombinedOther2",
+                                                "init",
+                                            ),
+                                            (
+                                                "r1",
+                                                "VaccCountFullyRaceCombinedOther2",
+                                                "complete",
+                                            ),
+                                        ],
+                                    ),
+                                    "Where": where_clause,
+                                }
+                            }
+                        }
+                    ]
+                },
+                "QueryId": "",
+                "ApplicationContext": self.construct_application_context(
+                    ds_id, report_id
+                ),
+            }
+        ]
+
+        return body
+
+    def fetch(self):
+        # Get general information
+        self._setup_sess()
+        dashboard_frame = self.get_dashboard_iframe()
+        resource_key = self.get_resource_key(dashboard_frame)
+        ds_id, model_id, report_id = self.get_model_data(resource_key)
+
+        # Get the post url
+        url = self.powerbi_query_url()
+
+        # Build post headers
+        headers = self.construct_headers(resource_key)
+
+        counties = list(
+            pd.read_csv(
+                os.path.dirname(__file__) + "/../../../bootstrap_data/locations.csv"
+            ).query("state == @self.state_fips and name != 'Washington'")["name"]
+        )
+
+        jsons = []
+        """
+        make one call per county to ensure that all the data is received
+        """
+        for county in counties:
+            # if county == 'Lewis':
+            #     break
+            print("making request for: ", county)
+            body = self.construct_body(resource_key, ds_id, model_id, report_id, county)
+            res = self.sess.post(url, json=body, headers=headers)
+            jsons.append(res.json())
+        return jsons
+
+    def normalize(self, resjson: dict) -> pd.DataFrame:
+        data = []
+        for chunk in resjson:
+            foo = chunk["results"][0]["result"]["data"]
+            d = foo["dsr"]["DS"][0]["PH"][1]["DM1"]
+            data.extend(d)
+
+        # Iterate through all of the rows and store relevant data
+        data_rows = []
+        for record in data:
+            flat_record = flatten_dict(record)
+
+            for demo_key, demo in self.demographic_key.items():
+                row = {}
+                row["race"] = demo
+                for k in list(self.col_mapping.keys()):
+                    k_formatted = k.format(demo=demo_key)
+                    flat_record_key = [
+                        frk for frk in flat_record.keys() if k_formatted in frk
+                    ]
+                    if len(flat_record_key) > 0:
+                        row[self.col_mapping[k]] = flat_record[flat_record_key[0]]
+                data_rows.append(row)
+
+        # combine into dataframe
+        df = (
+            pd.DataFrame.from_records(data_rows)
+            .dropna()
+            .assign(
+                initiated=lambda x: x["initiated"].astype(str).str.replace("L", ""),
+                completed=lambda x: x["completed"].astype(str).str.replace("L", ""),
+                location_name=lambda x: x["location_name"].str.replace(" County", ""),
+                dt=self._retrieve_dtm1d("US/Eastern"),
+                vintage=self._retrieve_vintage(),
+            )
+        )
+        out = self._reshape_variables(
+            df,
+            self.variables,
+            id_vars=["race"],
+            skip_columns=["race"],
+        )
+
+        # shift 'hispanic' entries into ethnicity column
+        # mark ethnicity as unknown for unknown race columns b/c the variable is 'unknown race/ethnicity'
+        hisp_rows = out["race"] == "hispanic"
+        out.loc[hisp_rows, "ethnicity"] = "hispanic"
+        out.loc[hisp_rows, "race"] = "all"
+        unknown_rows = out["race"] == "unknown"
+        out.loc[unknown_rows, "ethnicity"] = "unknown"
+
+        return out


### PR DESCRIPTION
collects `total_vaccine_initiated/completed` data for WA counties. 

they have a no-javascript blocker on the page, so at the moment I'm grabbing the iframe manually (like with Minnesota). 
The error is `<noscript>Please enable JavaScript to view the page content.<br/>Your support ID is: 14042030691975912665.</noscript>`

I can take a look at by-passing that (and for the MN one too), but I wanted to get this up before the end of today. 