### PR TITLE
fix MT vaccine completed

### DIFF
--- a/can_tools/scrapers/official/IA/ia_vaccine_county.py
+++ b/can_tools/scrapers/official/IA/ia_vaccine_county.py
@@ -19,8 +19,6 @@ class IowaCountyVaccine(StateDashboard):
     source_name = "Iowa Department of Public Health"
 
     dashboard_link = "https://public.domo.com/embed/pages/1wB9j"
-    card_id = "1179017552"
-    # csv_link = "https://public.domo.com/embed/pages/1wB9j/cards/1179017552/export"
     csv_link = "https://public.domo.com/embed/pages/1wB9j/cards/1698180896/export"
 
     variables = {

--- a/can_tools/scrapers/official/IA/ia_vaccine_county.py
+++ b/can_tools/scrapers/official/IA/ia_vaccine_county.py
@@ -12,7 +12,7 @@ from can_tools.scrapers.util import requests_retry_session
 
 
 class IowaCountyVaccine(StateDashboard):
-    has_location = False
+    has_location = True
     location_type = "county"
     state_fips = int(us.states.lookup("Iowa").fips)
     source = "https://coronavirus.iowa.gov/pages/vaccineinformation#VaccineInformation"
@@ -20,12 +20,12 @@ class IowaCountyVaccine(StateDashboard):
 
     dashboard_link = "https://public.domo.com/embed/pages/1wB9j"
     card_id = "1179017552"
-    csv_link = "https://public.domo.com/embed/pages/1wB9j/cards/1179017552/export"
+    # csv_link = "https://public.domo.com/embed/pages/1wB9j/cards/1179017552/export"
+    csv_link = "https://public.domo.com/embed/pages/1wB9j/cards/1698180896/export"
 
     variables = {
         "total_vaccine_initiated": variables.INITIATING_VACCINATIONS_ALL,
         "total_vaccine_completed": variables.FULLY_VACCINATED_ALL,
-        "total_administered": variables.TOTAL_DOSES_ADMINISTERED_ALL,
     }
     _req = None
 
@@ -50,7 +50,7 @@ class IowaCountyVaccine(StateDashboard):
             {
                 "request": json.dumps(
                     {
-                        "fileName": "Vaccine Series by County of Vaccine Provider.csv",
+                        "fileName": "Total Doses Administered by Recipient County of Residence.csv",
                         "accept": "text/csv",
                         "type": "file",
                     }
@@ -64,19 +64,16 @@ class IowaCountyVaccine(StateDashboard):
     def normalize(self, data):
         df = data.rename(
             columns={
-                "Two-Dose Series Initiated": "total_vaccine_initiated",
-                "Two-Dose Series Completed": "total_vaccine_completed",
-                "Single-Dose Series Completed": "single_complete",
-                "Total Doses Administered": "total_administered",
+                "First Dose Given": "total_vaccine_initiated",
+                "2-Dose Vaccinations Completed": "total_vaccine_completed",
+                "1-Dose Vaccinations Completed": "single_complete",
             }
-        )
+        ).dropna()
 
         df = self._rename_or_add_date_and_location(
             df,
-            location_name_column="County",
+            location_column="RECIP_ADDRESS_COUNTY",
             timezone="US/Central",
-            apply_title_case=True,
-            location_names_to_drop=["Out of State"],
         )
         # Count single dose vaccine as both initiated and completed
         df.total_vaccine_initiated += df.total_vaccine_completed + df.single_complete

--- a/can_tools/scrapers/official/IA/ia_vaccine_county.py
+++ b/can_tools/scrapers/official/IA/ia_vaccine_county.py
@@ -12,18 +12,20 @@ from can_tools.scrapers.util import requests_retry_session
 
 
 class IowaCountyVaccine(StateDashboard):
-    has_location = True
+    has_location = False
     location_type = "county"
     state_fips = int(us.states.lookup("Iowa").fips)
     source = "https://coronavirus.iowa.gov/pages/vaccineinformation#VaccineInformation"
     source_name = "Iowa Department of Public Health"
 
     dashboard_link = "https://public.domo.com/embed/pages/1wB9j"
-    csv_link = "https://public.domo.com/embed/pages/1wB9j/cards/1698180896/export"
+    card_id = "1179017552"
+    csv_link = "https://public.domo.com/embed/pages/1wB9j/cards/1179017552/export"
 
     variables = {
         "total_vaccine_initiated": variables.INITIATING_VACCINATIONS_ALL,
         "total_vaccine_completed": variables.FULLY_VACCINATED_ALL,
+        "total_administered": variables.TOTAL_DOSES_ADMINISTERED_ALL,
     }
     _req = None
 
@@ -48,7 +50,7 @@ class IowaCountyVaccine(StateDashboard):
             {
                 "request": json.dumps(
                     {
-                        "fileName": "Total Doses Administered by Recipient County of Residence.csv",
+                        "fileName": "Vaccine Series by County of Vaccine Provider.csv",
                         "accept": "text/csv",
                         "type": "file",
                     }
@@ -62,16 +64,19 @@ class IowaCountyVaccine(StateDashboard):
     def normalize(self, data):
         df = data.rename(
             columns={
-                "First Dose Given": "total_vaccine_initiated",
-                "2-Dose Vaccinations Completed": "total_vaccine_completed",
-                "1-Dose Vaccinations Completed": "single_complete",
+                "Two-Dose Series Initiated": "total_vaccine_initiated",
+                "Two-Dose Series Completed": "total_vaccine_completed",
+                "Single-Dose Series Completed": "single_complete",
+                "Total Doses Administered": "total_administered",
             }
-        ).dropna()
+        )
 
         df = self._rename_or_add_date_and_location(
             df,
-            location_column="RECIP_ADDRESS_COUNTY",
+            location_name_column="County",
             timezone="US/Central",
+            apply_title_case=True,
+            location_names_to_drop=["Out of State"],
         )
         # Count single dose vaccine as both initiated and completed
         df.total_vaccine_initiated += df.total_vaccine_completed + df.single_complete

--- a/can_tools/scrapers/official/MT/mt_vaccinations.py
+++ b/can_tools/scrapers/official/MT/mt_vaccinations.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import us
 
-from can_tools.scrapers import CMU
+from can_tools.scrapers import variables as v
 from can_tools.scrapers.official.base import ArcGIS
 
 
@@ -12,22 +12,10 @@ class MontanaCountyVaccine(ArcGIS):
     state_fips = int(us.states.lookup("Montana").fips)
     source = "https://montana.maps.arcgis.com/apps/MapSeries/index.html?appid=7c34f3412536439491adcc2103421d4b"
     source_name = "Montana Department of Health & Human Services"
-    crename = {
-        "Dose_1": CMU(
-            category="total_vaccine_initiated",
-            measurement="cumulative",
-            unit="people",
-        ),
-        "Fully_Vaxed": CMU(
-            category="total_vaccine_completed",
-            measurement="cumulative",
-            unit="people",
-        ),
-        "Total_Doses_Admin": CMU(
-            category="total_vaccine_doses_administered",
-            measurement="cumulative",
-            unit="doses",
-        ),
+    variables = {
+        "Dose_1": v.INITIATING_VACCINATIONS_ALL,
+        "Fully_Vaxed": v.FULLY_VACCINATED_ALL,
+        "Total_Doses_Admin": v.TOTAL_DOSES_ADMINISTERED_ALL,
     }
 
     def fetch(self):
@@ -67,10 +55,10 @@ class MontanaCountyVaccine(ArcGIS):
             loc_col_type = "location_name"
 
         out = data.melt(
-            id_vars=["dt", loc_col_type], value_vars=self.crename.keys()
+            id_vars=["dt", loc_col_type], value_vars=self.variables.keys()
         ).dropna()
         out.loc[:, "value"] = pd.to_numeric(out["value"])
-        out = self.extract_CMU(out, self.crename)
+        out = self.extract_CMU(out, self.variables)
         out["vintage"] = self._retrieve_vintage()
 
         cols_to_keep = [
@@ -92,17 +80,9 @@ class MontanaCountyVaccine(ArcGIS):
 class MontanaStateVaccine(MontanaCountyVaccine):
     location_type = "state"
     has_location = True
-    crename = {
-        "Total_Montanans_Immunized": CMU(
-            category="total_vaccine_completed",
-            measurement="cumulative",
-            unit="people",
-        ),
-        "Total_Doses_Administered": CMU(
-            category="total_vaccine_doses_administered",
-            measurement="cumulative",
-            unit="doses",
-        ),
+    variables = {
+        "Total_Montanans_Immunized": v.FULLY_VACCINATED_ALL,
+        "Total_Doses_Administered": v.TOTAL_DOSES_ADMINISTERED_ALL,
     }
 
     def fetch(self):

--- a/can_tools/scrapers/official/MT/mt_vaccinations.py
+++ b/can_tools/scrapers/official/MT/mt_vaccinations.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import us
 
-from can_tools.scrapers import variables as v
+from can_tools.scrapers import variables
 from can_tools.scrapers.official.base import ArcGIS
 
 
@@ -13,9 +13,9 @@ class MontanaCountyVaccine(ArcGIS):
     source = "https://montana.maps.arcgis.com/apps/MapSeries/index.html?appid=7c34f3412536439491adcc2103421d4b"
     source_name = "Montana Department of Health & Human Services"
     variables = {
-        "Dose_1": v.INITIATING_VACCINATIONS_ALL,
-        "Fully_Vaxed": v.FULLY_VACCINATED_ALL,
-        "Total_Doses_Admin": v.TOTAL_DOSES_ADMINISTERED_ALL,
+        "Dose_1": variables.INITIATING_VACCINATIONS_ALL,
+        "Fully_Vaxed": variables.FULLY_VACCINATED_ALL,
+        "Total_Doses_Admin": variables.TOTAL_DOSES_ADMINISTERED_ALL,
     }
 
     def fetch(self):
@@ -81,8 +81,8 @@ class MontanaStateVaccine(MontanaCountyVaccine):
     location_type = "state"
     has_location = True
     variables = {
-        "Total_Montanans_Immunized": v.FULLY_VACCINATED_ALL,
-        "Total_Doses_Administered": v.TOTAL_DOSES_ADMINISTERED_ALL,
+        "Total_Montanans_Immunized": variables.FULLY_VACCINATED_ALL,
+        "Total_Doses_Administered": variables.TOTAL_DOSES_ADMINISTERED_ALL,
     }
 
     def fetch(self):

--- a/can_tools/scrapers/official/MT/mt_vaccinations.py
+++ b/can_tools/scrapers/official/MT/mt_vaccinations.py
@@ -18,10 +18,15 @@ class MontanaCountyVaccine(ArcGIS):
             measurement="cumulative",
             unit="people",
         ),
-        "Dose_2": CMU(
+        "Fully_Vaxed": CMU(
             category="total_vaccine_completed",
             measurement="cumulative",
             unit="people",
+        ),
+        "Total_Doses_Admin": CMU(
+            category="total_vaccine_doses_administered",
+            measurement="cumulative",
+            unit="doses",
         ),
     }
 


### PR DESCRIPTION
We were pulling from a strictly "2 dose" column that did not include j&j doses. Updated to pull correct `total_vaccine_completed` data and added `total_vaccine_doses_administered` data.