### PR TITLE
update WA url and MS vaccine county scrapers

### DIFF
--- a/can_tools/scrapers/official/MS/ms_vaccine.py
+++ b/can_tools/scrapers/official/MS/ms_vaccine.py
@@ -38,13 +38,22 @@ class MSCountyVaccine(StateDashboard):
 
     def normalize(self, raw):
         # Clean up dataframe from PDF.
-        data = raw[1].df
+        data = raw[0].df
         # find header
         header_loc = data.index[data.iloc[:, 0] == "County of Residence"].values[0]
         header = data.loc[[header_loc]].iloc[0]
         # grab all data from after the header
         data = data.iloc[header_loc + 1 :, :].reset_index(drop=True)
         data.columns = header.to_list()
+        data = data.loc[
+            :,
+            [
+                "County of Residence",
+                "People Receiving at least One Dose**",
+                "People Fully Vaccinated***",
+                "Total Doses Administered",
+            ],
+        ]
 
         data = self._rename_or_add_date_and_location(
             data,

--- a/can_tools/scrapers/official/WA/wa_vaccine.py
+++ b/can_tools/scrapers/official/WA/wa_vaccine.py
@@ -59,7 +59,7 @@ class WashingtonVaccineCountyRace(MicrosoftBIDashboard):
 
     source = "https://www.doh.wa.gov/Emergencies/COVID19/DataDashboard"
     powerbi_url = "https://wabi-us-gov-virginia-api.analysis.usgovcloudapi.net"
-    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiMWFlZjgyZmItYzFmZC00NDRjLTg0YzUtZjA2YTEwZDgwM2MxIiwidCI6IjExZDBlMjE3LTI2NGUtNDAwYS04YmEwLTU3ZGNjMTI3ZDcyZCJ9"
+    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiOTg0MjAwMjUtOTU3NC00OGUwLWI1ZWYtZjAzNWRhZWZlNWFkIiwidCI6IjExZDBlMjE3LTI2NGUtNDAwYS04YmEwLTU3ZGNjMTI3ZDcyZCJ9"
 
     variables = {
         "initiated": variables.INITIATING_VACCINATIONS_ALL,


### PR DESCRIPTION
really need a way to bypass the no-script element for WA, but for now this updates the dashboard URL.

MS pdf format may have changed slightly, this ensures that only the needed columns are kept (and that they exist)