### PR TITLE
set Phila scraper provider to "county"

### DIFF
--- a/can_tools/scrapers/official/PA/philadelhpia_vaccine.py
+++ b/can_tools/scrapers/official/PA/philadelhpia_vaccine.py
@@ -14,6 +14,7 @@ class PhiladelphiaVaccine(TableauDashboard):
     state_fips = int(states.lookup("Pennsylvania").fips)
     has_location = True
     location_type = "county"
+    provider = "county"
     source = (
         "https://www.phila.gov/programs/coronavirus-disease-2019-covid-19/data/vaccine/"
     )


### PR DESCRIPTION
The Philadelphia county vaccine scraper inherited from the TableauDashboard class, which had `provider = state`. Update to correct the provider, and hopefully fix the pipeline issue.