### PR TITLE
temporarily remove TN race/ethnicty/sex cases scraper to remove transaction block

### DIFF
--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -153,7 +153,7 @@ from can_tools.scrapers.official.SD.sd_vaccine_demographics import (
 from can_tools.scrapers.official.TN.tn_state import (
     TennesseeAge,
     TennesseeAgeByCounty,
-    TennesseeRaceEthnicitySex,
+    # TennesseeRaceEthnicitySex,
 )
 from can_tools.scrapers.official.TN.tn_vaccine import TennesseeVaccineCounty
 from can_tools.scrapers.official.TX.texas_vaccine import (


### PR DESCRIPTION
TennesseeRaceEthnicitySex scraper failing with error:
```
psycopg2.errors.InFailedSqlTransaction) current transaction is aborted, commands ignored until end of transaction block\n
```
I'm hoping that running a MainFlow without the scraper will flush the issue/create a new transaction, fixing this issue. 

If not, I'll do some SQL spelunking to see how to rollback a transaction.