### PR TITLE
Add scraper for NE cumulative cases

### DIFF
--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -116,6 +116,8 @@ from can_tools.scrapers.official.NE.ne_vaccines import (
     NebraskaVaccineAge,
 )
 
+from can_tools.scrapers.official.NE.ne_cases import NebraskaCases
+
 from can_tools.scrapers.official.NJ.nj_vaccine import NewJerseyVaccineCounty
 from can_tools.scrapers.official.NM.nm_vaccine import NewMexicoVaccineCounty
 from can_tools.scrapers.official.NV.nv_vaccines import NevadaCountyVaccines

--- a/can_tools/scrapers/official/NE/ne_cases.py
+++ b/can_tools/scrapers/official/NE/ne_cases.py
@@ -2,7 +2,7 @@ import pandas as pd
 import us
 import requests
 
-from can_tools.scrapers import CMU
+from can_tools.scrapers import variables
 from can_tools.scrapers.official.base import StateDashboard
 
 
@@ -16,14 +16,7 @@ class NebraskaCases(StateDashboard):
         "https://gis.ne.gov/Enterprise/rest/services/C19Combine/FeatureServer/0/query"
     )
     source_name = "Nebraska Department of Health and Human Services"
-
-    variables = {
-        "attributes.PosCases": CMU(
-            category="cases",
-            measurement="cumulative",
-            unit="people",
-        )
-    }
+    variables = {"attributes.PosCases": variables.CUMULATIVE_CASES_PEOPLE}
 
     def fetch(self) -> requests.models.Response:
         params = {

--- a/can_tools/scrapers/official/NE/ne_cases.py
+++ b/can_tools/scrapers/official/NE/ne_cases.py
@@ -23,17 +23,17 @@ class NebraskaCases(StateDashboard):
             "f": "json",
             "where": "0=0",
             "returnGeometry": "false",
-            "outFields": "name,PosCases",
+            "outFields": "name,Counties_S,PosCases",
         }
         return requests.get(self.fetch_url, params=params)
 
     def normalize(self, data: requests.models.Response) -> pd.DataFrame:
         return (
             pd.json_normalize(data.json()["features"])
-            .pipe(
-                self._rename_or_add_date_and_location,
-                location_name_column="attributes.name",
-                timezone="US/Central",
-            )
-            .pipe(self._reshape_variables, variable_map=self.variables)
+            # .pipe(
+                # self._rename_or_add_date_and_location,
+                # location_name_column="attributes.name",
+                # timezone="US/Central",
+            # )
+            # .pipe(self._reshape_variables, variable_map=self.variables)
         )

--- a/can_tools/scrapers/official/NE/ne_cases.py
+++ b/can_tools/scrapers/official/NE/ne_cases.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pandas.core.accessor import register_index_accessor
 import us
 import requests
 
@@ -8,7 +9,7 @@ from can_tools.scrapers.official.base import StateDashboard
 
 class NebraskaCases(StateDashboard):
 
-    has_location = False
+    has_location = True
     location_type = "county"
     state_fips = int(us.states.lookup("Nebraska").fips)
     source = "https://experience.arcgis.com/experience/ece0db09da4d4ca68252c3967aa1e9dd"
@@ -16,7 +17,7 @@ class NebraskaCases(StateDashboard):
         "https://gis.ne.gov/Enterprise/rest/services/C19Combine/FeatureServer/0/query"
     )
     source_name = "Nebraska Department of Health and Human Services"
-    variables = {"attributes.PosCases": variables.CUMULATIVE_CASES_PEOPLE}
+    variables = {"county_cases": variables.CUMULATIVE_CASES_PEOPLE}
 
     def fetch(self) -> requests.models.Response:
         params = {
@@ -28,12 +29,53 @@ class NebraskaCases(StateDashboard):
         return requests.get(self.fetch_url, params=params)
 
     def normalize(self, data: requests.models.Response) -> pd.DataFrame:
+        # fetch county population table, keep only cols and rows of interest
+        county_pops = (
+            pd.read_csv(
+                "https://media.githubusercontent.com/media/covid-projections/covid-data-public/main/data/misc/fips_population.csv"
+            )
+            .query("state == 'NE'")
+            .assign(county=lambda x: x["county"].str.replace(" County", ""))
+            .rename(columns={"population": "county_population"})
+            .loc[:, ["county", "fips", "county_population"]]
+            .set_index("county")
+        )
+
         return (
+            # parse and format dashboard data
             pd.json_normalize(data.json()["features"])
-            # .pipe(
-                # self._rename_or_add_date_and_location,
-                # location_name_column="attributes.name",
-                # timezone="US/Central",
-            # )
-            # .pipe(self._reshape_variables, variable_map=self.variables)
+            .assign(county=lambda x: x["attributes.Counties_S"].str.split(", "))
+            .drop(columns={"attributes.Counties_S"})
+            .rename(
+                columns={
+                    "attributes.PosCases": "region_cases",
+                    "attributes.name": "health_region",
+                }
+            )
+            .explode("county")
+            # left join with the county population table on county names
+            .set_index("county")
+            .join(county_pops, how="left")
+            .reset_index()
+            # calculate each health region's population (sum pop'n of each county in each region)
+            # find % of region's total population for each county
+            # multiply % by region's total cases to get estimated number of cases for each county
+            .assign(
+                region_population=lambda x: (
+                    x["health_region"].map(
+                        x.groupby("health_region").sum()["county_population"].to_dict()
+                    )
+                ),
+                county_percent_pop=lambda x: (
+                    x["county_population"] / x["region_population"]
+                ),
+                county_cases=lambda x: x["region_cases"] * x["county_percent_pop"],
+            )
+            # add date, melt into CMU variables
+            .pipe(
+                self._rename_or_add_date_and_location,
+                location_column="fips",
+                timezone="US/Central",
+            )
+            .pipe(self._reshape_variables, variable_map=self.variables)
         )

--- a/can_tools/scrapers/official/NE/ne_cases.py
+++ b/can_tools/scrapers/official/NE/ne_cases.py
@@ -57,18 +57,18 @@ class NebraskaCases(StateDashboard):
             .set_index("county")
             .join(county_pops, how="left")
             .reset_index()
-            # calculate each health region's population (sum pop'n of each county in each region)
-            # find % of region's total population for each county
-            # multiply % by region's total cases to get estimated number of cases for each county
             .assign(
+                # calculate health region populations by summing county populations
                 region_population=lambda x: (
                     x["health_region"].map(
                         x.groupby("health_region").sum()["county_population"].to_dict()
                     )
                 ),
+                # calculate proportion of total health region population for each county
                 county_percent_pop=lambda x: (
                     x["county_population"] / x["region_population"]
                 ),
+                # multiply proportion by region's total cases to get estimated number of cases for each county
                 county_cases=lambda x: x["region_cases"] * x["county_percent_pop"],
             )
             # add date, melt into CMU variables

--- a/can_tools/scrapers/variables.py
+++ b/can_tools/scrapers/variables.py
@@ -37,3 +37,9 @@ TOTAL_VACCINE_DISTRIBUTED: CMU = CMU(
     measurement="cumulative",
     unit="doses",
 )
+
+CUMULATIVE_CASES_PEOPLE: CMU = CMU(
+    category="cases",
+    measurement="cumulative",
+    unit="people",
+)


### PR DESCRIPTION
Steps taken to disaggregate from health regions to county level:
* calculate health region populations (pop'n) by summing the pop'ns of all the counties within each respective region.
* calculate the percentage of the corresponding health region population for each county (`county pop'n` / `health region pop'n`)
* estimate cases per county my multiplying `% of total health region pop'n` * `total health region cases`

Source of data is [here](https://experience.arcgis.com/experience/ece0db09da4d4ca68252c3967aa1e9dd)

---

**Testing:**

The tests below are run on the data _before it is transformed into long-form_ (return at line 74, before the `_reshape_variables` method), so that the health region and proportion of population data are still accessible.  

Where `d = NebraskaCases().fetch_normalize()`,

Ensure that county cases are never larger than the health region they come from (equal is okay, there are regions with one county):
```
len(d.loc[ d['county_cases'] > d['region_cases']]) == 0
```

Ensure that the proportion of total health region population sums to one across all counties within each health region:
```
d.groupby('health_region').sum()[['county_percent_pop']]
```

Ensure that the sum of the county cases within each health region equals the total number of cases for that health region:
```
# sum county cases in each region
sum_cases = d.groupby('health_region').sum()[['county_cases']].to_dict()["county_cases"]
# find each health region and it's total cases
region_cases = d.groupby('health_region').first()['region_cases'].reset_index()
# compare summed county values and total region values side by side
region_cases['sum_county_cases'] = region_cases['health_region'].map(sum_cases)
```