### PR TITLE
add missing closing bracket to delete_scraped_data function

### DIFF
--- a/db/queries/delete_data_function.sql
+++ b/db/queries/delete_data_function.sql
@@ -10,7 +10,7 @@ DECLARE
 	location_id_and text := CASE WHEN _location IS NOT NULL THEN
 		format('and location_id in (select id from meta.locations where location = %s)', _location)
 	WHEN _state_fips IS NOT NULL THEN
-		format('and location_id in(select id from meta.locations where state_fips = %s and location_type ~ %L', _state_fips, _location_type_regex)
+		format('and location_id in(select id from meta.locations where state_fips = %s and location_type ~ %L)', _state_fips, _location_type_regex)
 	ELSE
 		''
 	END;


### PR DESCRIPTION
`delete_scraped_data` threw a syntax error, which appears to be due to a missing closing bracket

```
Error invoking remote method 'DB_EXECUTE_CANCELLABLE_QUERY': error: syntax error at end of input
```