### PR TITLE
fix TN scraper (remove duplicate variable entries)

### DIFF
--- a/can_tools/scrapers/official/TN/tn_state.py
+++ b/can_tools/scrapers/official/TN/tn_state.py
@@ -222,7 +222,7 @@ class TennesseeRaceEthnicitySex(TennesseeBase):
         )
 
         # Drop the information that we won't be keeping track of
-        cat_detail_not_keep = ["Pending"]
+        cat_detail_not_keep = ["PENDING", "YES", "NO", "Pending", "Yes", "No"]
         df = df.query("category_detail not in @cat_detail_not_keep")
 
         # Translate race, ethnicity, and gender (sex) to standard names


### PR DESCRIPTION
TN appears to have slightly changed the variable naming in their XLSX file, which caused us to start collecting duplicate and unnecessary entries. This removes them