### PR TITLE
add 1+ dose values from county level CDC data

### DIFF
--- a/can_tools/scrapers/official/federal/CDC/cdc_county_vaccines.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_county_vaccines.py
@@ -20,6 +20,8 @@ class CDCCountyVaccine(FederalDashboard):
 
     variables = {
         "Series_Complete_Yes": variables.FULLY_VACCINATED_ALL,
+        "Administered_Dose1_Recip": variables.INITIATING_VACCINATIONS_ALL,
+        "Administered_Dose1_Pop_Pct": variables.PERCENTAGE_PEOPLE_INITIATING_VACCINE,
         "Series_Complete_18Plus": CMU(
             category="total_vaccine_completed",
             measurement="cumulative",


### PR DESCRIPTION
CDC has updated their data to include 1+ dose data for ~2700 counties, (they provide vaccine completed data for ~2900 counties).  