### PR TITLE
Fix DC, WA race, VA demographics, WI demographics, DE demographics, ID, and HI vaccine scrapers

### DIFF
--- a/can_tools/scrapers/official/DC/dc_vaccines.py
+++ b/can_tools/scrapers/official/DC/dc_vaccines.py
@@ -35,7 +35,7 @@ class DCVaccine(TableauDashboard):
             data.query(
                 "`Measure Names-alias` in"
                 "['Fully Vaccinated', 'At Least One Dose', 'Total Administrations']"
-                "and `Type of Resident1-value` in"
+                "and `Type of Resident-value` in"
                 "['DC Resident (outside DC)', 'DC Resident (within DC)', 'DC Resident (Federal Entity)']"
             )
             .assign(

--- a/can_tools/scrapers/official/DE/de_vaccine.py
+++ b/can_tools/scrapers/official/DE/de_vaccine.py
@@ -188,7 +188,7 @@ class DelawareVaccineDemographics(DelawareCountyVaccine):
                     if title is not None:
                         # extract table and load into dataframe
                         table = div.find(
-                            "table", class_="c-dash-table__table table table-striped"
+                            "table", class_="table c-dash-table__table table-striped"
                         )
                         table = pd.read_html(str(table))[0].assign(
                             variable=var, location_name=county

--- a/can_tools/scrapers/official/HI/hi_county.py
+++ b/can_tools/scrapers/official/HI/hi_county.py
@@ -29,7 +29,7 @@ class HawaiiVaccineCounty(TableauDashboard):
     # baseurl = "https://public.tableau.com/shared/"
     # viewPath = "7TCBHC568"
     counties = ["Maui", "Hawaii", "Honolulu", "Kauai"]
-    data_tableau_table = "County Progress (JUR+PHARM) (mobile)"
+    data_tableau_table = "Updated County Progress"
 
     variables = {
         "initiated": v.INITIATING_VACCINATIONS_ALL,
@@ -42,29 +42,20 @@ class HawaiiVaccineCounty(TableauDashboard):
         df = (
             data.rename(
                 columns={
-                    "SUM(Population)-alias": "population",
-                    f"AGG(% initiating )-alias": "percent_initiating",
-                    f"AGG(% completing)-alias": "percent_completing",
+                    f"AGG(TOTAL 1st doses)-alias": "initiated",
+                    f"AGG(TOTAL 2nd doses)-alias": "completed",
                     "County-alias": "location_name",
                 }
-            )
-            .loc[
+            ).loc[
                 :,
-                [
-                    "population",
-                    "percent_initiating",
-                    "percent_completing",
-                    "location_name",
-                ],
+                ["initiated", "completed", "location_name", "Measure Names-alias"],
             ]
-            .query("location_name != 0")
-            .assign(
-                initiated=lambda x: x["population"] * x["percent_initiating"],
-                completed=lambda x: x["population"] * x["percent_completing"],
-                dt=self._retrieve_dtm1d("US/Hawaii"),
-            )
+            # The data is repeated twice (with different values of measure name alias)
+            # Slice the data to only get one instance of it
+            .query("`Measure Names-alias` != 'TOTAL State progress 1st dose'")
         )
         out = self._reshape_variables(df, self.variables)
+        out["dt"] = self._retrieve_dt("US/Hawaii")
         return out
 
     def get_filters(self):

--- a/can_tools/scrapers/official/ID/id_county.py
+++ b/can_tools/scrapers/official/ID/id_county.py
@@ -9,7 +9,7 @@ class IdahoCountyVaccine(TableauDashboard):
     location_type = "county"
     source = "https://coronavirus.idaho.gov/"
     source_name = "Idaho Official Government Website"
-    data_tableau_table = "Vax Rate / County Chart"
+    data_tableau_table = "Vax Rate / County Chart (2)"
     baseurl = "https://public.tableau.com"
     viewPath = "COVID-19VaccineDataDashboard/VaccineUptakeIdahoIIS"
     filterFunctionName = "[Parameters].[Map (copy)]"  # set to county level
@@ -41,7 +41,7 @@ class IdahoCountyVaccine(TableauDashboard):
                 "dose_number-value": "dose_number",
             }
         )
-        keep = df[["county", "doses", "dose_number"]]
+        keep = df[["county", "doses", "dose_number"]].drop_duplicates()
         out = (
             keep.pivot(index="county", columns="dose_number", values="doses")
             .reset_index()

--- a/can_tools/scrapers/official/ID/id_county.py
+++ b/can_tools/scrapers/official/ID/id_county.py
@@ -41,6 +41,8 @@ class IdahoCountyVaccine(TableauDashboard):
                 "dose_number-value": "dose_number",
             }
         )
+
+        # duplicate rows (repeated data) were causing the pivot to fail, so remove them
         keep = df[["county", "doses", "dose_number"]].drop_duplicates()
         out = (
             keep.pivot(index="county", columns="dose_number", values="doses")

--- a/can_tools/scrapers/official/VA/va_vaccine.py
+++ b/can_tools/scrapers/official/VA/va_vaccine.py
@@ -167,6 +167,7 @@ class VirginiaCountyVaccineDemographics(VirginiaVaccine):
                 "SUM(Vaccine Status Count)-value": "value",
                 "ATTR(KPI String)-alias": "category",
                 "Age Group-alias": "age",
+                "New Age Group-alias": "age",
             }
         )
         df.category = df.category.str.replace(

--- a/can_tools/scrapers/official/VA/va_vaccine.py
+++ b/can_tools/scrapers/official/VA/va_vaccine.py
@@ -161,6 +161,7 @@ class VirginiaCountyVaccineDemographics(VirginiaVaccine):
     def _normalize_age(self, data):
         df = pd.concat(x["age"] for x in data)
         df["dt"] = self._retrieve_dt()
+        # I've seen the age column be labeled multiple ways, so rename both of them
         df = df.rename(
             columns={
                 "AGG(Locality Name for String)-alias": "location_name",

--- a/can_tools/scrapers/official/WA/wa_vaccine.py
+++ b/can_tools/scrapers/official/WA/wa_vaccine.py
@@ -59,7 +59,7 @@ class WashingtonVaccineCountyRace(MicrosoftBIDashboard):
 
     source = "https://www.doh.wa.gov/Emergencies/COVID19/DataDashboard"
     powerbi_url = "https://wabi-us-gov-virginia-api.analysis.usgovcloudapi.net"
-    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiMTdhMjU3MzktZDI3MS00YWNlLThjNDYtOGI3MjkyMWNjMjQ5IiwidCI6IjExZDBlMjE3LTI2NGUtNDAwYS04YmEwLTU3ZGNjMTI3ZDcyZCJ9"
+    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiMjE4MTA2ZGUtYzQ3NC00MWQ2LTlhOTctODBmMmVlNjU5MWRmIiwidCI6IjExZDBlMjE3LTI2NGUtNDAwYS04YmEwLTU3ZGNjMTI3ZDcyZCJ9"
 
     variables = {
         "initiated": variables.INITIATING_VACCINATIONS_ALL,

--- a/can_tools/scrapers/official/WI/wi_demographic_vaccine.py
+++ b/can_tools/scrapers/official/WI/wi_demographic_vaccine.py
@@ -202,8 +202,9 @@ class WisconsinVaccineCountyRace(WisconsinVaccineStateAge):
         data = data.rename(columns={"AGG(Geography TT)-alias": "location_name"})
         data["location_name"] = (
             data["location_name"]
+            .str.title()
             .str.replace(" County", "")
-            .replace("St Croix", "St. Croix")
+            .replace({"St Croix": "St. Croix", "Fond Du Lac": "Fond du Lac"})
         )
         data[self.demographic_column] = (
             data[self.demographic_column]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ lxml==4.6.2
 sentry-sdk==1.0.0
 jmespath==0.10.0
 textract
+html5lib==1.1


### PR DESCRIPTION
Mostly minor fixes such as renaming columns or data tables. 

HI seems to have fixed their data, and now provides the values they surface on the dashboard, so we no longer have to calculate the values from `population` * `percentage vaccinated`. 

`pd.read_html` requires `html5lib`, so this adds the module to the requirements list. 