### PR TITLE
scraper fixes and removals

### DIFF
--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -55,11 +55,6 @@ from can_tools.scrapers.official.federal.HHS.hhs_state import (
     HHSReportedPatientImpactHospitalCapacityState,
 )
 
-# Scrapers disabled due to source data no longer being updated
-# from can_tools.scrapers.official.FL.fl_vaccine import (
-#     FloridaCountyVaccine,
-#     FloridaCountyVaccineDemographics,
-# )
 from can_tools.scrapers.official.GA.ga_vaccines import (
     GeorgiaCountyVaccine,
     GeorgiaCountyVaccineAge,
@@ -75,7 +70,6 @@ from can_tools.scrapers.official.HI.hi_demographics import (
 
 from can_tools.scrapers.official.ID.id_county import IdahoCountyVaccine
 
-# from can_tools.scrapers.official.IL import IllinoisDemographics, IllinoisHistorical
 from can_tools.scrapers.official.IA.ia_vaccine_county import IowaCountyVaccine
 from can_tools.scrapers.official.ID.id_county import IdahoCountyVaccine
 from can_tools.scrapers.official.IL.il_vaccine import (
@@ -110,7 +104,6 @@ from can_tools.scrapers.official.MT.mt_vaccinations import (
     MontanaStateVaccine,
 )
 
-# from can_tools.scrapers.official.MA import Massachusetts
 from can_tools.scrapers.official.MA.ma_vaccines import MassachusettsVaccineDemographics
 from can_tools.scrapers.official.NC.nc_vaccine import NCVaccine
 from can_tools.scrapers.official.ND.nd_vaccines import NDVaccineCounty
@@ -158,12 +151,6 @@ from can_tools.scrapers.official.SD.sd_vaccine_demographics import (
     SDVaccineAge,
 )
 
-# State provided cases/deaths data is no longer being scraped
-# from can_tools.scrapers.official.TN.tn_state import (
-#     TennesseeAge,
-#     TennesseeAgeByCounty,
-#     TennesseeRaceEthnicitySex,
-# )
 from can_tools.scrapers.official.TN.tn_vaccine import TennesseeVaccineCounty
 from can_tools.scrapers.official.TX.texas_vaccine import (
     TexasCountyVaccine,

--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -54,10 +54,11 @@ from can_tools.scrapers.official.federal.HHS.facility import (
 from can_tools.scrapers.official.federal.HHS.hhs_state import (
     HHSReportedPatientImpactHospitalCapacityState,
 )
-from can_tools.scrapers.official.FL.fl_vaccine import (
-    FloridaCountyVaccine,
-    FloridaCountyVaccineDemographics,
-)
+# Scrapers disabled due to source data no longer being updated
+# from can_tools.scrapers.official.FL.fl_vaccine import (
+#     FloridaCountyVaccine,
+#     FloridaCountyVaccineDemographics,
+# )
 from can_tools.scrapers.official.GA.ga_vaccines import (
     GeorgiaCountyVaccine,
     GeorgiaCountyVaccineAge,
@@ -156,11 +157,12 @@ from can_tools.scrapers.official.SD.sd_vaccine_demographics import (
     SDVaccineAge,
 )
 
-from can_tools.scrapers.official.TN.tn_state import (
-    TennesseeAge,
-    TennesseeAgeByCounty,
-    TennesseeRaceEthnicitySex,
-)
+# State provided cases/deaths data is no longer being scraped
+# from can_tools.scrapers.official.TN.tn_state import (
+#     TennesseeAge,
+#     TennesseeAgeByCounty,
+#     TennesseeRaceEthnicitySex,
+# )
 from can_tools.scrapers.official.TN.tn_vaccine import TennesseeVaccineCounty
 from can_tools.scrapers.official.TX.texas_vaccine import (
     TexasCountyVaccine,

--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -54,6 +54,7 @@ from can_tools.scrapers.official.federal.HHS.facility import (
 from can_tools.scrapers.official.federal.HHS.hhs_state import (
     HHSReportedPatientImpactHospitalCapacityState,
 )
+
 # Scrapers disabled due to source data no longer being updated
 # from can_tools.scrapers.official.FL.fl_vaccine import (
 #     FloridaCountyVaccine,

--- a/can_tools/scrapers/official/ME/me_vaccines.py
+++ b/can_tools/scrapers/official/ME/me_vaccines.py
@@ -96,6 +96,45 @@ class MaineCountyVaccines(MicrosoftBIDashboard):
                                             ),
                                         ],
                                     ),
+                                    # 07/22/21
+                                    # There are 5 counties that have data for AstraZeneca doses (all w/ fewer than 10 initiated doses)
+                                    # The way in which the data is returned is unpredictable b/c there are no completed doses yet
+                                    # In some cases the number of completed doses is returned, in others it is skipped
+                                    # Since the data is stored in a list having a variable # of list items causes issues in parsing the JSON.
+                                    # B/c of this, Astrazeneca doses have been removed until the vaccine is formally approved and counties have data 
+                                    "Where": [
+											{
+												"Condition": {
+                                                    "Not": {
+                                                        "Expression": {
+                                                            "In": {
+                                                                "Expressions": [
+                                                                    {
+                                                                        "Column": {
+                                                                            "Expression": {
+                                                                                "SourceRef": {
+                                                                                    "Source": "c"
+                                                                                }
+                                                                            },
+                                                                            "Property": "Vaccine Manufacturer"
+                                                                        }
+                                                                    }
+                                                                ],
+                                                                "Values": [
+                                                                    [
+                                                                        {
+                                                                            "Literal": {
+                                                                                "Value": "'AstraZeneca'"
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+											}
+										]
                                 }
                             }
                         }
@@ -161,7 +200,6 @@ class MaineCountyVaccines(MicrosoftBIDashboard):
             data_rows.append(row)
 
         df = pd.DataFrame.from_records(data_rows)
-
         # calculate vaccine initiated to match def'n
         df["total_vaccine_initiated"] = (
             df["pfizer_moderna_first_dose"] + df["janssen_series"]
@@ -320,6 +358,37 @@ class MaineRaceVaccines(MicrosoftBIDashboard):
                                                 }
                                             }
                                         },
+                                        {
+                                            "Condition": {
+                                                "Not": {
+                                                    "Expression": {
+                                                        "In": {
+                                                            "Expressions": [
+                                                                {
+                                                                    "Column": {
+                                                                        "Expression": {
+                                                                            "SourceRef": {
+                                                                                "Source": "c1"
+                                                                            }
+                                                                        },
+                                                                        "Property": "Vaccine Manufacturer"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "Values": [
+                                                                [
+                                                                    {
+                                                                        "Literal": {
+                                                                            "Value": "'AstraZeneca'"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+										},
                                     ],
                                 }
                             }
@@ -552,6 +621,37 @@ class MaineAgeVaccines(MaineRaceVaccines):
                                                 }
                                             }
                                         },
+                                        {
+                                            "Condition": {
+                                                "Not": {
+                                                    "Expression": {
+                                                        "In": {
+                                                            "Expressions": [
+                                                                {
+                                                                    "Column": {
+                                                                        "Expression": {
+                                                                            "SourceRef": {
+                                                                                "Source": "c1"
+                                                                            }
+                                                                        },
+                                                                        "Property": "Vaccine Manufacturer"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "Values": [
+                                                                [
+                                                                    {
+                                                                        "Literal": {
+                                                                            "Value": "'AstraZeneca'"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+										},
                                     ],
                                 }
                             }

--- a/can_tools/scrapers/official/ME/me_vaccines.py
+++ b/can_tools/scrapers/official/ME/me_vaccines.py
@@ -101,40 +101,40 @@ class MaineCountyVaccines(MicrosoftBIDashboard):
                                     # The way in which the data is returned is unpredictable b/c there are no completed doses yet
                                     # In some cases the number of completed doses is returned, in others it is skipped
                                     # Since the data is stored in a list having a variable # of list items causes issues in parsing the JSON.
-                                    # B/c of this, Astrazeneca doses have been removed until the vaccine is formally approved and counties have data 
+                                    # B/c of this, Astrazeneca doses have been removed until the vaccine is formally approved and counties have data
                                     "Where": [
-											{
-												"Condition": {
-                                                    "Not": {
-                                                        "Expression": {
-                                                            "In": {
-                                                                "Expressions": [
+                                        {
+                                            "Condition": {
+                                                "Not": {
+                                                    "Expression": {
+                                                        "In": {
+                                                            "Expressions": [
+                                                                {
+                                                                    "Column": {
+                                                                        "Expression": {
+                                                                            "SourceRef": {
+                                                                                "Source": "c"
+                                                                            }
+                                                                        },
+                                                                        "Property": "Vaccine Manufacturer",
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "Values": [
+                                                                [
                                                                     {
-                                                                        "Column": {
-                                                                            "Expression": {
-                                                                                "SourceRef": {
-                                                                                    "Source": "c"
-                                                                                }
-                                                                            },
-                                                                            "Property": "Vaccine Manufacturer"
+                                                                        "Literal": {
+                                                                            "Value": "'AstraZeneca'"
                                                                         }
                                                                     }
-                                                                ],
-                                                                "Values": [
-                                                                    [
-                                                                        {
-                                                                            "Literal": {
-                                                                                "Value": "'AstraZeneca'"
-                                                                            }
-                                                                        }
-                                                                    ]
                                                                 ]
-                                                            }
+                                                            ],
                                                         }
                                                     }
                                                 }
-											}
-										]
+                                            }
+                                        }
+                                    ],
                                 }
                             }
                         }
@@ -371,7 +371,7 @@ class MaineRaceVaccines(MicrosoftBIDashboard):
                                                                                 "Source": "c1"
                                                                             }
                                                                         },
-                                                                        "Property": "Vaccine Manufacturer"
+                                                                        "Property": "Vaccine Manufacturer",
                                                                     }
                                                                 }
                                                             ],
@@ -383,12 +383,12 @@ class MaineRaceVaccines(MicrosoftBIDashboard):
                                                                         }
                                                                     }
                                                                 ]
-                                                            ]
+                                                            ],
                                                         }
                                                     }
                                                 }
                                             }
-										},
+                                        },
                                     ],
                                 }
                             }
@@ -634,7 +634,7 @@ class MaineAgeVaccines(MaineRaceVaccines):
                                                                                 "Source": "c1"
                                                                             }
                                                                         },
-                                                                        "Property": "Vaccine Manufacturer"
+                                                                        "Property": "Vaccine Manufacturer",
                                                                     }
                                                                 }
                                                             ],
@@ -646,12 +646,12 @@ class MaineAgeVaccines(MaineRaceVaccines):
                                                                         }
                                                                     }
                                                                 ]
-                                                            ]
+                                                            ],
                                                         }
                                                     }
                                                 }
                                             }
-										},
+                                        },
                                     ],
                                 }
                             }

--- a/can_tools/scrapers/official/ND/nd_vaccines.py
+++ b/can_tools/scrapers/official/ND/nd_vaccines.py
@@ -499,18 +499,21 @@ class NDVaccineCounty(MicrosoftBIDashboard):
         # combine first dose rows with fully vaccinated rows
         data_rows = first_dose_data_rows + fully_vaccinated_data_rows
 
-        # multiply percentages per county by populations to get actual number of people
+        non_counties = ["ND-COUNTY UNKNOWN"]
         data_rows_with_population = []
+
+        # multiply percentages per county by populations to get actual number of people
         for i, row in enumerate(data_rows):
             county_name = row["county"]
+            if county_name in non_counties:
+                continue
 
             # differentiate dose type from `at_least_one_dose` and `fully_vaccinated`
             keys = list(row.keys())
             dose_type = keys[1]
             dose_percentage = float(row[dose_type])
 
-            if county_name in nd_populations:
-                doses = int(dose_percentage * nd_populations[county_name])
+            doses = int(dose_percentage * nd_populations[county_name])
 
             row_with_population = {
                 "county": county_name,

--- a/can_tools/scrapers/official/SD/sd_vaccines.py
+++ b/can_tools/scrapers/official/SD/sd_vaccines.py
@@ -25,31 +25,6 @@ class SDVaccineCounty(MicrosoftBIDashboard):
         "total_vaccine_initiated": variables.INITIATING_VACCINATIONS_ALL,
         "total_vaccine_doses_administered": variables.TOTAL_DOSES_ADMINISTERED_ALL,
         "total_vaccine_completed": variables.FULLY_VACCINATED_ALL,
-        "moderna_1_dose": CMU(
-            category="moderna_vaccine_initiated",
-            measurement="cumulative",
-            unit="people",
-        ),
-        "pfizer_1_dose": CMU(
-            category="pfizer_vaccine_initiated",
-            measurement="cumulative",
-            unit="people",
-        ),
-        "moderna_complete": CMU(
-            category="moderna_vaccine_completed",
-            measurement="cumulative",
-            unit="people",
-        ),
-        "pfizer_complete": CMU(
-            category="pfizer_vaccine_completed",
-            measurement="cumulative",
-            unit="people",
-        ),
-        "janssen_series": CMU(
-            category="janssen_vaccine_completed",
-            measurement="cumulative",
-            unit="people",
-        ),
     }
 
     def construct_body(self, resource_key, ds_id, model_id, report_id, counties):
@@ -198,11 +173,11 @@ class SDVaccineCounty(MicrosoftBIDashboard):
         col_mapping = {
             "G0": "county",
             "M_0_DM2_0_A1": "total_vaccine_initiated",
-            "M_1_DM3_0_C_1": "janssen_series",
-            "M_1_DM3_1_C_1": "moderna_1_dose",
-            "M_1_DM3_2_C_1": "moderna_complete",
-            "M_1_DM3_3_C_1": "pfizer_1_dose",
-            "M_1_DM3_4_C_1": "pfizer_complete",
+            "M_1_DM3_1_C_1": "janssen_series",
+            "M_1_DM3_2_C_1": "moderna_1_dose",
+            "M_1_DM3_3_C_1": "moderna_complete",
+            "M_1_DM3_4_C_1": "pfizer_1_dose",
+            "M_1_DM3_5_C_1": "pfizer_complete",
         }
         data_rows = []
         for record in data:
@@ -218,7 +193,6 @@ class SDVaccineCounty(MicrosoftBIDashboard):
 
         # Dump records into a DataFrame and transform
         df = pd.DataFrame.from_records(data_rows)
-
         # calculate metrics to match our def'ns
         df["total_vaccine_completed"] = (
             df["janssen_series"] + df["moderna_complete"] + df["pfizer_complete"]

--- a/can_tools/scrapers/official/WA/wa_vaccine.py
+++ b/can_tools/scrapers/official/WA/wa_vaccine.py
@@ -59,7 +59,7 @@ class WashingtonVaccineCountyRace(MicrosoftBIDashboard):
 
     source = "https://www.doh.wa.gov/Emergencies/COVID19/DataDashboard"
     powerbi_url = "https://wabi-us-gov-virginia-api.analysis.usgovcloudapi.net"
-    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiMjE4MTA2ZGUtYzQ3NC00MWQ2LTlhOTctODBmMmVlNjU5MWRmIiwidCI6IjExZDBlMjE3LTI2NGUtNDAwYS04YmEwLTU3ZGNjMTI3ZDcyZCJ9"
+    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiZTZhOTlkYzgtMTlkYi00OWEzLTg2NjUtN2FmODgxNzZkMzA2IiwidCI6IjExZDBlMjE3LTI2NGUtNDAwYS04YmEwLTU3ZGNjMTI3ZDcyZCJ9"
 
     variables = {
         "initiated": variables.INITIATING_VACCINATIONS_ALL,

--- a/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
@@ -80,9 +80,10 @@ class CDCCovidDataTracker(FederalDashboard):
             ignore_index=True,
         )
 
+        # We have no way to handle suppressed entries, so remove them
         df = self._rename_or_add_date_and_location(
             df, location_column="fips_code", date_column="date"
-        )
+        ).replace("suppressed", None)
 
         df = self._reshape_variables(df, self.variables)
         return df


### PR DESCRIPTION
- CDCCovidDataTracker began returning suppressed values, causing the scraper to break. This removes those entries, I'm not sure if there is a more graceful way to handle this. 

- The FL scrapers were collecting old data (from June) because the PDF they scrape has not been updated. The TN scrapers were collecting cases and deaths data, so I've disabled them. 

Maine:

-  Removed AstraZeneca doses for the time being, because the variability in which they are reported would mean re-structuring how we parse the JSON, which does not seem worth doing at the moment (when the number of doses is only in the double digits). The reporting should stabilize once the vaccine is approved/more widespread, at which point the query condition should be removed. 

SD:
- Fixed the JSON parse-key ordering (the indices of each dose shifted by one in the list that they're returned in).
- Removed the manufacturer-specific doses from the variables, as I don't believe we have any use for them. 
