### PR TITLE
Automatically fetch WA iframe url, VA demographics column name fix

### DIFF
--- a/can_tools/scrapers/official/VA/va_vaccine.py
+++ b/can_tools/scrapers/official/VA/va_vaccine.py
@@ -14,7 +14,7 @@ class VirginiaVaccine(TableauDashboard):
     baseurl = "https://vdhpublicdata.vdh.virginia.gov"
     provider = "state"
     has_location = True
-    location_type = ""
+    location_type = "county"
     filterFunctionName = None
     viewPath = "VirginiaCOVID-19Dashboard-VaccineSummary/VirginiaCOVID-19VaccineSummary"
 
@@ -161,7 +161,7 @@ class VirginiaCountyVaccineDemographics(VirginiaVaccine):
     def _normalize_age(self, data):
         df = pd.concat(x["age"] for x in data)
         df["dt"] = self._retrieve_dt()
-        # I've seen the age column be labeled multiple ways, so rename both of them
+        # I've seen the age column be labeled multiple ways, so rename all of them
         df = df.rename(
             columns={
                 "AGG(Locality Name for String)-alias": "location_name",
@@ -169,6 +169,7 @@ class VirginiaCountyVaccineDemographics(VirginiaVaccine):
                 "ATTR(KPI String)-alias": "category",
                 "Age Group-alias": "age",
                 "New Age Group-alias": "age",
+                "Cases and Vaccine Age Group-alias": "age",
             }
         )
         df.category = df.category.str.replace(

--- a/can_tools/scrapers/official/WA/wa_vaccine.py
+++ b/can_tools/scrapers/official/WA/wa_vaccine.py
@@ -86,7 +86,7 @@ class WashingtonVaccineCountyRace(MicrosoftBIDashboard):
     async def _get_from_browser(self):
         """use an async function to wait until the javascript has loaded to extract the iframe url.
 
-        The page is protected by a "no-javascript" blocker, so we cannot parse the html directly with an lxml/html parser.
+        The page is protected by a "no-javascript" blocker, so we cannot parse the html directly.
         """
         browser = await launch()
         page = await browser.newPage()

--- a/can_tools/scrapers/official/WA/wa_vaccine.py
+++ b/can_tools/scrapers/official/WA/wa_vaccine.py
@@ -3,6 +3,9 @@ import asyncio
 import pandas as pd
 import us
 import os
+import re
+from pyppeteer import launch
+
 
 from can_tools.scrapers import variables
 from can_tools.scrapers.official.base import StateDashboard, MicrosoftBIDashboard
@@ -59,7 +62,6 @@ class WashingtonVaccineCountyRace(MicrosoftBIDashboard):
 
     source = "https://www.doh.wa.gov/Emergencies/COVID19/DataDashboard"
     powerbi_url = "https://wabi-us-gov-virginia-api.analysis.usgovcloudapi.net"
-    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiZTZhOTlkYzgtMTlkYi00OWEzLTg2NjUtN2FmODgxNzZkMzA2IiwidCI6IjExZDBlMjE3LTI2NGUtNDAwYS04YmEwLTU3ZGNjMTI3ZDcyZCJ9"
 
     variables = {
         "initiated": variables.INITIATING_VACCINATIONS_ALL,
@@ -81,9 +83,26 @@ class WashingtonVaccineCountyRace(MicrosoftBIDashboard):
         "8": "pacific_islander",
     }
 
+    async def _get_from_browser(self):
+        """use an async function to wait until the javascript has loaded to extract the iframe url.
+
+        The page is protected by a "no-javascript" blocker, so we parse the html directly with an lxml/html parser.
+        """
+        browser = await launch()
+        page = await browser.newPage()
+        await page.goto(self.source)
+
+        sel = "#dnn_ctr34282_HtmlModule_lblContent div"
+        # wait until element that contains the iframe url has loaded into the page
+        iframe_div = await page.waitForSelector(sel)
+        iframe = await page.J(sel)
+        iframe = await page.evaluate(" x => x.outerHTML", iframe)
+        await browser.close()
+
+        return {"src": re.findall(r'pbi-resize-src="(.*?)"', iframe)[0]}
+
     def get_dashboard_iframe(self):
-        fumn = {"src": self.powerbi_dashboard_link}
-        return fumn
+        return asyncio.get_event_loop().run_until_complete(self._get_from_browser())
 
     def construct_body(self, resource_key, ds_id, model_id, report_id, county):
         "Build body request"

--- a/can_tools/scrapers/official/WA/wa_vaccine.py
+++ b/can_tools/scrapers/official/WA/wa_vaccine.py
@@ -86,7 +86,7 @@ class WashingtonVaccineCountyRace(MicrosoftBIDashboard):
     async def _get_from_browser(self):
         """use an async function to wait until the javascript has loaded to extract the iframe url.
 
-        The page is protected by a "no-javascript" blocker, so we parse the html directly with an lxml/html parser.
+        The page is protected by a "no-javascript" blocker, so we cannot parse the html directly with an lxml/html parser.
         """
         browser = await launch()
         page = await browser.newPage()


### PR DESCRIPTION
use asyncio to bypass WA's no-javascript blocker, so that the iframe URL will no longer have to be manually updated