### PR TITLE
modify WA demographic async method

### DIFF
--- a/can_tools/scrapers/official/WA/wa_vaccine.py
+++ b/can_tools/scrapers/official/WA/wa_vaccine.py
@@ -84,6 +84,10 @@ class WashingtonVaccineCountyRace(MicrosoftBIDashboard):
     }
 
     async def _get_from_browser(self):
+        """use an async function to wait until the javascript has loaded to extract the iframe url.
+
+        The page is protected by a "no-javascript" blocker, so we cannot parse the html directly.
+        """
         async with with_page(headless=True) as page:
             await page.goto(self.source)
             sel = "#dnn_ctr34282_HtmlModule_lblContent div"

--- a/can_tools/scrapers/official/WA/wa_vaccine.py
+++ b/can_tools/scrapers/official/WA/wa_vaccine.py
@@ -92,7 +92,6 @@ class WashingtonVaccineCountyRace(MicrosoftBIDashboard):
             await page.goto(self.source)
             sel = "#dnn_ctr34282_HtmlModule_lblContent div"
             iframe_div = await page.waitForSelector(sel)
-            print("found iframe!")
             iframe = await page.J(sel)
             iframe = await page.evaluate(" x => x.outerHTML", iframe)
             return {"src": re.findall(r'pbi-resize-src="(.*?)"', iframe)[0]}

--- a/can_tools/scrapers/official/WA/wa_vaccine.py
+++ b/can_tools/scrapers/official/WA/wa_vaccine.py
@@ -84,22 +84,14 @@ class WashingtonVaccineCountyRace(MicrosoftBIDashboard):
     }
 
     async def _get_from_browser(self):
-        """use an async function to wait until the javascript has loaded to extract the iframe url.
-
-        The page is protected by a "no-javascript" blocker, so we cannot parse the html directly.
-        """
-        browser = await launch()
-        page = await browser.newPage()
-        await page.goto(self.source)
-
-        sel = "#dnn_ctr34282_HtmlModule_lblContent div"
-        # wait until element that contains the iframe url has loaded into the page
-        iframe_div = await page.waitForSelector(sel)
-        iframe = await page.J(sel)
-        iframe = await page.evaluate(" x => x.outerHTML", iframe)
-        await browser.close()
-
-        return {"src": re.findall(r'pbi-resize-src="(.*?)"', iframe)[0]}
+        async with with_page(headless=True) as page:
+            await page.goto(self.source)
+            sel = "#dnn_ctr34282_HtmlModule_lblContent div"
+            iframe_div = await page.waitForSelector(sel)
+            print("found iframe!")
+            iframe = await page.J(sel)
+            iframe = await page.evaluate(" x => x.outerHTML", iframe)
+            return {"src": re.findall(r'pbi-resize-src="(.*?)"', iframe)[0]}
 
     def get_dashboard_iframe(self):
         return asyncio.get_event_loop().run_until_complete(self._get_from_browser())


### PR DESCRIPTION
updates the async  `_get_from_browser()` method to match the syntax of the method in the WA county scraper. The previous syntax did not work on the server (the connection would hang/timeout), so this should resolve that issue. 