### PR TITLE
update CDC data tracker to pull from county endpoints

### DIFF
--- a/can_tools/scrapers/official/base.py
+++ b/can_tools/scrapers/official/base.py
@@ -17,7 +17,6 @@ import requests
 from bs4 import BeautifulSoup
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.orm.session import sessionmaker
-from us.states import VA
 
 from can_tools.db_util import fast_append_to_sql
 from can_tools.models import (
@@ -183,8 +182,8 @@ class StateDashboard(DatasetBase, ABC):
         as_series: Optional[bool] = False,
         replace: Optional[Dict[str, str]] = None,
         state: Optional[us.states.State] = None,
-        fips: Optional[bool] = False
-        ):
+        fips: Optional[bool] = False,
+    ):
         """Get a list of all counties in current state"""
         """
         as_series: 
@@ -201,16 +200,16 @@ class StateDashboard(DatasetBase, ABC):
 
         if state is not None:
             query = f"state == {int(state.fips)} and location != {int(state.fips)}"
-        elif hasattr(self, 'state_fips') is not None:
+        elif hasattr(self, "state_fips") is not None:
             query = f"state == {self.state_fips} and location != {self.state_fips}"
         else:
-            raise ValueError("directly provide a state or ensure parent class has the state_fips attribute")
+            raise ValueError(
+                "directly provide a state or ensure parent class has the state_fips attribute"
+            )
 
         if fips:
             counties = (
-                pd.read_csv(path).query(query)["location"]
-                .astype(str)
-                .str.zfill(5)
+                pd.read_csv(path).query(query)["location"].astype(str).str.zfill(5)
             )
         else:
             counties = pd.read_csv(path).query(query)["name"]

--- a/can_tools/scrapers/official/base.py
+++ b/can_tools/scrapers/official/base.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import re
+import os
+import us
 import urllib.parse
 import uuid
 from abc import ABC, abstractmethod
@@ -15,6 +17,7 @@ import requests
 from bs4 import BeautifulSoup
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.orm.session import sessionmaker
+from us.states import VA
 
 from can_tools.db_util import fast_append_to_sql
 from can_tools.models import (
@@ -174,6 +177,50 @@ class StateDashboard(DatasetBase, ABC):
             data["vintage"] = self._retrieve_vintage()
 
         return data
+
+    def _retrieve_counties(
+        self,
+        as_series: Optional[bool] = False,
+        replace: Optional[Dict[str, str]] = None,
+        state: Optional[us.states.State] = None,
+        fips: Optional[bool] = False
+        ):
+        """Get a list of all counties in current state"""
+        """
+        as_series: 
+            Returns counties as a list by default. If True, returns counties as a pd.Series
+        fips:
+            return list of fips code if fips is specified, else return county names
+        state:
+            a state to fetch locations for. A state must either be specified, or the parent class must
+            have the state_fips attribute. In the instance where both are present, the state parameter is preferred
+        replace: 
+            Dictionary of county names to replace, formatted as {old_value: new_value}
+        """
+        path = os.path.dirname(__file__) + "/../../bootstrap_data/locations.csv"
+
+        if state is not None:
+            query = f"state == {int(state.fips)} and location != {int(state.fips)}"
+        elif hasattr(self, 'state_fips') is not None:
+            query = f"state == {self.state_fips} and location != {self.state_fips}"
+        else:
+            raise ValueError("directly provide a state or ensure parent class has the state_fips attribute")
+
+        if fips:
+            counties = (
+                pd.read_csv(path).query(query)["location"]
+                .astype(str)
+                .str.zfill(5)
+            )
+        else:
+            counties = pd.read_csv(path).query(query)["name"]
+
+        if replace is not None:
+            counties = counties.replace(replace)
+        if not as_series:
+            return list(counties)
+        else:
+            return counties.reset_index(drop=True)
 
     def _rename_or_add_date_and_location(
         self,

--- a/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py
@@ -4,7 +4,7 @@ import pandas as pd
 import requests
 import us
 
-from can_tools.scrapers.base import ALL_STATES_PLUS_DC, CMU
+from can_tools.scrapers.base import CMU
 from can_tools.scrapers.official.base import FederalDashboard
 
 
@@ -22,7 +22,7 @@ class CDCCovidDataTracker(FederalDashboard):
         "new_deaths_7_day_rolling_average": CMU(
             category="deaths", measurement="rolling_average_7_day", unit="people"
         ),
-        "percent_positive_7_day": CMU(
+        "percent_new_test_results_reported_positive_7_day_rolling_average": CMU(
             category="pcr_tests_positive",
             measurement="rolling_average_7_day",
             unit="percentage",
@@ -52,16 +52,15 @@ class CDCCovidDataTracker(FederalDashboard):
         self.exceptions = []
         fetcher_url = (
             "https://covid.cdc.gov/covid-data-tracker/COVIDData/"
-            "getAjaxData?id=integrated_county_timeseries_state_{}_external"
+            "getAjaxData?id=integrated_county_timeseries_fips_{}_external"
         )
 
         if self.state:
-            states = [self.state]
+            counties = self._retrieve_counties(state=self.state, fips=True)
         else:
-            states = ALL_STATES_PLUS_DC
+            raise ValueError("please specify state to fetch data for")
 
-        urls = [fetcher_url.format(state.abbr.lower()) for state in states]
-
+        urls = [fetcher_url.format(county) for county in counties]
         responses = [requests.get(url) for url in urls]
 
         bad_idx = [i for (i, r) in enumerate(responses) if not r.ok]


### PR DESCRIPTION
This re-purposes and replaces the existing functionality that allows the scraper to be run for all states at once to instead fetch all the counties within one state. Each state is then added as a task to a [prefect flow](https://github.com/covid-projections/can-scrapers/blob/main/can_tools/scrapers/official/federal/CDC/cdc_coviddatatracker.py). 



pulled in the `_retrieve_counties()` method from [existing branch](https://github.com/covid-projections/can-scrapers/compare/create_get_counties_method).