### PR TITLE
add duplicate row removal to _reshape_variables

### DIFF
--- a/can_tools/scrapers/official/base.py
+++ b/can_tools/scrapers/official/base.py
@@ -175,7 +175,7 @@ class StateDashboard(DatasetBase, ABC):
         if "vintage" not in data.columns:
             data["vintage"] = self._retrieve_vintage()
 
-        return data
+        return data.drop_duplicates()
 
     def _retrieve_counties(
         self,

--- a/can_tools/scrapers/official/base.py
+++ b/can_tools/scrapers/official/base.py
@@ -139,7 +139,7 @@ class StateDashboard(DatasetBase, ABC):
             Map from column name to output variables
         id_vars: Optional[List[str]], (default=None)
             Variables that should be included as "id_vars" when melting from wide to long
-        drop_duplicates: 
+        drop_duplicates:
             if true duplicate rows are removed, else they are ignored
         kwargs:
             Other kwargs to pass to `self.extract_CMU`

--- a/can_tools/scrapers/official/base.py
+++ b/can_tools/scrapers/official/base.py
@@ -126,6 +126,7 @@ class StateDashboard(DatasetBase, ABC):
         data: pd.DataFrame,
         variable_map: Dict[str, CMU],
         id_vars: Optional[List[str]] = None,
+        drop_duplicates: Optional[bool] = False,
         **kwargs,
     ) -> pd.DataFrame:
         """Reshape columns in data to be long form definitions defined in `variable_map`.
@@ -138,6 +139,8 @@ class StateDashboard(DatasetBase, ABC):
             Map from column name to output variables
         id_vars: Optional[List[str]], (default=None)
             Variables that should be included as "id_vars" when melting from wide to long
+        drop_duplicates: 
+            if true duplicate rows are removed, else they are ignored
         kwargs:
             Other kwargs to pass to `self.extract_CMU`
 
@@ -174,8 +177,10 @@ class StateDashboard(DatasetBase, ABC):
 
         if "vintage" not in data.columns:
             data["vintage"] = self._retrieve_vintage()
+        if drop_duplicates:
+            data = data.drop_duplicates()
 
-        return data.drop_duplicates()
+        return data
 
     def _retrieve_counties(
         self,


### PR DESCRIPTION
some instances of the `CDCCovidDataTracker` were failing on insertion into the database (`put()`) because of duplicated entries in the dataframe. 

There shouldn't ever be duplicated rows in the scraper output data (as far as I can think of), so this adds a line to remove them. `_reshape_variables()` is a helper method used by many scrapers (including `CDCCovidDataTracker`) to format the data