### PR TITLE
remove duplicate rows from CDC Vaccine Source

### DIFF
--- a/can_tools/scrapers/official/federal/CDC/cdc_historical_vaccine.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_historical_vaccine.py
@@ -24,7 +24,7 @@ class CDCCountyVaccine2(FederalDashboard):
         out = self._rename_or_add_date_and_location(
             data, location_column="FIPS", date_column="Date", locations_to_drop=["UNK"]
         )
-        out = self._reshape_variables(out, self.variables)
+        out = self._reshape_variables(out, self.variables, drop_duplicates=True)
 
         # an alaska county was renamed in 2014 and given a new fips: update from the old fips (2270) to the new (2158)
         # source: https://www.cdc.gov/nchs/data/data_acces_files/County-Geography.pdf


### PR DESCRIPTION
[CDC vaccine source has some duplicate rows,](https://data.cdc.gov/Vaccinations/COVID-19-Vaccinations-in-the-United-States-County/8xkx-amqh/data) causing the scraper to fail--this removes them.

For example:
<img width="794" alt="image" src="https://user-images.githubusercontent.com/55333380/134816941-e44ae1fd-86e8-4e18-b311-13066b80e3bd.png">
