### PR TITLE
replace CDCCovidDataTracker with official CDC testing dataset

### DIFF
--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -36,6 +36,9 @@ from can_tools.scrapers.official.DC.dc_vaccines import (
 from can_tools.scrapers.official.federal.CDC.cdc_coviddatatracker import (
     CDCCovidDataTracker,
 )
+
+from can_tools.scrapers.official.federal.CDC.cdc_testing_cases import CDCHistoricalTestingDataset
+
 from can_tools.scrapers.official.federal.CDC.cdc_vaccines import (
     CDCStateVaccine,
     CDCUSAVaccine,

--- a/can_tools/scrapers/base.py
+++ b/can_tools/scrapers/base.py
@@ -609,25 +609,6 @@ class DatasetBase(ABC):
         "Internal _put method for dumping data using TempTable class"
         pass
 
-    def find_unknown_variable_id(self, engine: Engine, df: pd.DataFrame):
-        variables = pd.read_sql("select * from covid_variables", engine)
-        merged = df.merge(variables, on=["category", "measurement", "unit"], how="left")
-        bad = merged["id"].isna()
-        return df.loc[bad, :]
-
-    def find_unknown_location_id(self, engine: Engine, df: pd.DataFrame):
-        locs = pd.read_sql("select * from locations", engine)
-        good_rows = df.location_name.isin(
-            locs.loc[locs.state_fips == self.state_fips, :].name
-        )
-        return df.loc[~good_rows, :]
-
-    def find_unknown_demographic_id(self, engine: Engine, df: pd.DataFrame):
-        dems = pd.read_sql("select * from covid_demographics", engine)
-        merged = df.merge(dems, on=["sex", "age", "race", "ethnicity"], how="left")
-        bad = list(merged["id"].isna())
-        return df.loc[bad, :]
-
     def fetch_normalize(self):
         "Call `self.normalize(self.fetch())`"
         data = self.fetch()

--- a/can_tools/scrapers/official/federal/CDC/cdc_testing_cases.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_testing_cases.py
@@ -15,6 +15,9 @@ class CDCHistoricalTestingDataset(FederalDashboard):
     location_type = "county"
     source = "https://data.cdc.gov/Public-Health-Surveillance/United-States-COVID-19-County-Level-of-Community-T/nra9-vzzn/data"
     source_name = "Centers for Disease Control and Prevention"
+    # We also collect CDC testing data via the CDCCovidDataTracker class. 
+    # In order to not overwrite/mix the data sources we use the cdc2 provider instead of cdc.
+    # 11/1/21: This is the offical CDC testing dataset and the one that is used by the pipeline downstream.
     provider = "cdc2"
 
     # SODA API stream has different variable names than the CSV and online dataset -- but the columns appear to be the same.

--- a/can_tools/scrapers/official/federal/CDC/cdc_testing_cases.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_testing_cases.py
@@ -1,0 +1,59 @@
+from typing import Dict
+
+import pandas as pd
+
+from can_tools.scrapers.base import CMU
+from can_tools.scrapers.official.base import FederalDashboard
+
+# Set the maximum number of records to ten million to ensure we collect all rows in the dataset.
+# Currently the size of the dataset is 2 million records, so this may need to be updated (increased)
+# in the future
+SODA_API_RESPONSE_LIMIT = 10000000
+
+class CDCHistoricalTestingDataset(FederalDashboard):
+    has_location = True
+    location_type = "county"
+    source = "https://data.cdc.gov/Public-Health-Surveillance/United-States-COVID-19-County-Level-of-Community-T/nra9-vzzn/data"
+    source_name = "Centers for Disease Control and Prevention"
+    provider = "cdc2"
+
+    # SODA API stream has different variable names than the CSV and online dataset -- but the columns appear to be the same.
+    variables = {
+        "cases_per_100k_7_day_count": CMU(
+            category="cases", measurement="rolling_average_7_day", unit="people"
+        ),
+        "percent_test_results_reported": CMU(
+            category="pcr_tests_positive",
+            measurement="rolling_average_7_day",
+            unit="percentage",
+        ),
+    }
+
+    def fetch(self) -> pd.DataFrame:
+        # select only the columns we care about in order to speed up query
+        data = pd.read_json(
+            f"https://data.cdc.gov/resource/nra9-vzzn.json?$limit={SODA_API_RESPONSE_LIMIT}"
+            "&$select=fips_code,date,cases_per_100k_7_day_count,percent_test_results_reported"
+        )
+        if len(data) == SODA_API_RESPONSE_LIMIT:
+            raise ValueError(
+                f"Size of the dataset has reached the currently set API response limit of {SODA_API_RESPONSE_LIMIT}. "
+                "Please increase the limit by modifying SODA_API_RESPONSE_LIMIT."
+            )
+        return data
+
+    def normalize(self, data: pd.DataFrame) -> pd.DataFrame:
+        return (
+            # remove suppressed values as we have no way to handle them
+            data.replace("suppressed", None)
+            # 02066, Copper River Census Area is a new area established in 2019.
+            # We currently do not track it, and instead track Valdez-Cordova Census Area,
+            # the census area from which Copper River split.
+            # https://en.wikipedia.org/wiki/Copper_River_Census_Area,_Alaska
+            .pipe(
+                self._rename_or_add_date_and_location,
+                location_column="fips_code",
+                date_column="date",
+                locations_to_drop=[2066],
+            ).pipe(self._reshape_variables, variable_map=self.variables)
+        )

--- a/can_tools/utils.py
+++ b/can_tools/utils.py
@@ -1,6 +1,7 @@
 from typing import Optional
 import pandas as pd
 import sqlalchemy as sa
+from sqlalchemy.engine.base import Engine
 
 
 def determine_location_column(df: pd.DataFrame) -> str:
@@ -42,3 +43,26 @@ def load_most_recent_cdc(
         pd.DataFrame: DataFrame with CDC Covid Tracker data
     """
     pass
+
+
+def find_unknown_variable_id(engine: Engine, df: pd.DataFrame):
+    """Find any CMU variables in the specified dataframe that do not match an entry in the covid_variables file"""
+    variables = pd.read_sql("select * from covid_variables", engine)
+    merged = df.merge(variables, on=["category", "measurement", "unit"], how="left")
+    bad = merged["id"].isna()
+    return df.loc[bad, :]
+
+def find_unknown_location_id(engine: Engine, df: pd.DataFrame, state_fips: int):
+    """Find any locations in the specified dataframe that do not match an entry in the locations file"""
+    locs = pd.read_sql("select * from locations", engine)
+    good_rows = df.location_name.isin(
+        locs.loc[locs.state_fips == state_fips, :].name
+    )
+    return df.loc[~good_rows, :]
+
+def find_unknown_demographic_id(engine: Engine, df: pd.DataFrame):
+    """Find any demographic pairs in the specified dataframe that do not match an entry in the covid_demographics file"""
+    dems = pd.read_sql("select * from covid_demographics", engine)
+    merged = df.merge(dems, on=["sex", "age", "race", "ethnicity"], how="left")
+    bad = list(merged["id"].isna())
+    return df.loc[bad, :]


### PR DESCRIPTION
Creates a scraper for the new CDC testing dataset.

With this dataset, I think `CDCCovidDataTracker()` becomes obsolete. The new dataset does not track rolling average deaths, or rolling average total tests as the internal data tracker did, but this data was never used anywhere in the pipeline anyway. 

The data in this [historical dataset](https://data.cdc.gov/Public-Health-Surveillance/United-States-COVID-19-County-Level-of-Community-T/nra9-vzzn) lags behind the ["as originally posted"](https://data.cdc.gov/Public-Health-Surveillance/United-States-COVID-19-County-Level-of-Community-T/8396-v7yb) dataset, but includes history going back to the start of 2021 (as opposed to august 2021) and accounts for corrections, updates and other changes in the data over time (whereas the other only reports the initially reported values.)

With this update I think the only necessary change will be to [change the provider](https://github.com/covid-projections/covid-data-model/compare/smcclure17-update-test-source) of the CDC testing dataset source in covid-data-model. If this is checked in, I can create a test snapshot. 

