### PR TITLE
Add bootstrap CSVs script and github action workflow.

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,27 @@
+name: Bootstrap CSVs
+
+on:
+  push:
+    paths:
+      - "can_tools/bootstrap_data"
+    branches:
+      - main
+
+env:
+  CAN_SCRAPERS_DB_URL: ${{ secrets.CAN_SCRAPERS_DB_URL }}
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Install dependencies
+        run: |
+          pip install -e .
+      - name: Bootstrap
+        run: python can_tools/bootstrap.py
+

--- a/can_tools/bootstrap.py
+++ b/can_tools/bootstrap.py
@@ -1,0 +1,14 @@
+import os
+import sqlalchemy.orm as sa_orm
+import sqlalchemy as sa
+from can_tools.models import bootstrap
+
+db_url = os.environ.get('CAN_SCRAPERS_DB_URL')
+if not db_url:
+    raise RuntimeError('Missing CAN_SCRAPERS_DB_URL environment variable.')
+
+engine = sa.create_engine(db_url, echo=False)
+Session = sa_orm.sessionmaker(bind=engine)
+sess = Session(bind=engine)
+
+bootstrap(sess, delete_first=False)


### PR DESCRIPTION
This wires up the bootstrap action to run automatically after pushes to main of can_tools/bootstrap_data/* files.