### PR TITLE
Use Prefect logger to log TableauScraper version

### DIFF
--- a/can_tools/scrapers/official/NH/nh_demographics.py
+++ b/can_tools/scrapers/official/NH/nh_demographics.py
@@ -5,7 +5,7 @@ from can_tools.scrapers import variables
 import multiprocessing
 from functools import partial
 import pkg_resources
-import logging
+import prefect
 
 
 from can_tools.scrapers.official.base import StateDashboard
@@ -45,8 +45,8 @@ class NHVaccineRace(StateDashboard):
     def fetch(self):
 
         ts_version = pkg_resources.get_distribution("tableauscraper").version
-        _logger = logging.getLogger(__name__)
-        _logger.warning(f"tableauscraper version {ts_version}")
+        logger = prefect.context.get("logger")
+        logger.info(f"tableauscraper version {ts_version}")
 
         # fetch NUM_PROCESSES counties at a time
         pool = multiprocessing.Pool(processes=NUM_PROCESSES)


### PR DESCRIPTION
the other log didn't show up in the console :( so I'm copying the Prefect logger instances/code from
https://github.com/covid-projections/can-scrapers/blob/main/services/prefect/flows/generated_flows.py#L19

FWIW, the changes in #374  fix the NH scraper, but SC is having a similar issue (that I haven't resolved yet) so I do want to track this down.

