### PR TITLE
Update dependencies on Prefect with webhook 

### DIFF
--- a/services/webhook/update_flows.sh
+++ b/services/webhook/update_flows.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
 git pull origin main
-sudo apt install python3-pip
-/home/sglyon/miniconda/envs/prefect-can-scrapers/bin/pip3 install -e /home/sglyon/can-scrapers
+/home/sglyon/miniconda/envs/prefect-can-scrapers/bin/pip install -e /home/sglyon/can-scrapers
 /home/sglyon/miniconda/envs/prefect-can-scrapers/bin/python /home/sglyon/can-scrapers/services/prefect/flows/generated_flows.py

--- a/services/webhook/update_flows.sh
+++ b/services/webhook/update_flows.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 git pull origin main
+/home/sglyon/miniconda/envs/prefect-can-scrapers/bin/pip install -e .
 /home/sglyon/miniconda/envs/prefect-can-scrapers/bin/python /home/sglyon/can-scrapers/services/prefect/flows/generated_flows.py

--- a/services/webhook/update_flows.sh
+++ b/services/webhook/update_flows.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
 git pull origin main
-/home/sglyon/miniconda/envs/prefect-can-scrapers/bin/pip install -e .
+sudo apt install python3-pip
+/home/sglyon/miniconda/envs/prefect-can-scrapers/bin/pip3 install -e /home/sglyon/can-scrapers
 /home/sglyon/miniconda/envs/prefect-can-scrapers/bin/python /home/sglyon/can-scrapers/services/prefect/flows/generated_flows.py


### PR DESCRIPTION
#377 did not solve the `tableauscraper` version issue, unfortunately (Production is still using `0.1.4`).

This should hopefully reinstall the dependencies on production whenever code is merged to main. 

I consulted: https://stackoverflow.com/questions/41060382/using-pip-to-install-packages-to-anaconda-environment
