### PR TITLE
Add Prefect flow to generate one Parquet file per location

### DIFF
--- a/services/prefect/flows/update_location_parquet_files.py
+++ b/services/prefect/flows/update_location_parquet_files.py
@@ -1,0 +1,79 @@
+# This is similar to update_api_view.py (which defines the flow named
+# UpdateParquetFiles) but instead of producing a single monolithic Parquet
+# file, it produces one Parquet file for each `location_id` in the PostgreSQL
+# database's `covid_us` view.
+
+import os
+import pandas as pd
+import pathlib
+import prefect
+import sqlalchemy as sa
+
+from prefect import flatten, Flow, task, unmapped
+from prefect.tasks.shell import ShellTask
+from prefect.tasks.secrets import EnvVarSecret
+
+DATA_PATH = pathlib.Path(os.environ["DATAPATH"]) / "final"
+DATA_PATH.mkdir(parents=True, exist_ok=True)
+FILENAME_PREFIX = "can_scrape_api_covid_us"
+
+
+@task
+def fetch_location_ids(connstr: str):
+    engine = sa.create_engine(connstr)
+    with engine.connect() as conn:
+        result = conn.execute(
+            sa.text("SELECT DISTINCT location_id FROM public.covid_us;")
+        )
+        location_ids = [row[0] for row in result.fetchall()]
+        return location_ids
+
+
+@task
+def create_location_parquet(connstr: str, location_id: str):
+    engine = sa.create_engine(connstr)
+    with engine.connect() as conn:
+        query = sa.text(
+            "SELECT * FROM public.covid_us WHERE location_id = :location_id;"
+        ).bindparams(location_id=location_id)
+
+        # Read rows from PostgreSQL into Pandas dataframe.
+        # TODO: Can we read to plain dicts/tuples instead and remove Pandas as
+        # a dependency? Would probably use pyarrow instead for Parquet IO.
+        df = pd.read_sql_query(query, conn)
+
+    # Write vintage file.
+    ts = prefect.context.scheduled_start_time
+    dt_str = pd.to_datetime(ts).strftime("%Y-%m-%dT%H")
+    vintage_fn = f"{FILENAME_PREFIX}_{location_id}_{dt_str}.parquet"
+    df.to_parquet(DATA_PATH / vintage_fn, index=False)
+
+    # Replace primary file.
+    fn = f"{FILENAME_PREFIX}_{location_id}.parquet"
+    df.to_parquet(DATA_PATH / fn, index=False)
+
+    return vintage_fn, fn
+
+
+@task
+def get_gcs_cmd(fn):
+    return f"gsutil acl ch -u AllUsers:R gs://can-scrape-outputs/final/{fn}"
+
+
+def main():
+    with Flow("UpdateLocationParquetFiles") as flow:
+        connstr = EnvVarSecret("COVID_DB_CONN_URI")
+        location_ids = fetch_location_ids(connstr)
+        filename_tuples = create_location_parquet.map(
+            connstr=unmapped(connstr), location_id=location_ids
+        )
+
+        file_permission_commands = get_gcs_cmd.map(flatten(filename_tuples))
+        # TODO: figure out how to test this
+        # ShellTask().map(file_permission_commands)
+
+    flow.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
@mikelehen Here's a proof of concept for using a Prefect flow to generate one Parquet file per location. Original flow for generating a single Parquet file here, for comparison: https://github.com/covid-projections/can-scrapers/blob/d24325185168d74c72c5dc8391ba62fd677ae05b/services/prefect/flows/update_api_view.py.

I'm opening this PR just for inspection, it's not production-ready. Things we'd have to do before deploying:
* Uncomment the shell task that updates file permissions
* Register the flow instead of running it
* Pick a schedule
* Figure out how to test/monitor it

I poked around a bit in the Prefect UI but couldn't find monitoring for tasks' resource usage. Maybe you can help me with that?

Overall, this was pretty straightforward to write, and I liked Prefect's approach to dynamically spawning one task for each output of a prior task via `.map`. I noticed that the scraper flows are currently spawned off a static list, but I was able to write a flow that queries the PostgreSQL DB for a list of locations and then dynamically spawn a task for each location, which seems useful if we're going to start changing the set of locations.

My next task is to write a flow that performs our [minimal pipeline](https://www.dropbox.com/scl/fi/baoh3cmzyupbk6w349s8l/CAN-Data-Pipeline-v2-Exploration---Dropbox-Paper.paper?dl=0&noDesktopRedirect=1&open_id=server-34c9f2ce-2a6f-41ff-bda8-7d3e981835ed&parent_frame_referrer=&rlkey=zcwc105h5cdhlm1xwdesshupy) for exploration purposes.