### PR TITLE
Fix WV, GA, MN and add context to test failures

### DIFF
--- a/can_tools/bootstrap_data/covid_demographics.csv
+++ b/can_tools/bootstrap_data/covid_demographics.csv
@@ -396,3 +396,7 @@ all,asian_or_pacific_islander,non-hispanic,all
 5-11,all,non-hispanic,all
 18-25,all,all,all
 all,ai_an_asian_or_pacific_islander,all,all
+16-20,all,all,all
+21-25,all,all,all
+26-30,all,all,all
+71_plus,all,all,all

--- a/can_tools/scrapers/official/GA/ga_vaccines.py
+++ b/can_tools/scrapers/official/GA/ga_vaccines.py
@@ -49,7 +49,7 @@ class GeorgiaCountyVaccineAge(GeorgiaCountyVaccine):
     has_location = True
     variables = {"PERSONVAX": variables.INITIATING_VACCINATIONS_ALL}
     demographic_formatting = {
-        "00-05": "0-5",
+        "00_04": "0-4",
         "05_09": "5-9",
         "10_14": "10-14",
         "15_19": "15-19",

--- a/can_tools/scrapers/official/MN/mn_vaccine.py
+++ b/can_tools/scrapers/official/MN/mn_vaccine.py
@@ -26,7 +26,7 @@ class MinnesotaCountyVaccines(MicrosoftBIDashboard):
     # get the iframe link manually to bypass captcha
     # this will need to be updated periodically -- find the iframe in the page source html
 
-    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiNjFmNzRkNTctNjg4Mi00MmM5LTk2Y2EtODBiZDMxNGE4M2UwIiwidCI6ImViMTRiMDQ2LTI0YzQtNDUxOS04ZjI2LWI4OWMyMTU5ODI4YyJ9"
+    powerbi_dashboard_link = "https://app.powerbigov.us/view?r=eyJrIjoiYTE5MDM4NjMtMWM0Ny00MDlmLWIxNTYtODFlMjFkOGYxYjljIiwidCI6ImViMTRiMDQ2LTI0YzQtNDUxOS04ZjI2LWI4OWMyMTU5ODI4YyJ9"
 
     def get_dashboard_iframe(self):
         fumn = {"src": self.powerbi_dashboard_link}

--- a/can_tools/scrapers/official/WV/wv_vaccine.py
+++ b/can_tools/scrapers/official/WV/wv_vaccine.py
@@ -7,7 +7,7 @@ import os
 from can_tools.scrapers import CMU, variables
 from can_tools.scrapers.official.base import MicrosoftBIDashboard
 from can_tools.scrapers.util import flatten_dict
-pd.set_option("max_rows", 100000)
+
 
 class WVCountyVaccine(MicrosoftBIDashboard):
 

--- a/can_tools/scrapers/official/WV/wv_vaccine.py
+++ b/can_tools/scrapers/official/WV/wv_vaccine.py
@@ -7,7 +7,7 @@ import os
 from can_tools.scrapers import CMU, variables
 from can_tools.scrapers.official.base import MicrosoftBIDashboard
 from can_tools.scrapers.util import flatten_dict
-
+pd.set_option("max_rows", 100000)
 
 class WVCountyVaccine(MicrosoftBIDashboard):
 
@@ -35,7 +35,7 @@ class WVCountyVaccine(MicrosoftBIDashboard):
         from_variables = [
             (
                 "c",
-                "COVID_Vaccine",
+                "factVaccine",
                 0,
             ),
             (
@@ -197,7 +197,7 @@ class WVCountyVaccine(MicrosoftBIDashboard):
 
 class WVCountyVaccineRace(WVCountyVaccine):
     demographic = "race"
-    demographic_query_name = "Race1"
+    demographic_query_name = "Race"
     col_mapping = {
         "G0": "location_name",
         "M_1_DM3_0_C_1": "black",
@@ -235,7 +235,7 @@ class WVCountyVaccineRace(WVCountyVaccine):
                                         [
                                             # From
                                             ("d", "dimCounty", 0),
-                                            ("c", "COVID_Vaccine", 0),
+                                            ("c", "factVaccine", 0),
                                             ("n", "Navigation", 0),
                                         ]
                                     ),
@@ -475,16 +475,18 @@ class WVCountyVaccineRace(WVCountyVaccine):
 class WVCountyVaccineAge(WVCountyVaccineRace):
     col_mapping = {
         "G0": "location_name",
-        "M_1_DM3_0_C_1": "12-24",
-        "M_1_DM3_1_C_1": "25-34",
-        "M_1_DM3_2_C_1": "35-44",
-        "M_1_DM3_3_C_1": "45-54",
-        "M_1_DM3_4_C_1": "55-64",
-        "M_1_DM3_5_C_1": "65-74",
-        "M_1_DM3_6_C_1": "75-84",
-        "M_1_DM3_7_C_1": "85_plus",
+        "M_1_DM3_0_C_1": "5-11",
+        "M_1_DM3_1_C_1": "12-15",
+        "M_1_DM3_2_C_1": "16-20",
+        "M_1_DM3_3_C_1": "21-25",
+        "M_1_DM3_4_C_1": "26-30",
+        "M_1_DM3_5_C_1": "31-40",
+        "M_1_DM3_6_C_1": "41-50",
+        "M_1_DM3_7_C_1": "51-60",
+        "M_1_DM3_8_C_1": "61-70",
+        "M_1_DM3_9_C_1": "71_plus",
     }
-    demographic_query_name = "Age Group"
+    demographic_query_name = "AgeGroupVax"
     demographic = "age"
 
 

--- a/can_tools/utils.py
+++ b/can_tools/utils.py
@@ -2,7 +2,7 @@ from typing import Optional
 import pandas as pd
 import sqlalchemy as sa
 from sqlalchemy.engine.base import Engine
-from can_tools.models import Location, create_dev_engine
+from can_tools.models import create_dev_engine
 
 
 def determine_location_column(df: pd.DataFrame) -> str:
@@ -62,7 +62,9 @@ def find_unknown_variable_id(df: pd.DataFrame, engine: Engine = None, csv_rows=F
     return df_bad_combinations.to_csv(index=False, header=False)
 
 
-def find_unknown_location_id(df: pd.DataFrame, state_fips: int, engine: Engine = None, csv_rows=False):
+def find_unknown_location_id(
+    df: pd.DataFrame, state_fips: int, engine: Engine = None, csv_rows=False
+):
     """Find any locations in the specified dataframe that do not match an entry in the locations file"""
     if not engine:
         engine = create_dev_engine()[0]
@@ -74,7 +76,7 @@ def find_unknown_location_id(df: pd.DataFrame, state_fips: int, engine: Engine =
             locs.loc[locs.state_fips == state_fips, :].name
         )
     bad_df = df.loc[~good_rows, :]
-    
+
     if not csv_rows:
         return bad_df
     if "location" in df.columns:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -113,7 +113,7 @@ def _create_put_error_msg(engine: Engine, data: pd.DataFrame, cls: DatasetBase):
     error_msg = (
         "NOT NULL constraint failed on insert. "
         "Verify the missing rows are expected and add them to the corresponding files "
-        "or modify the scraper output to match the expected, existing CSV entries. \n"
+        "or modify the scraper output to match the expected and existing CSV entries. \n"
     )
     if unk_demographics:
         error_msg += "covid_demographics.csv: \n" + "".join(unk_demographics) + "\n"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from sqlalchemy.engine.base import Engine
 from can_tools.scrapers.base import DatasetBase
 from can_tools.scrapers.official.federal.CDC.cdc_coviddatatracker import (
@@ -25,9 +23,6 @@ if CONN_STR is not None:
     Base.metadata.create_all(bind=engine)
 else:
     engine, sess = create_dev_engine(verbose=VERBOSE)
-
-class UnverifiedScraperOutputError(Exception):
-    pass
 
 
 def _covid_dataset_tests(cls, df):
@@ -84,7 +79,7 @@ def test_datasets(cls):
         d.put(engine, clean)
     except sa.exc.IntegrityError:
         error_msg = _create_put_error_msg(engine, clean, cls)
-        raise UnverifiedScraperOutputError(error_msg)
+        raise Exception(error_msg)
 
 
 @pytest.mark.parametrize("cls", SORTED_SCRAPERS)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,3 +1,7 @@
+from typing import Optional
+
+from sqlalchemy.engine.base import Engine
+from can_tools.scrapers.base import DatasetBase
 from can_tools.scrapers.official.federal.CDC.cdc_coviddatatracker import (
     CDCCovidDataTracker,
 )
@@ -6,7 +10,6 @@ import os
 import pandas as pd
 import pytest
 import sqlalchemy as sa
-from us import states
 
 from can_tools import ALL_SCRAPERS
 from can_tools.models import Base, create_dev_engine
@@ -80,23 +83,7 @@ def test_datasets(cls):
     try:
         d.put(engine, clean)
     except sa.exc.IntegrityError:
-        unk_demographics = utils.find_unknown_demographic_id(clean, engine=engine, csv_rows=True)
-        unk_variables = utils.find_unknown_variable_id(clean, engine=engine, csv_rows=True)
-        if cls.location_type in ["county", "state"] or cls.has_location == True:
-            unk_locations = utils.find_unknown_location_id(clean, engine=engine, state_fips=cls.state_fips, csv_rows=True)
-        
-        error_msg = (
-            "NOT NULL constraint failed on insert. " 
-            "Verify the missing rows are expected and add them to the corresponding files "
-            "or modify the scraper output to match the expected, existing CSV entries. \n"
-        )
-        if unk_demographics:
-            error_msg += "covid_demographics.csv: \n" + "".join(unk_demographics) + "\n"
-        if unk_variables:
-            error_msg += "covid_variables.csv: \n" + "".join(unk_variables) + "\n"
-        if unk_locations:
-            error_msg += "locations.csv: \n" + "".join(unk_locations)
-        
+        error_msg = _create_put_error_msg(engine, clean, cls)
         raise UnverifiedScraperOutputError(error_msg)
 
 
@@ -120,3 +107,23 @@ def test_covid_dataset_has_source(cls):
 @pytest.mark.parametrize("cls", SORTED_SCRAPERS)
 def test_all_datasets_has_source_name(cls):
     assert hasattr(cls, "source_name")
+
+def _create_put_error_msg(engine: Engine, data: pd.DataFrame, cls: DatasetBase):
+    """Find unknown/missing variable entries and format an error message"""
+    unk_demographics = utils.find_unknown_demographic_id(data, engine=engine, csv_rows=True)
+    unk_variables = utils.find_unknown_variable_id(data, engine=engine, csv_rows=True)
+    if cls.location_type in ["county", "state"] or cls.has_location == True:
+        unk_locations = utils.find_unknown_location_id(data, engine=engine, state_fips=cls.state_fips, csv_rows=True)
+    
+    error_msg = (
+        "NOT NULL constraint failed on insert. "
+        "Verify the missing rows are expected and add them to the corresponding files "
+        "or modify the scraper output to match the expected, existing CSV entries. \n"
+    )
+    if unk_demographics:
+        error_msg += "covid_demographics.csv: \n" + "".join(unk_demographics) + "\n"
+    if unk_variables:
+        error_msg += "covid_variables.csv: \n" + "".join(unk_variables) + "\n"
+    if unk_locations:
+        error_msg += "locations.csv: \n" + "".join(unk_locations)
+    return error_msg

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -111,8 +111,8 @@ def _create_put_error_msg(engine: Engine, data: pd.DataFrame, cls: DatasetBase):
         unk_locations = utils.find_unknown_location_id(data, engine=engine, state_fips=cls.state_fips, csv_rows=True)
     
     error_msg = (
-        "NOT NULL constraint failed on insert. "
-        "Verify the missing rows are expected and add them to the corresponding files "
+        "Exception encountered during scraper put() method. "
+        "This may be due to unknown values in the scraper output. Verify any unknown rows are expected and add them to the corresponding files "
         "or modify the scraper output to match the expected and existing CSV entries. \n"
     )
     if unk_demographics:


### PR DESCRIPTION
Fixes scrapers and pulls in some code from an older branch that gives more context to failing tests. If a test fails due to an unknown demographic, location, or variable value the missing variables/keys are output as seen below. The original error message is still output as well. 

![image](https://user-images.githubusercontent.com/55333380/145117071-b89a1095-6868-4db0-80a6-c012bf03e99d.png)
