### PR TITLE
Add CDC booster data and update vaccine schema (and rename CDC scraper)

### DIFF
--- a/can_tools/bootstrap_data/covid_categories.csv
+++ b/can_tools/bootstrap_data/covid_categories.csv
@@ -67,6 +67,7 @@ vaccine,total_vaccine_allocated
 vaccine,total_vaccine_distributed
 vaccine,total_vaccine_initiated
 vaccine,total_vaccine_completed
+vaccine,total_vaccine_additional_dose
 vaccine,total_vaccine_doses_administered
 vaccine,janssen_vaccine_allocated
 vaccine,janssen_vaccine_completed

--- a/can_tools/bootstrap_data/covid_variables.csv
+++ b/can_tools/bootstrap_data/covid_variables.csv
@@ -189,6 +189,7 @@ total_vaccine_allocated,cumulative,doses
 total_vaccine_distributed,cumulative,doses
 total_vaccine_initiated,cumulative,people
 total_vaccine_completed,cumulative,people
+total_vaccine_additional_dose,cumulative,people
 total_vaccine_completed,new,people
 total_vaccine_completed,new,doses
 total_vaccine_completed,new_7_day,people

--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -47,7 +47,7 @@ from can_tools.scrapers.official.federal.CDC.cdc_vaccines import (
 from can_tools.scrapers.official.federal.CDC.cdc_county_vaccines import CDCCountyVaccine
 
 from can_tools.scrapers.official.federal.CDC.cdc_historical_vaccine import (
-    CDCCountyVaccine2,
+    CDCHistoricalCountyVaccine,
 )
 from can_tools.scrapers.official.federal.CDC.cdc_variant_tracker import (
     CDCVariantTracker,

--- a/can_tools/scrapers/official/federal/CDC/cdc_historical_vaccine.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_historical_vaccine.py
@@ -14,7 +14,7 @@ class CDCHistoricalCountyVaccine(FederalDashboard, ETagCacheMixin):
     variables = {
         "Administered_Dose1_Recip": variables.INITIATING_VACCINATIONS_ALL,
         "Series_Complete_Yes": variables.FULLY_VACCINATED_ALL,
-        "Booster_Doses": variables.PEOPLE_VACCINATED_ADDITIONAL_DOSE
+        "Booster_Doses": variables.PEOPLE_VACCINATED_ADDITIONAL_DOSE,
     }
 
     # Send URL and filename that Mixin will use to check the etag

--- a/can_tools/scrapers/official/federal/CDC/cdc_historical_vaccine.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_historical_vaccine.py
@@ -3,7 +3,7 @@ from can_tools.scrapers import variables
 from can_tools.scrapers.official.base import ETagCacheMixin, FederalDashboard
 
 
-class CDCCountyVaccine2(FederalDashboard, ETagCacheMixin):
+class CDCHistoricalCountyVaccine(FederalDashboard, ETagCacheMixin):
     has_location = True
     location_type = "county"
     source = "https://data.cdc.gov/Vaccinations/COVID-19-Vaccinations-in-the-United-States-County/8xkx-amqh"
@@ -14,6 +14,7 @@ class CDCCountyVaccine2(FederalDashboard, ETagCacheMixin):
     variables = {
         "Administered_Dose1_Recip": variables.INITIATING_VACCINATIONS_ALL,
         "Series_Complete_Yes": variables.FULLY_VACCINATED_ALL,
+        "Booster_Doses": variables.PEOPLE_VACCINATED_ADDITIONAL_DOSE
     }
 
     # Send URL and filename that Mixin will use to check the etag

--- a/can_tools/scrapers/variables.py
+++ b/can_tools/scrapers/variables.py
@@ -38,6 +38,12 @@ TOTAL_VACCINE_DISTRIBUTED: CMU = CMU(
     unit="doses",
 )
 
+PEOPLE_VACCINATED_ADDITIONAL_DOSE: CMU = CMU(
+    category="total_vaccine_additional_dose",
+    measurement="cumulative",
+    unit="people",
+)
+
 CUMULATIVE_CASES_PEOPLE: CMU = CMU(
     category="cases",
     measurement="cumulative",


### PR DESCRIPTION
The [CDC booster column](https://data.cdc.gov/Vaccinations/COVID-19-Vaccinations-in-the-United-States-County/8xkx-amqh) is documented as: 
```Total number of people who are fully vaccinated and have received a booster (or additional) dose.```
which suggests that if someone were to receive a second booster it would not be counted in this column. I'm not sure how the CDC plans to track 4th-shot-boosters when they are authorized (if they will update this column to include those doses or create a new column etc.)

At the moment I've created the CMU variable to mirror the CDC description, but I wonder if we should track `doses` instead of `people` so that we can continue to use this variable when future doses are authorized (e.g. by combining future 3rd-, 4th- and subsequent-shot columns into one). 