### PR TITLE
Add booster data to CA scraper

### DIFF
--- a/can_tools/scrapers/official/CA/ca_vaccine.py
+++ b/can_tools/scrapers/official/CA/ca_vaccine.py
@@ -25,6 +25,7 @@ class CaliforniaVaccineCounty(StateDashboard):
         "cumulative_fully_vaccinated": variables.FULLY_VACCINATED_ALL,
         "cumulative_at_least_one_dose": variables.INITIATING_VACCINATIONS_ALL,
         "cumulative_total_doses": variables.TOTAL_DOSES_ADMINISTERED_ALL,
+        "cumulative_booster_recip_count": variables.PEOPLE_VACCINATED_ADDITIONAL_DOSE,
     }
 
     def fetch(self) -> pd.DataFrame:


### PR DESCRIPTION
Add variable to collect booster data from [CA's public health vaccine dataset](https://data.chhs.ca.gov/dataset/e283ee5a-cf18-4f20-a92c-ee94a2866ccd/resource/130d7ba2-b6eb-438d-a412-741bde207e1c/download/covid19vaccinesbycounty.csv)