### PR TITLE
Add NC state-level vaccine scraper

### DIFF
--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -119,7 +119,7 @@ from can_tools.scrapers.official.MT.mt_vaccinations import (
 )
 
 from can_tools.scrapers.official.MA.ma_vaccines import MassachusettsVaccineDemographics
-from can_tools.scrapers.official.NC.nc_vaccine import NCVaccine
+from can_tools.scrapers.official.NC.nc_vaccine import NCVaccine, NCVaccineState
 from can_tools.scrapers.official.ND.nd_vaccines import NDVaccineCounty
 
 # 12/02/21: NE has made their server private, so we can no longer access the data driving the NebraskaCases scraper

--- a/can_tools/scrapers/official/NC/nc_vaccine.py
+++ b/can_tools/scrapers/official/NC/nc_vaccine.py
@@ -1,9 +1,10 @@
 import pandas as pd
 import us
+from typing import Dict
 
 from can_tools.scrapers import variables
 from can_tools.scrapers.official.base import TableauDashboard
-from tableauscraper import TableauScraper
+from tableauscraper import TableauScraper, TableauWorkbook
 
 
 class NCVaccine(TableauDashboard):
@@ -24,6 +25,7 @@ class NCVaccine(TableauDashboard):
     cmus = {
         "AGG(Calc.At Least One Dose Vaccinated)-alias": variables.INITIATING_VACCINATIONS_ALL,
         "AGG(Calc.Fully Vaccinated)-alias": variables.FULLY_VACCINATED_ALL,
+        "AGG(Calc.Additional/Booster Dose)-alias": variables.PEOPLE_VACCINATED_ADDITIONAL_DOSE,
     }
 
     def fetch(self):
@@ -39,3 +41,39 @@ class NCVaccine(TableauDashboard):
         ).str.strip()  # Strip whitespace
         df.loc[df["location_name"] == "Mcdowell", "location_name"] = "McDowell"
         return df
+
+
+class NCVaccineState(NCVaccine):
+    location_type = "state"
+    has_location = True
+
+    variables = {
+        "First of Two": variables.INITIATING_VACCINATIONS_ALL,
+        "Second of Two": variables.FULLY_VACCINATED_ALL,
+        "Additional Dose": variables.PEOPLE_VACCINATED_ADDITIONAL_DOSE,
+    }
+
+    def fetch(self) -> TableauWorkbook:
+        scraper_instance = TableauScraper()
+        scraper_instance.loads(self.fetch_url)
+        return scraper_instance.getWorkbook()
+
+    def normalize(self, workbook: TableauWorkbook) -> pd.DataFrame:
+        data: Dict[str, int] = {}
+        variables = ["Single Shot", "First of Two", "Second of Two", "Additional Dose"]
+        for variable in variables:
+            frame = workbook.getWorksheet(f"Total Card {variable}").data
+            data[variable] = frame["AGG(Calc.Total Card Administered)-alias"].values[0]
+
+        # add J&J doses to match our initiated and completed definitions
+        data["First of Two"] += data["Single Shot"]
+        data["Second of Two"] += data["Single Shot"]
+
+        data = pd.DataFrame.from_dict(data, orient="index").reset_index()
+        data.columns = ["variable", "value"]
+        data = data.assign(
+            dt=self._retrieve_dt(),
+            vintage=self._retrieve_vintage(),
+            location=self.state_fips,
+        ).query("variable != 'Single Shot'")
+        return self.extract_CMU(data, self.variables)


### PR DESCRIPTION
This also adds booster data to the county-level scraper. We should be able to get historical booster data for the counties by using the [rerun_scraper](https://github.com/covid-projections/can-scrapers/blob/ba36f84d9d9806721f9b5f5b2b4ed9e086176f10/can_tools/scraper_maintenance.py#L42) functionality (running the `normalize()` method on the saved outputs of the previous `fetch()` runs from GCS), though, I've never actually tried it before. 

This, unfortunately, won't be possible for the state data as it comes from different tables, so we'll have no historical data. 