### PR TITLE
Only allow one instance of each flow to run at a time

### DIFF
--- a/services/prefect/flows/generated_flows.py
+++ b/services/prefect/flows/generated_flows.py
@@ -11,6 +11,7 @@ from prefect.schedules import CronSchedule
 from prefect.tasks.secrets import EnvVarSecret
 from prefect.tasks.prefect.flow_run import StartFlowRun
 from can_tools.scrapers.official.base import ETagCacheMixin
+from services.prefect.flows.utils import skip_if_running_handler
 
 
 @task
@@ -92,7 +93,7 @@ def create_flow_for_scraper(ix: int, cls: Type[DatasetBase], schedule=True):
     if schedule:
         sched = CronSchedule(f"{ix % 60} */4 * * *")
 
-    with Flow(cls.__name__, sched) as flow:
+    with Flow(cls.__name__, sched, state_handlers=[skip_if_running_handler]) as flow:
 
         # check if scraper has etag checking
         # if so and the data has been updated since the last check set new_data to True

--- a/services/prefect/flows/utils.py
+++ b/services/prefect/flows/utils.py
@@ -2,13 +2,14 @@ import prefect
 from prefect.client import Client
 from prefect.engine.state import Skipped
 
+
 def skip_if_running_handler(obj, old_state, new_state):
     """State handler to skip flow if another instance is already in progress.
     
     see: https://github.com/PrefectHQ/prefect/discussions/5373
     """
     logger = prefect.context.get("logger")
-    
+
     # queries the graphql server to see if any instances of the same flow
     # is already running, and if so, sets the flow state to Skipped
     if new_state.is_running():

--- a/services/prefect/flows/utils.py
+++ b/services/prefect/flows/utils.py
@@ -17,7 +17,6 @@ def skip_if_running_handler(obj, old_state, new_state):
                 where: {_and: [{flow_id: {_eq: $flow_id}},
                 {state: {_eq: "Running"}}]}
                 limit: 1
-                offset: 1
               ) {
                 name
                 state

--- a/services/prefect/flows/utils.py
+++ b/services/prefect/flows/utils.py
@@ -7,8 +7,10 @@ def skip_if_running_handler(obj, old_state, new_state):
     
     see: https://github.com/PrefectHQ/prefect/discussions/5373
     """
-    
     logger = prefect.context.get("logger")
+    
+    # queries the graphql server to see if any instances of the same flow
+    # is already running, and if so, sets the flow state to Skipped
     if new_state.is_running():
         client = Client()
         query = """

--- a/services/prefect/flows/utils.py
+++ b/services/prefect/flows/utils.py
@@ -1,0 +1,36 @@
+import prefect
+from prefect.client import Client
+from prefect.engine.state import Skipped
+
+def skip_if_running_handler(obj, old_state, new_state):
+    """State handler to skip flow if another instance is already in progress.
+    
+    see: https://github.com/PrefectHQ/prefect/discussions/5373
+    """
+    
+    logger = prefect.context.get("logger")
+    if new_state.is_running():
+        client = Client()
+        query = """
+            query($flow_id: uuid) {
+              flow_run(
+                where: {_and: [{flow_id: {_eq: $flow_id}},
+                {state: {_eq: "Running"}}]}
+                limit: 1
+                offset: 1
+              ) {
+                name
+                state
+                start_time
+              }
+            }
+        """
+        response = client.graphql(
+            query=query, variables=dict(flow_id=prefect.context.flow_id)
+        )
+        active_flow_runs = response["data"]["flow_run"]
+        if active_flow_runs:
+            message = "Flow already has a run in progress, skipping..."
+            logger.info(message)
+            return Skipped(message)
+    return new_state

--- a/services/prefect/flows/utils.py
+++ b/services/prefect/flows/utils.py
@@ -32,7 +32,10 @@ def skip_if_running_handler(obj, old_state, new_state):
         )
         active_flow_runs = response["data"]["flow_run"]
         if active_flow_runs:
-            message = "Flow already has a run in progress, skipping..."
+            message = (
+                "Flow already has a run in progress..."
+                f"Skipping due to run in progress: {active_flow_runs}"
+            )
             logger.info(message)
             return Skipped(message)
     return new_state


### PR DESCRIPTION
Adds a state handler that, whenever a flow run is set to execute, checks to see if the current flow already has another instance running and if so, skips the instance that's about to start. 

Last night, it looks like two NYT scrapers kicked off around the same time (see screenshots below), and I think this might be what caused them to take longer to complete. #410 eliminates the need to rely on scheduling/timing, so if the scrapers take longer in the future it won't be as big of a deal, but regardless, there's no need to have two instances of the same scraper flow running at the same time. 

<img width="438" alt="image" src="https://user-images.githubusercontent.com/55333380/154365330-d1d85d81-6912-46ba-b016-492d8aefc02b.png">
<img width="438" alt="image" src="https://user-images.githubusercontent.com/55333380/154365294-a685b9cd-d38d-4899-becb-0b8adbecb071.png">
