### PR TITLE
Move etag_skip_flag to signal's context to fix terminal state handling. 

### DIFF
--- a/services/prefect/flows/generated_flows.py
+++ b/services/prefect/flows/generated_flows.py
@@ -78,11 +78,11 @@ def initialize_sentry(sentry_dsn: str):
 
 @task
 def skip_cached_flow():
-    # Set the task state to skipped.
-    # The flow's terminal state handler(etag_caching_terminal_state_handler)
-    # will see etag_skip_flag and will in turn set the final state of the flow to skipped.
+    # Set the task state to skipped. The flow's terminal state
+    # handler (etag_caching_terminal_state_handler) will see the etag_skip_flag
+    # context item and will in turn set the final state of the flow to skipped.
     message = "No new source data. Skipping..."
-    skip_signal = signals.SKIP(dict(message=message, etag_skip_flag=True))
+    skip_signal = signals.SKIP(message=message, context=dict(etag_skip_flag=True))
     raise skip_signal
 
 

--- a/services/prefect/flows/utils.py
+++ b/services/prefect/flows/utils.py
@@ -44,11 +44,9 @@ def skip_if_running_handler(obj, old_state, new_state):
 
 
 def etag_caching_terminal_state_handler(
-    flow: Flow,
-    state: State,
-    reference_task_states: Set[State],
+    flow: Flow, state: State, reference_task_states: Set[State],
 ) -> Optional[State]:
-    """Update flow's final state to Skipped if a reference task is skipped with etag_skip_flag = True.
+    """Update final state to Skipped if a reference task is skipped with context item etag_skip_flag = True.
 
     This is used in conjunction with the skip_cached_flow() task to manually skip a
     flow if the Etag caching does not detect new data. This allows us to conditionally
@@ -61,15 +59,15 @@ def etag_caching_terminal_state_handler(
     """
 
     # look through all the flow's tasks to see if any were skipped.
-    # If so, and the etag_skip_flag attribute is True, set the final state of the flow to Skipped.
-    # etag_skip_flag is a custom flag passed to a task's skip signal during the etag cache checking process.
+    # If so, and the etag_skip_flag context item exists and is True, set the final state of the flow to Skipped.
+    # etag_skip_flag is a custom flag passed to a state signal's context during the etag cache checking process.
     # Any tasks that normally finish with the Skipped state will not trigger this state handler.
     for task_state in reference_task_states:
         if task_state.is_skipped():
-            if getattr(task_state, "etag_skip_flag", False) is True:
+            if dict.get(task_state.context, "etag_skip_flag", False) is True:
                 return Skipped(
-                    "Setting final state to skipped due to reference task "
-                    "skipped with attribute etag_skip_flag = True"
+                    "Setting final state to skipped due to reference task. "
+                    "Skipped due to state context item etag_skip_flag = True"
                 )
     return state
 


### PR DESCRIPTION
Originally I thought we could just add arbitrary tags/arguments to a state signal. The code I had in place before just created a signal message that looked like: `"{'message': 'No new source data. Skipping...', 'etag_skip_flag': True}"` (note that it's just one big string 🤦). So, there never was an `etag_skip_flag` attribute to look for, meaning the final flow state would never be set to `Skipped`. 

To fix this, this now modifies the [signal's context](https://github.com/PrefectHQ/prefect/blob/4e9cc138e98535e45937e53c972f718af5144f60/src/prefect/engine/state.py#L41) and adds the `etag_skip_flag` to this dictionary. 

My local testing must have been slightly different to not catch this :/ 