### PR TITLE
Fix deploy airflow workflow.

### DIFF
--- a/.github/workflows/deploy-airflow.yml
+++ b/.github/workflows/deploy-airflow.yml
@@ -19,7 +19,7 @@ jobs:
       FORCE_COLOR: 1
     steps:
     - uses: actions/checkout@v2
-    - uses: google-github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@v0
       with:
         version: '318.0.0'
         service_account_key: ${{ secrets.GCLOUD_SA_KEY }}


### PR DESCRIPTION
The last two deploy airflow jobs failed with:

> Error: On 2022-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.
>
> We strongly advise updating your GitHub Action YAML from:
>
>     uses: 'google-github-actions/setup-gcloud@master'
>
> to:
>
>     uses: 'google-github-actions/setup-gcloud@v0'

So this updates it with the fix.  Successful run [here](https://github.com/covid-projections/can-scrapers/actions/runs/2087279165)