### PR TITLE
Remove NYT scraper from MainFlow

### DIFF
--- a/services/prefect/flows/generated_flows.py
+++ b/services/prefect/flows/generated_flows.py
@@ -16,7 +16,11 @@ from services.prefect.flows.utils import (
     etag_caching_terminal_state_handler, skip_if_running_handler
 )
 
-# A list of flows that we want to be registered, but not included in the MainFlow runs. 
+# A list of flows that we want to be registered, but not included in the MainFlow runs.
+# NYTimesCasesDeaths: We have a dedicated flow that checks the NYT source every 30 minutes, 
+# and runs the scraper, updates the parquet file, and kicks off a Github action pipeline run upon new data. 
+# As such, its unnecessary for this flow to run in the MainFlow, and it can cause issues 
+# where the NYT data will update, but a snapshot will not be kicked off. 
 FLOWS_EXCLUDED_FROM_MAIN_FLOW: List[Flow] = [scrapers.NYTimesCasesDeaths]
 
 
@@ -170,7 +174,7 @@ def init_flows():
         flow = create_flow_for_scraper(ix, cls, schedule=False)
         flows.append(flow)
         flow.register(project_name="can-scrape")
-        
+
     flows = [flow for flow in flows if flow not in FLOWS_EXCLUDED_FROM_MAIN_FLOW]
     flow = create_main_flow(flows, "can-scrape")
     flow.register(project_name="can-scrape")


### PR DESCRIPTION
Since we have the `NYTParquetScheduledUpdater` which checks/runs the NYT flow every 30 minutes, having the NYT flow in the Mainflow is unnecessary, and can cause some confusion