### PR TITLE
Remove NYT `live/` files, fix VA scraper

### DIFF
--- a/can_tools/scrapers/nytimes/nyt_cases_deaths.py
+++ b/can_tools/scrapers/nytimes/nyt_cases_deaths.py
@@ -109,17 +109,14 @@ class NYTimesCasesDeaths(FederalDashboard, ETagCacheMixin):
     has_location = True
     provider: str = "nyt"
     location_type = ""  # multiple location types, so we identify the type with a column
-    # NOTE 5/15/22: NYT temporarily stopped updating the usual files, but the live files remained active.
-    # Collect historical data from usual files and "current" data from the live files.
     file_slugs = {
         "county": [
             "us-counties-2020.csv",
             "us-counties-2021.csv",
             "us-counties-2022.csv",
-            "live/us-counties.csv",
         ],
-        "state": ["us-states.csv", "live/us-states.csv"],
-        "nation": ["us.csv", "live/us.csv"],
+        "state": ["us-states.csv"],
+        "nation": ["us.csv"],
     }
 
     variables = {
@@ -145,12 +142,10 @@ class NYTimesCasesDeaths(FederalDashboard, ETagCacheMixin):
                 ).assign(location_type=location_type)
 
                 # Nation-level file does not have FIPS column, so create one
-                if file in ["us.csv", "live/us.csv"]:
+                if file in ["us.csv"]:
                     location = location.assign(fips=0)
                 data.append(location)
-        # TODO Remove when removeing live/ files. Dropping duplicates in case there is overlap
-        # between live and historical data.
-        return pd.concat(data).drop_duplicates()
+        return pd.concat(data)
 
     def normalize(self, data: pd.DataFrame) -> pd.DataFrame:
         data = remove_county_backfilled_cases(data, COUNTY_BACKFILLED_CASES)

--- a/can_tools/scrapers/official/VA/va_vaccine.py
+++ b/can_tools/scrapers/official/VA/va_vaccine.py
@@ -11,7 +11,7 @@ class VirginiaVaccine(TableauDashboard):
     state_fips = int(us.states.lookup("Virginia").fips)
     source = "https://www.vdh.virginia.gov/coronavirus/covid-19-vaccine-summary/"
     source_name = "Virginia Department of Health"
-    baseurl = "https://vdhpublicdata.vdh.virginia.gov"
+    baseurl = "https://public.tableau.com"
     provider = "state"
     has_location = False
     location_type = "county"


### PR DESCRIPTION
NYT is updating the yearly county files and the standard state/us files, so we no longer need to grab data from the `live/` files (see https://github.com/nytimes/covid-19-data/commit/5552a312c25189ff92a32dd15c32304a81c0e316)