### PR TITLE
Use Python 3.7 and pin Click version to fix CI

### DIFF
--- a/.github/workflows/scraper-ci.yml
+++ b/.github/workflows/scraper-ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install dependencies
         run: |
           pip install -e .

--- a/can_tools/scrapers/nytimes/nyt_cases_deaths.py
+++ b/can_tools/scrapers/nytimes/nyt_cases_deaths.py
@@ -103,7 +103,7 @@ STATE_BACKFILLED_CASES = [
 
 
 class NYTimesCasesDeaths(FederalDashboard, ETagCacheMixin):
-    source_name = "NYT"  # Undo this
+    source_name = "The New York Times"
     source = "https://github.com/nytimes/covid-19-data"
 
     has_location = True

--- a/can_tools/scrapers/nytimes/nyt_cases_deaths.py
+++ b/can_tools/scrapers/nytimes/nyt_cases_deaths.py
@@ -103,7 +103,7 @@ STATE_BACKFILLED_CASES = [
 
 
 class NYTimesCasesDeaths(FederalDashboard, ETagCacheMixin):
-    source_name = "The New York Times"
+    source_name = "NYT"  # Undo this
     source = "https://github.com/nytimes/covid-19-data"
 
     has_location = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ sentry-sdk==1.0.0
 jmespath==0.10.0
 textract
 html5lib==1.1
+click==8.0.2


### PR DESCRIPTION
Bumps Python to 3.7 to fix an issue with Pandas (https://stackoverflow.com/a/68750409/14034347) , pins Click to fix an issue with Black (https://github.com/psf/black/issues/2964#issuecomment-1080971383).