### PR TITLE
Decrease number of Prefect flows by excluding unnecessary scrapers

### DIFF
--- a/can_tools/__init__.py
+++ b/can_tools/__init__.py
@@ -38,13 +38,42 @@ def all_subclasses(cls):
     )
 
 
-def scrapers_for_flow(cls):
-
+def fetch_all_unblocked_scrapers(cls):
     blocked = [PennsylvaniaVaccineDemographics, TableauDashboard, CDCTestingBase]
-
     return list(
         x for x in all_subclasses(cls) if not inspect.isabstract(x) and x not in blocked
     )
 
 
-ALL_SCRAPERS: List[Type[scrapers.DatasetBase]] = scrapers_for_flow(scrapers.DatasetBase)
+ALL_SCRAPERS: List[Type[scrapers.DatasetBase]] = fetch_all_unblocked_scrapers(
+    scrapers.DatasetBase
+)
+
+
+# Data sources currently used by the CAN site/API to be included in Prefect flows.
+# Last updated 08/01/2022
+ACTIVE_SCRAPERS = [
+    # National/federal dataset scrapers
+    scrapers.NYTimesCasesDeaths,
+    scrapers.USAFactsCases,
+    scrapers.USAFactsDeaths,
+    scrapers.HHSReportedPatientImpactHospitalCapacityFacility,
+    scrapers.HHSReportedPatientImpactHospitalCapacityState,
+    scrapers.HHSTestingState,
+    scrapers.CDCCommunityLevelMetrics,
+    scrapers.CDCHistoricalCountyVaccine,
+    scrapers.CDCOriginallyPostedTestingDataset,
+    scrapers.CDCHistoricalTestingDataset,
+    scrapers.CDCUSAVaccine,
+    # State- and county-specific scrapers
+    scrapers.PhiladelphiaVaccine,
+    scrapers.PennsylvaniaCountyVaccines,
+    scrapers.CaliforniaVaccineCounty,
+    scrapers.NewMexicoVaccineCounty,
+    scrapers.VirginiaVaccine,
+    scrapers.VermontCountyVaccine,
+    scrapers.HawaiiVaccineCounty,
+    scrapers.NCVaccine,
+    # Demographic data scrapers
+    *[scraper for scraper in ALL_SCRAPERS if scraper.demographic_data == True],
+]

--- a/can_tools/__init__.py
+++ b/can_tools/__init__.py
@@ -38,19 +38,22 @@ def all_subclasses(cls):
     )
 
 
-def fetch_all_unblocked_scrapers(cls):
+def unblocked_scrapers(cls):
+    # TableauDashboard, CDCTestingBase and PennsylvaniaVaccineDemographics
+    # are base classes that are not functional scrapers, so we explicitly remove them.
     blocked = [PennsylvaniaVaccineDemographics, TableauDashboard, CDCTestingBase]
     return list(
         x for x in all_subclasses(cls) if not inspect.isabstract(x) and x not in blocked
     )
 
 
-ALL_SCRAPERS: List[Type[scrapers.DatasetBase]] = fetch_all_unblocked_scrapers(
+ALL_SCRAPERS: List[Type[scrapers.DatasetBase]] = unblocked_scrapers(
     scrapers.DatasetBase
 )
 
 
 # Data sources currently used by the CAN site/API to be included in Prefect flows.
+# We're currently minimizing our list of active scrapers in order to reduce our Prefect costs.
 # Last updated 08/01/2022
 ACTIVE_SCRAPERS = [
     # National/federal dataset scrapers

--- a/can_tools/scrapers/base.py
+++ b/can_tools/scrapers/base.py
@@ -154,6 +154,10 @@ class DatasetBase(ABC):
     source: str
         A string containing a URL that points to the dashboard or remote
         resource that will be scraped
+
+    demographic_data:
+        Whether the class collects demographic data (e.g. data
+        with breakdowns by age, race, sex, etc.) False by default.
     """
 
     autodag: bool = True
@@ -162,6 +166,7 @@ class DatasetBase(ABC):
     location_type: Optional[str]
     base_path: Path
     source: str
+    demographic_data: bool = False
 
     # this list of tuples specifies categories for which the first
     # category listed should always be less than or equal to the second

--- a/can_tools/scrapers/official/AL/al_vaccine.py
+++ b/can_tools/scrapers/official/AL/al_vaccine.py
@@ -39,6 +39,7 @@ class ALCountyVaccine(ArcGIS):
 
 
 class ALCountyVaccineSex(ALCountyVaccine):
+    demographic_data = True
     variables = {
         "F": CMU(
             category="total_vaccine_initiated",

--- a/can_tools/scrapers/official/AZ/az_demographics.py
+++ b/can_tools/scrapers/official/AZ/az_demographics.py
@@ -12,6 +12,7 @@ class ArizonaVaccineRace(StateDashboard):
     source_name = "ARIZONA DEPARTMENT OF HEALTH SERVICES"
     location_type = "county"
     timezone = "US/Mountain"
+    demographic_data = True
 
     state_fips = us.states.lookup("Arizona").fips
 

--- a/can_tools/scrapers/official/AZ/counties/maricopa_race.py
+++ b/can_tools/scrapers/official/AZ/counties/maricopa_race.py
@@ -8,6 +8,7 @@ class MaricopaVaccineRace(ArizonaMaricopaVaccine):
     variables = {
         1: variables.INITIATING_VACCINATIONS_ALL,
     }
+    demographic_data = True
 
     def fetch(self) -> requests.models.Response:
         url = "https://datawrapper.dwcdn.net/T99SS/4/"

--- a/can_tools/scrapers/official/CA/ca_vaccine.py
+++ b/can_tools/scrapers/official/CA/ca_vaccine.py
@@ -77,6 +77,7 @@ class CaliforniaVaccineDemographics(CaliforniaVaccineCounty):
             unit="people",
         ),
     }
+    demographic_data = True
 
     def normalize(self, data: pd.DataFrame) -> pd.DataFrame:
         data = self._rename_or_add_date_and_location(

--- a/can_tools/scrapers/official/DC/dc_vaccines.py
+++ b/can_tools/scrapers/official/DC/dc_vaccines.py
@@ -77,6 +77,7 @@ class DCVaccineDemographics(DCVaccine):
         "sex": "Gender",
         "ethnicity": "Ethnicity",
     }
+    demographic_data = True
 
     def fetch(self):
         dfs = {}

--- a/can_tools/scrapers/official/DE/de_vaccine.py
+++ b/can_tools/scrapers/official/DE/de_vaccine.py
@@ -56,6 +56,7 @@ class DelawareVaccineDemographics(DelawareCountyVaccine):
         "have_received_at_least_one_dose": variables.INITIATING_VACCINATIONS_ALL,
         "are_fully_vaccinated": variables.FULLY_VACCINATED_ALL,
     }
+    demographic_data = True
 
     def fetch(self) -> Dict[str, requests.models.Response]:
         # each combination of county and dose type has its own page (6 pages total) with the url as below

--- a/can_tools/scrapers/official/GA/ga_vaccines.py
+++ b/can_tools/scrapers/official/GA/ga_vaccines.py
@@ -62,6 +62,7 @@ class GeorgiaCountyVaccineAge(GeorgiaCountyVaccine):
         "75_84": "75-84",
         "85PLUS": "85_plus",
     }
+    demographic_data = True
 
     def normalize(self, data: requests.models.Response) -> pd.DataFrame:
         sheet = pd.read_excel(data.content, sheet_name=self.sheet_name)

--- a/can_tools/scrapers/official/HI/hi_demographics.py
+++ b/can_tools/scrapers/official/HI/hi_demographics.py
@@ -14,6 +14,7 @@ class HawaiiVaccineRace(HawaiiVaccineCounty):
     filterFunctionName = "[sqlproxy.0td6cgz0bpiy7x131qvze0jvbqr1].[none:County:nk]"
     counties = ["Maui", "Hawaii", "Honolulu", "Kauai"]
     baseurl = "https://public.tableau.com"
+    demographic_data = True
 
     variables = {
         "total_vaccine_initiated": variables.INITIATING_VACCINATIONS_ALL,

--- a/can_tools/scrapers/official/IL/il_vaccine_demographics.py
+++ b/can_tools/scrapers/official/IL/il_vaccine_demographics.py
@@ -12,6 +12,7 @@ class ILVaccineRace(StateDashboard):
     state_fips = int(us.states.lookup("Illinois").fips)
     url = "https://idph.illinois.gov/DPHPublicInformation/api/covidvaccine/getVaccineAdministrationDemos?countyname={county}"
     location_type = "county"
+    demographic_data = True
 
     variables = {
         "PersonsVaccinatedOneDose": variables.INITIATING_VACCINATIONS_ALL,

--- a/can_tools/scrapers/official/LA/la_county.py
+++ b/can_tools/scrapers/official/LA/la_county.py
@@ -47,6 +47,7 @@ class LAVaccineCountyDemographics(LAVaccineCounty):
         "PercInt": variables.INITIATING_VACCINATIONS_ALL,
         "PercComp": variables.FULLY_VACCINATED_ALL,
     }
+    demographic_data = True
 
     def normalize(self, data):
         data = self.arcgis_jsons_to_df(data)

--- a/can_tools/scrapers/official/MA/ma_vaccines.py
+++ b/can_tools/scrapers/official/MA/ma_vaccines.py
@@ -15,6 +15,7 @@ class MassachusettsVaccineDemographics(StateDashboard):
     location_type = "county"
     state_fips = int(us.states.lookup("Massachusetts").fips)
     has_location = False
+    demographic_data = True
 
     variables = {
         "Fully vaccinated individuals": variables.FULLY_VACCINATED_ALL,

--- a/can_tools/scrapers/official/ME/me_vaccines.py
+++ b/can_tools/scrapers/official/ME/me_vaccines.py
@@ -237,6 +237,7 @@ class MaineRaceVaccines(MicrosoftBIDashboard):
 
     demographic = "race"
     demographic_query_name = "Race"
+    demographic_data = True
 
     variables = {
         "initiated_total": v.INITIATING_VACCINATIONS_ALL,

--- a/can_tools/scrapers/official/MI/mi_vaccine_demographics.py
+++ b/can_tools/scrapers/official/MI/mi_vaccine_demographics.py
@@ -11,6 +11,7 @@ class MIVaccineRaceAge(StateDashboard):
     state_fips = int(us.states.lookup("Michigan").fips)
     url = "https://www.michigan.gov/documents/coronavirus/Ethnicity-Race_Coverage_by_County-20210820_733398_7.xlsx"
     location_type = "county"
+    demographic_data = True
 
     variables = {
         "Initiation": variables.INITIATING_VACCINATIONS_ALL,

--- a/can_tools/scrapers/official/MN/mn_vaccine.py
+++ b/can_tools/scrapers/official/MN/mn_vaccine.py
@@ -218,6 +218,7 @@ class MinnesotaCountyAgeVaccines(MinnesotaCountyVaccines):
         "initiating": v.INITIATING_VACCINATIONS_ALL,
         "completing": v.FULLY_VACCINATED_ALL,
     }
+    demographic_data = True
 
     def construct_body(self, resource_key, ds_id, model_id, report_id, county):
 

--- a/can_tools/scrapers/official/MT/mt_vaccinations.py
+++ b/can_tools/scrapers/official/MT/mt_vaccinations.py
@@ -84,6 +84,7 @@ class MontanaStateVaccine(MontanaCountyVaccine):
         "Total_Montanans_Immunized": variables.FULLY_VACCINATED_ALL,
         "Total_Doses_Administered": variables.TOTAL_DOSES_ADMINISTERED_ALL,
     }
+    demographic_data = True
 
     def fetch(self):
         return self.get_all_jsons("COVID_Vaccination_PRD_View", 1, "")

--- a/can_tools/scrapers/official/NH/nh_demographics.py
+++ b/can_tools/scrapers/official/NH/nh_demographics.py
@@ -15,6 +15,7 @@ class NHVaccineRace(StateDashboard):
     source = "https://www.covid19.nh.gov/dashboard/vaccination"
     source_name = "New Hampshire DHHS"
     location_type = "county"
+    demographic_data = True
 
     state_fips = us.states.lookup("New Hampshire").fips
 

--- a/can_tools/scrapers/official/NY/ny_vaccine.py
+++ b/can_tools/scrapers/official/NY/ny_vaccine.py
@@ -53,6 +53,7 @@ class NewYorkVaccineCountyAge(NewYorkVaccineCounty):
     demographic = "age"
     demographic_column = "Age Group-alias"
     data_tableau_table = "Demographics by Age"
+    demographic_data = True
 
     variables = {
         "People with at least one Vaccine Dose": variables.INITIATING_VACCINATIONS_ALL,

--- a/can_tools/scrapers/official/OH/oh_vaccine_demographics.py
+++ b/can_tools/scrapers/official/OH/oh_vaccine_demographics.py
@@ -24,6 +24,7 @@ class OHVaccineCountyRace(StateDashboard):
         "native hawaiian pacific islander": "pacific_islander",
         "multiracial": "multiple",
     }
+    demographic_data = True
 
     # map wide form column names into CMUs
     variables = {

--- a/can_tools/scrapers/official/OR/or_vaccine_demographics.py
+++ b/can_tools/scrapers/official/OR/or_vaccine_demographics.py
@@ -35,6 +35,7 @@ class OregonVaccineRace(TableauDashboard):
 
     data_tableau_table = "Cty Race"
     timezone = "US/Pacific"
+    demographic_data = True
 
     def fetch(self):
         counties = self._retrieve_counties()

--- a/can_tools/scrapers/official/PA/pa_vaccines.py
+++ b/can_tools/scrapers/official/PA/pa_vaccines.py
@@ -209,6 +209,7 @@ class PennsylvaniaVaccineDemographics(MicrosoftBIDashboard, ABC):
         "Out-of-State*",
     ]
     location_names_to_replace = {"Mckean": "McKean"}
+    demographic_data = True
 
     # Reshape
     variables = {

--- a/can_tools/scrapers/official/SC/sc_demographics.py
+++ b/can_tools/scrapers/official/SC/sc_demographics.py
@@ -20,6 +20,7 @@ class SCVaccineRace(StateDashboard):
     demographic = "race"
     demographic_column = "Assigned Race For Rate-value"
     demographic_table = "at least 1 3 Age Groups x B W"
+    demographic_data = True
 
     def fetch(self):
         engine = TableauScraper()

--- a/can_tools/scrapers/official/SD/sd_vaccine_demographics.py
+++ b/can_tools/scrapers/official/SD/sd_vaccine_demographics.py
@@ -14,6 +14,7 @@ class SDVaccineSex(MicrosoftBIDashboard):
     has_location = False
     location_type = "county"
     state_fips = int(us.states.lookup("South Dakota").fips)
+    demographic_data = True
 
     source = "https://doh.sd.gov/COVID/Dashboard.aspx"
     source_name = "South Dakota Department of Health"

--- a/can_tools/scrapers/official/TX/texas_vaccine.py
+++ b/can_tools/scrapers/official/TX/texas_vaccine.py
@@ -124,6 +124,7 @@ class TexasStateVaccine(TexasCountyVaccine):
 class TXVaccineCountyAge(TexasVaccineParent):
     location_type = "county"
     has_location = False
+    demographic_data = True
     cmus = {
         "Doses Administered": CMU(
             category="total_vaccine_doses_administered",

--- a/can_tools/scrapers/official/VA/va_vaccine.py
+++ b/can_tools/scrapers/official/VA/va_vaccine.py
@@ -62,6 +62,7 @@ class VirginiaCountyVaccineDemographics(VirginiaVaccine):
     filterFunctionValue = None
     has_location = False
     location_type = "county"
+    demographic_data = True
 
     secondaryFilterFunctionName = "[Parameters].[Parameter 1]"
     secondaryFilterValues = ["full", "one"]

--- a/can_tools/scrapers/official/WA/wa_vaccine.py
+++ b/can_tools/scrapers/official/WA/wa_vaccine.py
@@ -153,6 +153,7 @@ class WashingtonVaccine(MicrosoftBIDashboard):
 
 class WashingtonVaccineCountyRace(WashingtonVaccine):
 
+    demographic_data = True
     col_mapping = {
         "G0": "location_name",
         "M_1_DM3_{demo}_C_1": "initiated",

--- a/can_tools/scrapers/official/WI/wi_demographic_vaccine.py
+++ b/can_tools/scrapers/official/WI/wi_demographic_vaccine.py
@@ -12,7 +12,7 @@ class WisconsinVaccineCountyRace(TableauDashboard):
     source = "https://www.dhs.wisconsin.gov/covid-19/vaccine-data.htm#summary"
     source_name = "Wisconsin Department of Health Services"
     state_fips = int(us.states.lookup("Wisconsin").fips)
-
+    demographic_data = True
     timezone = "US/Central"
 
     demographic_worksheet = "Race vax/unvax county"

--- a/can_tools/scrapers/official/WV/wv_vaccine.py
+++ b/can_tools/scrapers/official/WV/wv_vaccine.py
@@ -198,6 +198,7 @@ class WVCountyVaccine(MicrosoftBIDashboard):
 class WVCountyVaccineRace(WVCountyVaccine):
     demographic = "race"
     demographic_query_name = "Race"
+    demographic_data = True
     col_mapping = {
         "G0": "location_name",
         "M_1_DM3_0_C_1": "black",

--- a/services/prefect/flows/generated_flows.py
+++ b/services/prefect/flows/generated_flows.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import sentry_sdk
 import sqlalchemy as sa
 
-from can_tools import ALL_SCRAPERS, scrapers
+from can_tools import ACTIVE_SCRAPERS, scrapers
 from can_tools.scrapers.base import DatasetBase
 import prefect
 from prefect import Flow, task, case
@@ -138,7 +138,7 @@ def create_flow_for_scraper(ix: int, cls: Type[DatasetBase], schedule=True):
 
 
 def create_main_flow(flows: List[Flow], project_name):
-    schedule = CronSchedule("0 */4 * * *")
+    schedule = CronSchedule("0 */5 * * *")
 
     with Flow("MainFlow", schedule) as main_flow:
         tasks = []
@@ -168,16 +168,17 @@ def create_main_flow(flows: List[Flow], project_name):
 
 def init_flows():
     flows = []
-    for ix, cls in enumerate(ALL_SCRAPERS):
+    print(ACTIVE_SCRAPERS)
+    for ix, cls in enumerate(ACTIVE_SCRAPERS):
         if not cls.autodag:
             continue
         flow = create_flow_for_scraper(ix, cls, schedule=False)
         flows.append(flow)
-        flow.register(project_name="can-scrape")
+        flow.register(project_name="test")
 
     flows = [flow for flow in flows if flow not in FLOWS_EXCLUDED_FROM_MAIN_FLOW]
-    flow = create_main_flow(flows, "can-scrape")
-    flow.register(project_name="can-scrape")
+    flow = create_main_flow(flows, "test")
+    flow.register(project_name="test")
 
 
 if __name__ == "__main__":

--- a/services/prefect/flows/generated_flows.py
+++ b/services/prefect/flows/generated_flows.py
@@ -174,11 +174,11 @@ def init_flows():
             continue
         flow = create_flow_for_scraper(ix, cls, schedule=False)
         flows.append(flow)
-        flow.register(project_name="test")
+        flow.register(project_name="can-scrape")
 
     flows = [flow for flow in flows if flow not in FLOWS_EXCLUDED_FROM_MAIN_FLOW]
-    flow = create_main_flow(flows, "test")
-    flow.register(project_name="test")
+    flow = create_main_flow(flows, "can-scrape")
+    flow.register(project_name="can-scrape")
 
 
 if __name__ == "__main__":

--- a/services/prefect/flows/generated_flows.py
+++ b/services/prefect/flows/generated_flows.py
@@ -168,7 +168,6 @@ def create_main_flow(flows: List[Flow], project_name):
 
 def init_flows():
     flows = []
-    print(ACTIVE_SCRAPERS)
     for ix, cls in enumerate(ACTIVE_SCRAPERS):
         if not cls.autodag:
             continue


### PR DESCRIPTION
Decreases the number of scrapers executed in the `MainFlow`s from 114 to 75. The majority of the remaining scrapers are state-specific demographic vaccine scrapers. 

This disables any scrapers not currently used further downstream in the pipeline, including those that don't collect timeseries data. So, if we want to re-activate those scrapers in the future we will be missing chunks of timeseries data, but I find it unlikely that we'll do so (and I don't think it's a huge deal considering the stable/stagnant nature of the vaccine data). 