### PR TITLE
Remove validation task run from scraper flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ example, scrapers that extract data from North Carolina Deparment of Health are 
 ## Writing a new scraper
 
 Behind the scenes of every scraper written in `can-tools` are abstract base
-classes (ABC). These ABCs define abstract methods `fetch`, `normalize`, `validate`,
+classes (ABC). These ABCs define abstract methods `fetch`, `normalize`,
 and `put` which must be implemented in order to create a scraper.
 
 * The `fetch` method is responsible for making network requests. It should request
@@ -95,14 +95,12 @@ and `put` which must be implemented in order to create a scraper.
   and return a DataFrame with columns `(vintage, dt, location, category,
   measurement, unit, age, race, ethnicity, sex, value)`. See existing methods for
   examples
-* The `validate` method should verify the data to ensure that it passes any
-  necessary sanity checks.
 * The `put` method takes a SQL connection and a DataFrame and then puts the
   DataFrame into the SQL database. This is taken care of by parent classes and
   does not need to be updated manuallly
 
-Most scrapers will not require one to write the `validate` or put methods because
-the generic methods should be able to validate the data and dump it into the database
+Most scrapers will not require one to write the put methods because
+the generic methods should be able to dump the data into the database
 
 All scrapers must inherit from `DatasetBase`, but this typically happens by subclassing 
 a resource specific parent class like `TableauDashboard` or `ArcGIS`.

--- a/can_tools/scrapers/base.py
+++ b/can_tools/scrapers/base.py
@@ -78,12 +78,6 @@ class RequestError(Exception):
     pass
 
 
-class ValidateDataFailedError(Exception):
-    """Error raised when data vailidation fails."""
-
-    pass
-
-
 class ValidateRelativeOrderOfCategoriesError(Exception):
     def __init__(self, category_small, category_large, problems):
         self.category_small = category_small
@@ -526,49 +520,6 @@ class DatasetBase(ABC):
 
         return issues
 
-    def validate(self, df, df_hist):
-        """
-        The `validate` method checks what the tentative clean data looks
-        like and then checks whether the updates are sensible -- If they
-        are then it returns True otherwise it returns False and stops
-        the fetch->normalize->validate->put DAG
-
-        Raises Exceptions if validation fails
-
-        Parameters
-        ----------
-        df : pd.DataFrame
-            The data that is being proposed for put
-        df_hist : pd.DataFrame
-            Historical data
-
-        """
-        # TODO (SL, 2021-04-12): we aren't ready with other tooling for dealing
-        # nicely with validation errors and exception lists. Until then we will
-        # disable validation
-        return
-        issues = []
-        if utils.is_time_series(df):
-            issues.extend(self._validate_time_series(df))
-
-        issues.extend(self._validate_order_of_variables(df))
-
-        if len(issues) > 0:
-            raise ValidationErrors(issues)
-
-    def _validate(self):
-        """
-        The `_validate` method loads the appropriate data and then
-        checks the data using `validate` and determines whether the
-        data has been validated
-        """
-        # Load cleaned data
-        df = self._read_clean()
-        df_hist = None
-
-        # Validate data
-        return self.validate(df, df_hist)
-
     def put(self, engine: Engine, df: pd.DataFrame) -> bool:
         """
         Read DataFrame `df` from storage and put into corresponding
@@ -629,8 +580,5 @@ class DatasetBase(ABC):
     def reprocess_from_already_fetched_data(self, engine: Engine):
         """Reprocesses data from fetched data - useful to fix errors after fetch."""
         self._normalize()
-
-        # validate will either succeed or raise an Exception
-        self._validate()
 
         self._put(engine)

--- a/can_tools/scrapers/usafacts/data.py
+++ b/can_tools/scrapers/usafacts/data.py
@@ -84,12 +84,6 @@ class USAFactsBase(FederalDashboard):
             ["variable"], axis="columns"
         )
 
-    def validate(self, df, df_hist):
-        # Overriding validate method to not fail for usa facts because
-        # county cumulative case/death reporting has dips because of local corrections.
-        # TODO(chris): Add option to skip increasing over time validate check.
-        return
-
 
 class USAFactsCases(USAFactsBase, ETagCacheMixin):
     """

--- a/docs-src/scraping/structure.rst
+++ b/docs-src/scraping/structure.rst
@@ -125,7 +125,6 @@ We will do this by writing code needed for running the scraper
     scraper = NewJerseyVaccineCounty()
     raw = scraper.fetch()
     clean = scraper.normalize(raw)
-    scraper.validate(clean)
     scraper.put(engine, clean)
 
 The line by line description of this code is
@@ -133,5 +132,4 @@ The line by line description of this code is
 1. Create an instance of the scraper class. We can optionally pass ``execution_dt`` as an argument
 2. Call the ``.fetch`` method to do network requests and get ``raw`` data. This method is typically defined directly in the child class
 3. Call the ``.normalize(raw)`` method to get a cleaned DataFrame. This method is also typically defined directly in the child class. Implementing the ``.fetch`` and ``.normalize`` methods is the core of what we mean when we say "write a scraper"
-4. Call the ``.validate(clean)`` method to check the data. There is a default ``validate`` method in ``DatasetBase``, but you can override if you know something specific needs to be checked for the scraper you are working on
-5. Call ``.put(engine, clean)`` to store the data in the database backing the sqlalchemy Engine ``engine``. This is written in ``StateDashboard`` and should not need to be overwridden in child classes
+4. Call ``.put(engine, clean)`` to store the data in the database backing the sqlalchemy Engine ``engine``. This is written in ``StateDashboard`` and should not need to be overwridden in child classes

--- a/docs/_sources/scraping/structure.rst.txt
+++ b/docs/_sources/scraping/structure.rst.txt
@@ -125,7 +125,6 @@ We will do this by writing code needed for running the scraper
     scraper = NewJerseyVaccineCounty()
     raw = scraper.fetch()
     clean = scraper.normalize(raw)
-    scraper.validate(clean)
     scraper.put(engine, clean)
 
 The line by line description of this code is
@@ -133,5 +132,4 @@ The line by line description of this code is
 1. Create an instance of the scraper class. We can optionally pass ``execution_dt`` as an argument
 2. Call the ``.fetch`` method to do network requests and get ``raw`` data. This method is typically defined directly in the child class
 3. Call the ``.normalize(raw)`` method to get a cleaned DataFrame. This method is also typically defined directly in the child class. Implementing the ``.fetch`` and ``.normalize`` methods is the core of what we mean when we say "write a scraper"
-4. Call the ``.validate(clean)`` method to check the data. There is a default ``validate`` method in ``DatasetBase``, but you can override if you know something specific needs to be checked for the scraper you are working on
-5. Call ``.put(engine, clean)`` to store the data in the database backing the sqlalchemy Engine ``engine``. This is written in ``StateDashboard`` and should not need to be overwridden in child classes
+4. Call ``.put(engine, clean)`` to store the data in the database backing the sqlalchemy Engine ``engine``. This is written in ``StateDashboard`` and should not need to be overwridden in child classes

--- a/docs/scraping/structure.html
+++ b/docs/scraping/structure.html
@@ -182,7 +182,6 @@ to new location_name</p></li>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="linenos">1</span><span class="n">scraper</span> <span class="o">=</span> <span class="n">NewJerseyVaccineCounty</span><span class="p">()</span>
 <span class="linenos">2</span><span class="n">raw</span> <span class="o">=</span> <span class="n">scraper</span><span class="o">.</span><span class="n">fetch</span><span class="p">()</span>
 <span class="linenos">3</span><span class="n">clean</span> <span class="o">=</span> <span class="n">scraper</span><span class="o">.</span><span class="n">normalize</span><span class="p">(</span><span class="n">raw</span><span class="p">)</span>
-<span class="linenos">4</span><span class="n">scraper</span><span class="o">.</span><span class="n">validate</span><span class="p">(</span><span class="n">clean</span><span class="p">)</span>
 <span class="linenos">5</span><span class="n">scraper</span><span class="o">.</span><span class="n">put</span><span class="p">(</span><span class="n">engine</span><span class="p">,</span> <span class="n">clean</span><span class="p">)</span>
 </pre></div>
 </div>
@@ -191,7 +190,6 @@ to new location_name</p></li>
 <li><p>Create an instance of the scraper class. We can optionally pass <code class="docutils literal notranslate"><span class="pre">execution_dt</span></code> as an argument</p></li>
 <li><p>Call the <code class="docutils literal notranslate"><span class="pre">.fetch</span></code> method to do network requests and get <code class="docutils literal notranslate"><span class="pre">raw</span></code> data. This method is typically defined directly in the child class</p></li>
 <li><p>Call the <code class="docutils literal notranslate"><span class="pre">.normalize(raw)</span></code> method to get a cleaned DataFrame. This method is also typically defined directly in the child class. Implementing the <code class="docutils literal notranslate"><span class="pre">.fetch</span></code> and <code class="docutils literal notranslate"><span class="pre">.normalize</span></code> methods is the core of what we mean when we say “write a scraper”</p></li>
-<li><p>Call the <code class="docutils literal notranslate"><span class="pre">.validate(clean)</span></code> method to check the data. There is a default <code class="docutils literal notranslate"><span class="pre">validate</span></code> method in <code class="docutils literal notranslate"><span class="pre">DatasetBase</span></code>, but you can override if you know something specific needs to be checked for the scraper you are working on</p></li>
 <li><p>Call <code class="docutils literal notranslate"><span class="pre">.put(engine,</span> <span class="pre">clean)</span></code> to store the data in the database backing the sqlalchemy Engine <code class="docutils literal notranslate"><span class="pre">engine</span></code>. This is written in <code class="docutils literal notranslate"><span class="pre">StateDashboard</span></code> and should not need to be overwridden in child classes</p></li>
 </ol>
 </section>

--- a/services/prefect/flows/generated_flows.py
+++ b/services/prefect/flows/generated_flows.py
@@ -123,13 +123,11 @@ def create_flow_for_scraper(ix: int, cls: Type[DatasetBase], schedule=True):
             d = create_scraper(cls)
             fetched = fetch(d)
             normalized = normalize(d)
-            validated = validate(d)
             done = put(d, connstr)
 
             d.set_upstream(sentry_sdk_task)
             normalized.set_upstream(fetched)
-            validated.set_upstream(normalized)
-            done.set_upstream(validated)
+            done.set_upstream(normalized)
 
         with case(new_data, False):
             skip_cached_flow()

--- a/services/prefect/flows/generated_flows.py
+++ b/services/prefect/flows/generated_flows.py
@@ -52,12 +52,6 @@ def normalize(d: DatasetBase):
     logger.info("Saved clean data to: {}".format(fn))
 
 
-@task()
-def validate(d: DatasetBase):
-    # validation either completes successfully or raises an exception
-    d._validate()
-
-
 @task(max_retries=3, retry_delay=timedelta(minutes=1))
 def put(d: DatasetBase, connstr: str):
     logger = prefect.context.get("logger")

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -68,8 +68,6 @@ def test_datasets(cls):
     assert clean.shape[0] > 0
     _test_data_structure(d, clean)
 
-    d.validate(clean, None)
-
     try:
         d.put(engine, clean)
     except sa.exc.IntegrityError:

--- a/training/training.html
+++ b/training/training.html
@@ -583,8 +583,6 @@ The unit tests do the following:
 </li>
 </ul>
 </li>
-<li>The <code>validate</code> method runs without any issues and returns <code>True</code>
-</li>
 </ul>
 
 <p>
@@ -740,8 +738,6 @@ The scrapers are defined by 4 operations:
 </li>
 <li>Normalize: Ingests raw data and spits out normalized data
 </li>
-<li>Validate: Makes sure that the new normalized data is sensible
-</li>
 <li>Put: Puts data into our database
 </li>
 </ol>
@@ -850,15 +846,13 @@ As seen in <a href="#sec-6">Scraper Library</a>, a scraper requires 4 methods:
 </li>
 <li><code>normalize</code>
 </li>
-<li><code>validate</code>
-</li>
 <li><code>put</code>
 </li>
 </ol>
 
 <p>
-Most scrapers will <b>not</b> require one to write the <code>validate</code> or <code>put</code> methods
-because the generic methods should be able to validate the data and dump it into
+Most scrapers will <b>not</b> require one to write the <code>put</code> method
+because the generic methods should be able to dump the data into
 the database
 </p>
 </div>

--- a/training/training.org
+++ b/training/training.org
@@ -220,7 +220,6 @@ Finally the =data.covid_providers= table
     - Verify that the =normalize= method returns a DataFrame that
       - Is not empty
       - Has the correct columns
-    - The =validate= method runs without any issues and returns =True=
 
     The integration tests test that the =put= method can successfully load the
     data into a test instance of the database (see below).
@@ -309,8 +308,7 @@ The scrapers are defined by 4 operations:
 
 1. Fetch: Retrieves raw data from dashboard
 2. Normalize: Ingests raw data and spits out normalized data
-3. Validate: Makes sure that the new normalized data is sensible
-4. Put: Puts data into our database
+3. Put: Puts data into our database
 
 #+CAPTION: Scraper flow chart
 #+NAME: fig:CANSRAPERS
@@ -338,7 +336,6 @@ It is found in =can-scrapers/can_tools/scrapers/base.py=
 **Methods that will be defined for you**
 
 - =put=
-- =validate=: a very basic version
 - =
 
 *** =StateDashboard= or =CountyDashboard=
@@ -369,11 +366,10 @@ As seen in [[Scraper Library]], a scraper requires 4 methods:
 
 1. =fetch=
 2. =normalize=
-3. =validate=
-4. =put=
+3. =put=
 
-Most scrapers will *not* require one to write the =validate= or =put= methods
-because the generic methods should be able to validate the data and dump it into
+Most scrapers will *not* require one to write the =put= method
+because the generic methods should be able to dump the data it into
 the database
 
 * Example Scrapers


### PR DESCRIPTION
Remove the validate task from scraper flows as validation is currently disabled (and has been for > a year). This leaves the actual/underlying validation code untouched