### PR TITLE
Update CDC Monkeypox cases scraper

### DIFF
--- a/can_tools/scrapers/monkeypox/federal/CDC/current_cases.py
+++ b/can_tools/scrapers/monkeypox/federal/CDC/current_cases.py
@@ -36,11 +36,15 @@ class CDCCurrentMonkeypoxCases(FederalDashboard):
             return await page.evaluate("x => x.outerHTML", table)
 
     def fetch(self):
-        return asyncio.get_event_loop().run_until_complete(self._get_table_from_browser())
+        return asyncio.get_event_loop().run_until_complete(
+            self._get_table_from_browser()
+        )
 
     def normalize(self, data: pd.DataFrame) -> pd.DataFrame:
         data = pd.read_html(data)[0].assign(
-            location=lambda row: row["LocationSort by location in no order"].map(_lookup), 
-            dt=self._retrieve_dt()
+            location=lambda row: row["LocationSort by location in no order"].map(
+                _lookup
+            ),
+            dt=self._retrieve_dt(),
         )
         return self._reshape_variables(data=data, variable_map=self.variables)

--- a/can_tools/scrapers/monkeypox/federal/CDC/current_cases.py
+++ b/can_tools/scrapers/monkeypox/federal/CDC/current_cases.py
@@ -1,7 +1,8 @@
 from can_tools.scrapers.base import CMU
 from can_tools.scrapers.official.base import FederalDashboard
 import pandas as pd
-import requests
+from can_tools.scrapers.puppet import with_page
+import asyncio
 import us
 
 
@@ -21,21 +22,25 @@ class CDCCurrentMonkeypoxCases(FederalDashboard):
     provider = "cdc"
 
     variables = {
-        "Cases": CMU(
+        "CasesSort by cases in no order": CMU(
             category="monkeypox_cases",
             measurement="cumulative",
             unit="people",
         )
     }
 
+    async def _get_table_from_browser(self):
+        async with with_page(headless=True) as page:
+            await page.goto(self.source)
+            table = await page.J(".data-table")
+            return await page.evaluate("x => x.outerHTML", table)
+
     def fetch(self):
-        response = requests.get(self.fetch_url)
-        response.raise_for_status()
-        return response.json()
+        return asyncio.get_event_loop().run_until_complete(self._get_table_from_browser())
 
     def normalize(self, data: pd.DataFrame) -> pd.DataFrame:
-        data = pd.DataFrame.from_records(data["data"])
-        data = data.loc[data["State"] != "Non-US Resident"].assign(
-            location=lambda row: row["State"].map(_lookup), dt=self._retrieve_dt()
+        data = pd.read_html(data)[0].assign(
+            location=lambda row: row["LocationSort by location in no order"].map(_lookup), 
+            dt=self._retrieve_dt()
         )
         return self._reshape_variables(data=data, variable_map=self.variables)


### PR DESCRIPTION
The endpoint that's used to generate the [Monkeypox cases page](https://www.cdc.gov/poxvirus/monkeypox/response/2022/us-map.html) seems to be changing/not be super stable at the moment, causing our data to not always be up to date. This updates the scraper to pull directly from the HTML table on the page, instead of trying to hit the underlying endpoint.  

Two examples of the endpoints:
https://www.cdc.gov/poxvirus/monkeypox/response/modules/MX-response-case-count-US.json
https://www.cdc.gov/poxvirus/monkeypox/modules/data-viz/mpx-maps.json