### PR TITLE
Update CDC Testing scrapers

### DIFF
--- a/can_tools/__init__.py
+++ b/can_tools/__init__.py
@@ -66,6 +66,9 @@ ACTIVE_SCRAPERS = [
     scrapers.CDCCommunityLevelMetrics,
     scrapers.CDCHistoricalCountyVaccine,
     scrapers.CDCOriginallyPostedTestingDataset,
+    # TODO(sean) 2022-08-31: Disabling this scraper as the dataset is currently empty.
+    # Re-enable once the dataset is updated.
+    # scrapers.CDCHistoricalTestingDataset,
     scrapers.CDCUSAVaccine,
     scrapers.CDCStateVaccine,
     # State- and county-specific scrapers

--- a/can_tools/__init__.py
+++ b/can_tools/__init__.py
@@ -66,7 +66,6 @@ ACTIVE_SCRAPERS = [
     scrapers.CDCCommunityLevelMetrics,
     scrapers.CDCHistoricalCountyVaccine,
     scrapers.CDCOriginallyPostedTestingDataset,
-    scrapers.CDCHistoricalTestingDataset,
     scrapers.CDCUSAVaccine,
     scrapers.CDCStateVaccine,
     # State- and county-specific scrapers

--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -43,7 +43,6 @@ from can_tools.scrapers.official.DC.dc_vaccines import (
 )
 
 from can_tools.scrapers.official.federal.CDC.cdc_testing_cases import (
-    CDCHistoricalTestingDataset,
     CDCOriginallyPostedTestingDataset,
     CDCTestingBase,
 )

--- a/can_tools/scrapers/__init__.py
+++ b/can_tools/scrapers/__init__.py
@@ -43,6 +43,7 @@ from can_tools.scrapers.official.DC.dc_vaccines import (
 )
 
 from can_tools.scrapers.official.federal.CDC.cdc_testing_cases import (
+    CDCHistoricalTestingDataset,
     CDCOriginallyPostedTestingDataset,
     CDCTestingBase,
 )

--- a/can_tools/scrapers/official/federal/CDC/cdc_testing_cases.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_testing_cases.py
@@ -82,21 +82,9 @@ class CDCTestingBase(FederalDashboard, ETagCacheMixin):
         return data.groupby(group_columns).agg({"value": "last"}).reset_index()
 
 
-class CDCHistoricalTestingDataset(CDCTestingBase):
-    source = "https://data.cdc.gov/Public-Health-Surveillance/United-States-COVID-19-County-Level-of-Community-T/nra9-vzzn/data"
-    fetch_url = "https://data.cdc.gov/resource/nra9-vzzn.json"
-    date_column = "date"
-    cache_file = "cdc_historical_testing.txt"
-
-    # We used to also collect CDC testing data via the CDCCovidDataTracker class.
-    # In order to not overwrite/mix the data sources we use the cdc2 provider instead of cdc.
-    # 11/1/21: This is the offical CDC testing dataset and the one that is used by the pipeline downstream.
-    provider = "cdc2"
-
-
 class CDCOriginallyPostedTestingDataset(CDCTestingBase):
-    source = "https://data.cdc.gov/Public-Health-Surveillance/United-States-COVID-19-County-Level-of-Community-T/8396-v7yb"
-    fetch_url = "https://data.cdc.gov/resource/8396-v7yb.json"
+    source = "https://data.cdc.gov/Public-Health-Surveillance/Weekly-COVID-19-County-Level-of-Community-Transmis/dt66-w6m6/"
+    fetch_url = "https://data.cdc.gov/resource/dt66-w6m6.json"
     date_column = "report_date"
     cache_file = "cdc_originally_posted_testing.txt"
 

--- a/can_tools/scrapers/official/federal/CDC/cdc_testing_cases.py
+++ b/can_tools/scrapers/official/federal/CDC/cdc_testing_cases.py
@@ -82,6 +82,18 @@ class CDCTestingBase(FederalDashboard, ETagCacheMixin):
         return data.groupby(group_columns).agg({"value": "last"}).reset_index()
 
 
+class CDCHistoricalTestingDataset(CDCTestingBase):
+    source = "https://data.cdc.gov/Public-Health-Surveillance/United-States-COVID-19-County-Level-of-Community-T/jgk8-6dpn/"
+    fetch_url = "https://data.cdc.gov/resource/jgk8-6dpn.json"
+    date_column = "date"
+    cache_file = "cdc_historical_testing.txt"
+
+    # We used to also collect CDC testing data via the CDCCovidDataTracker class.
+    # In order to not overwrite/mix the data sources we use the cdc2 provider instead of cdc.
+    # 11/1/21: This is the offical CDC testing dataset and the one that is used by the pipeline downstream.
+    provider = "cdc2"
+
+
 class CDCOriginallyPostedTestingDataset(CDCTestingBase):
     source = "https://data.cdc.gov/Public-Health-Surveillance/Weekly-COVID-19-County-Level-of-Community-Transmis/dt66-w6m6/"
     fetch_url = "https://data.cdc.gov/resource/dt66-w6m6.json"


### PR DESCRIPTION
Updates the CDC testing scrapers to the new weekly datasets. Disables the "Historical Changes" dataset for now, as there's no data in the dataset (causing the tests/scraper to fail). 

Currently, in `covid-data-model` we combine the data from the two datasets because The "As Originally Posted" data was typically a couple of days ahead of the "Historical Changes" data, but this might not be necessary going forward, depending on the content of the new weekly "Historical Changes" data