### PR TITLE
Enable CDC historical testing dataset scraper

### DIFF
--- a/can_tools/__init__.py
+++ b/can_tools/__init__.py
@@ -66,9 +66,7 @@ ACTIVE_SCRAPERS = [
     scrapers.CDCCommunityLevelMetrics,
     scrapers.CDCHistoricalCountyVaccine,
     scrapers.CDCOriginallyPostedTestingDataset,
-    # TODO(sean) 2022-08-31: Disabling this scraper as the dataset is currently empty.
-    # Re-enable once the dataset is updated.
-    # scrapers.CDCHistoricalTestingDataset,
+    scrapers.CDCHistoricalTestingDataset,
     scrapers.CDCUSAVaccine,
     scrapers.CDCStateVaccine,
     # State- and county-specific scrapers


### PR DESCRIPTION
The [CDC's new historical testing dataset](https://data.cdc.gov/Public-Health-Surveillance/Weekly-COVID-19-County-Level-of-Community-Transmis/jgk8-6dpn) now has actual data, so we should enable its scraper. This data source gets picked up by `covid-data-model`, so no further changes should be necessary.