### PR TITLE
Revert change to NYT scraper that broke in prod.

### DIFF
--- a/can_tools/scrapers/nytimes/nyt_cases_deaths.py
+++ b/can_tools/scrapers/nytimes/nyt_cases_deaths.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from numpy import nan
-from typing import List, Optional, Tuple, Dict
+from typing import List, Tuple, Dict
 from can_tools.scrapers.official.base import FederalDashboard, ETagCacheMixin
 
 from can_tools.scrapers.variables import (
@@ -136,13 +136,9 @@ class NYTimesCasesDeaths(FederalDashboard, ETagCacheMixin):
         )
         super().__init__(execution_dt=execution_dt)
 
-    def fetch(self, files=Optional[Dict[str, List[str]]]) -> pd.DataFrame:
-        # Allow us to pass in a subset of files to speed up testing.
-        if files is None:
-            files = self.file_slugs
-
+    def fetch(self) -> pd.DataFrame:
         data = []
-        for location_type, files in files.items():
+        for location_type, files in self.file_slugs.items():
             for file in files:
                 location = pd.read_csv(
                     NYTIMES_RAW_BASE_URL + file, dtype={"fips": str}

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -58,18 +58,9 @@ def test_datasets(cls):
     execution_date = (pd.Timestamp.today() - pd.Timedelta("1 days")).strftime(
         "%Y-%m-%d"
     )
-    d: DatasetBase = cls(execution_date)
+    d = cls(execution_date)
 
-    # NYT scraper runs out of memory on GitHub Actions test runner
-    # so we only test a subset of their data.
-    if cls.__name__ == "NYTimesCasesDeaths":
-        files = {
-            "state": ["us-states.csv"],
-            "nation": ["us.csv"],
-        }
-        raw = d.fetch(files=files)
-    else:
-        raw = d.fetch()
+    raw = d.fetch()
 
     assert raw is not None
     clean = d.normalize(raw)


### PR DESCRIPTION
Reverts part of https://github.com/covid-projections/can-scrapers/pull/452.  Not 100% sure how this all works, but it looks like `fetch()` receives some additional args when running normally which caused stuff to break.

See https://cloud.prefect.io/actnow/task-run/f1aacad5-b2d8-4c90-85ac-f729314af8a2?logs

> Flow 'spry-caterpillar-NYTimesCasesDeaths': Task 'fetch': Exception encountered during task execution!
> Traceback (most recent call last):
>   File "/home/sglyon/miniconda/envs/prefect-can-scrapers/lib/python3.7/site-packages/prefect/engine/task_runner.py", line 884, in get_task_run_state
>     logger=self.logger,
>   File "/home/sglyon/miniconda/envs/prefect-can-scrapers/lib/python3.7/site-packages/prefect/utilities/executors.py", line 468, in run_task_with_timeout
>     return task.run(*args, **kwargs)  # type: ignore
>   File "services/prefect/flows/generated_flows.py", line 40, in fetch
>     fn = d._fetch()
>   File "/home/sglyon/can-scrapers/can_tools/scrapers/base.py", line 448, in _fetch
>     data = self.fetch()
>   File "/home/sglyon/can-scrapers/can_tools/scrapers/nytimes/nyt_cases_deaths.py", line 145, in fetch
>     for location_type, files in files.items():
>   File "/home/sglyon/miniconda/envs/prefect-can-scrapers/lib/python3.7/typing.py", line 706, in __getattr__
>     return getattr(self.__origin__, attr)
> AttributeError: '_SpecialForm' object has no attribute 'items'

